### PR TITLE
fix: Improve idle warning UX - smaller countdown and power-off icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
       }
 
       .idle-countdown {
-        font-size: 48px;
+        font-size: 40px;
         font-weight: 600;
         color: #18181b;
         margin: 24px 0;

--- a/js/modules/authentication.js
+++ b/js/modules/authentication.js
@@ -409,12 +409,17 @@ async function confirmLogout() {
 interfaceElements.classList.add('hidden');
 }
 
-  // Show goodbye notification using new system
+  // Show goodbye notification using new system with custom icon
   if (window.NotificationSystem) {
-    window.NotificationSystem.info('מתנתק מהמערכת... להתראות! 👋', 3000);
+    const notification = window.NotificationSystem.info('מתנתק מהמערכת... להתראות', 3000);
+    // Replace default info icon with power-off icon
+    const iconElement = notification.querySelector('.notification-icon i');
+    if (iconElement) {
+      iconElement.className = 'fas fa-power-off';
+    }
   } else if (window.manager) {
     // Fallback to old system if new one not loaded
-    window.manager.showNotification('מתנתק מהמערכת... להתראות! 👋', 'info');
+    window.manager.showNotification('מתנתק מהמערכת... להתראות', 'info');
   }
 
   // ✅ Track logout with Presence System


### PR DESCRIPTION
## 📋 סיכום

שיפורים קטנים ב-UX של ה-idle warning החדש:

### 🎨 שינויים:

1. **ספירה לאחור קטנה יותר**
   - קודם: `48px`
   - עכשיו: `40px`
   - סיבה: גודל מתאים יותר, לא שולט יותר מדי בפופאפ

2. **אייקון מקצועי בהודעת התנתקות**
   - קודם: "מתנתק מהמערכת... להתראות! 👋" (עם אימוג'י)
   - עכשיו: "<i class='fas fa-power-off'></i> מתנתק מהמערכת... להתראות" (עם אייקון FontAwesome)
   - סיבה: מראה מקצועי יותר, עקבי עם שאר המערכת

### 📁 קבצים ששונו:
- `index.html` - CSS של `.idle-countdown`
- `js/modules/authentication.js` - הודעת logout

### ✅ בדיקות:
- [x] הספירה קטנה יותר וברורה
- [x] אייקון power-off מופיע בהודעת logout
- [x] אין שימוש באימוג'ים
- [x] הכל עובד עם העיצוב הליינר החדש

🤖 Generated with [Claude Code](https://claude.com/claude-code)