### PR TITLE
fix: Show accurate record count in timesheet Load More button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1322,7 +1322,7 @@
     <!-- ===== Messaging System ===== -->
     <!-- ===== NEW: Main Application (ES6 Modules) ===== -->
     <!-- Modern modular architecture with ActionFlowManager + Smart Descriptions -->
-    <script type="module" src="js/main.js?v=f28b08d"></script>
+    <script type="module" src="js/main.js?v=7c8697d"></script>
     <script type="module" src="js/modules/description-tooltips.js?v=b4bb61b"></script>
 
     <!-- ===== SYSTEM ANNOUNCEMENT TICKER ===== -->

--- a/js/main.js
+++ b/js/main.js
@@ -1604,7 +1604,8 @@ plusButton.classList.remove('active');
       totalPages: Math.ceil(this.filteredTimesheetEntries.length / 20),
       hasMore: this.integrationManager?.firebasePagination?.hasMore?.timesheet_entries || false,
       displayedItems: this.filteredTimesheetEntries.length,
-      filteredItems: this.filteredTimesheetEntries.length
+      filteredItems: this.filteredTimesheetEntries.length,
+      pageSize: this.integrationManager?.config?.PAGINATION_PAGE_SIZE || 20
     };
 
     // Find the parent div that contains timesheetContainer and timesheetTableContainer

--- a/js/modules/timesheet.js
+++ b/js/modules/timesheet.js
@@ -318,7 +318,7 @@ export function renderTimesheetCards(entries, stats, paginationStatus, currentSo
     <div class="pagination-controls">
       <button class="load-more-btn" onclick="window.manager.loadMoreTimesheetEntries()">
         <i class="fas fa-chevron-down"></i>
-        טען עוד (${paginationStatus.filteredItems - paginationStatus.displayedItems} רשומות נוספות)
+        טען עוד (עד ${paginationStatus.pageSize || 20} רשומות נוספות)
       </button>
       <div class="pagination-info">
         מציג ${paginationStatus.displayedItems} מתוך ${paginationStatus.filteredItems} רשומות
@@ -623,7 +623,7 @@ export function renderTimesheetTable(entries, stats, paginationStatus, currentSo
     <div class="pagination-controls">
       <button class="load-more-btn" onclick="window.manager.loadMoreTimesheetEntries()">
         <i class="fas fa-chevron-down"></i>
-        טען עוד (${paginationStatus.filteredItems - paginationStatus.displayedItems} רשומות נוספות)
+        טען עוד (עד ${paginationStatus.pageSize || 20} רשומות נוספות)
       </button>
       <div class="pagination-info">
         מציג ${paginationStatus.displayedItems} מתוך ${paginationStatus.filteredItems} רשומות


### PR DESCRIPTION
## מטרה
לתקן את הטקסט של כפתור "טען עוד" בשעתון - במקום להציג "0 רשומות נוספות", יציג "עד 20 רשומות נוספות".

## הבעיה
הכפתור הציג: טען עוד (0 רשומות נוספות) במקום טען עוד (עד 20 רשומות נוספות)

סיבת הבעיה:
- paginationStatus.filteredItems = 36 (סה"כ רשומות בזיכרון)
- paginationStatus.displayedItems = 36 (אותו ערך!)
- חישוב: 36 - 36 = 0

## הפתרון

1. הוספת pageSize ל-paginationStatus (js/main.js:1608)
2. עדכון טקסט הכפתור (js/modules/timesheet.js:321, 626)
3. עדכון Cache Busting (index.html:1325)

## תוצאה
הכפתור מציג: טען עוד (עד 20 רשומות נוספות)

## קבצים ששונו
- js/main.js - הוספת pageSize ל-paginationStatus
- js/modules/timesheet.js - עדכון טקסט בשני מקומות
- index.html - עדכון cache busting

🤖 Generated with [Claude Code](https://claude.com/claude-code)