### PR TITLE
🚀 Deploy: Fix Realtime Listener INTERNAL cases bug

### DIFF
--- a/js/modules/case-creation/case-number-generator.js
+++ b/js/modules/case-creation/case-number-generator.js
@@ -171,6 +171,7 @@ return false;
     /**
      * הקמת listener לעדכונים בזמן אמת
      * 🛡️ עם Authentication Guard
+     * 🎯 מסנן רק תיקים מהשנה הנוכחית (למניעת התערבות תיקים פנימיים)
      */
     setupRealtimeListener() {
       // 🛡️ Authentication Guard
@@ -179,10 +180,15 @@ return false;
         return;
       }
 
-      // מאזין רק ליצירת לקוחות חדשים
+      // 🎯 Get current year for filtering (same as updateLastCaseNumber)
+      const currentYear = new Date().getFullYear();
+
+      // מאזין רק ליצירת לקוחות חדשים מהשנה הנוכחית
       this.updateListener = window.firebaseDB
         .collection('clients')
-        .orderBy('createdAt', 'desc')
+        .where('caseNumber', '>=', `${currentYear}000`)
+        .where('caseNumber', '<=', `${currentYear}999`)
+        .orderBy('caseNumber', 'desc')
         .limit(1)
         .onSnapshot(
           (snapshot) => {

--- a/master-admin-panel/js/modules/case-number-generator.js
+++ b/master-admin-panel/js/modules/case-number-generator.js
@@ -166,6 +166,7 @@ return false;
     /**
      * הקמת listener לעדכונים בזמן אמת
      * 🛡️ עם Authentication Guard
+     * 🎯 מסנן רק תיקים מהשנה הנוכחית (למניעת התערבות תיקים פנימיים)
      */
     setupRealtimeListener() {
       // 🛡️ Authentication Guard
@@ -174,10 +175,15 @@ return false;
         return;
       }
 
-      // מאזין רק ליצירת לקוחות חדשים
+      // 🎯 Get current year for filtering (same as updateLastCaseNumber)
+      const currentYear = new Date().getFullYear();
+
+      // מאזין רק ליצירת לקוחות חדשים מהשנה הנוכחית
       this.updateListener = window.firebaseDB
         .collection('clients')
-        .orderBy('createdAt', 'desc')
+        .where('caseNumber', '>=', `${currentYear}000`)
+        .where('caseNumber', '<=', `${currentYear}999`)
+        .orderBy('caseNumber', 'desc')
         .limit(1)
         .onSnapshot(
           (snapshot) => {


### PR DESCRIPTION
## 🐛 Bug Fix: Realtime Listener מסנן תיקים פנימיים

### בעיה שתוקנה:
ה-Realtime Listener היה מאזין לכל התיקים (כולל INTERNAL), וכתוצאה מכך עדכן את `lastCaseNumber` עם ערכים לא מספריים כמו "INTERNAL-עוזי", מה שגרם לכשל ביצירת מספרי תיק חדשים.

### התיקון:
הוספת סינון שנה זהה ל-`updateLastCaseNumber()` גם ב-`setupRealtimeListener()`:
- Query מסנן כעת: `caseNumber >= '2025000' AND <= '2025999'`
- מחריג תיקי INTERNAL-* מניטור בזמן אמת
- מבטיח ש-lastCaseNumber תמיד נשאר מספרי ומהשנה הנוכחית

### קבצים ששונו:
- `js/modules/case-creation/case-number-generator.js` (ממשק משתמשים)
- `master-admin-panel/js/modules/case-number-generator.js` (אדמין פאנל)

### השפעה:
✅ מספרי תיק נוצרים כראוי
✅ אין התערבות מתיקים פנימיים
✅ עקביות בין טעינה ראשונית ועדכוני real-time

### קומיט:
- 3aa181b - fix: Filter Realtime Listener to exclude INTERNAL cases

---
🤖 Generated via Claude Code deployment workflow