### PR TITLE
fix: Restore original ticker speed (60s)

### DIFF
--- a/css/system-announcement-ticker.css
+++ b/css/system-announcement-ticker.css
@@ -151,7 +151,7 @@
   line-height: 1.3;
   display: inline-flex;
   gap: 80px; /* רווח בין החזרות */
-  animation: ticker-scroll-loop 90s linear infinite; /* 90 שניות - מהירות איטית ונוחה לקריאה */
+  animation: ticker-scroll-loop 60s linear infinite; /* 60 שניות - מהירות בינונית, לופ אינסופי */
   will-change: transform;
 }
 


### PR DESCRIPTION
החזרת המהירות המקורית של הטיקר.

## מה השתנה:
- 90s → 60s (המהירות המקורית)

## למה:
המהירות של 90s הייתה מהירה מדי. חזרה למהירות המקורית שעבדה טוב.

🤖 Generated with [Claude Code](https://claude.com/claude-code)