### PR TITLE
🐛 Fix: Daily hours target in performance tab

### DIFF
--- a/functions/admin/master-admin-wrappers.js
+++ b/functions/admin/master-admin-wrappers.js
@@ -696,7 +696,8 @@ exports.getUserFullDetails = functions.https.onCall(async (data, context) => {
         loginCount: employeeData.loginCount || 0,
         photoURL: authUserData?.photoURL || null,
         emailVerified: authUserData?.emailVerified || false,
-        authUID: employeeData.authUID // ✅ הוספת authUID למשתמש
+        authUID: employeeData.authUID, // ✅ הוספת authUID למשתמש
+        dailyHoursTarget: employeeData.dailyHoursTarget || null // ✅ תקן שעות יומי אישי
       },
       clients: clients,
       tasks: tasks,


### PR DESCRIPTION
## 🐛 Bug Fix: Daily Performance Tab Shows Wrong Target

### Problem:
When viewing an employee's daily performance tab, the system displayed incorrect daily hours target:
- Employee has personal target: **9.5 hours**
- System showed: **8.45 hours** (default fallback)

### Root Cause:
Cloud Function `getUserFullDetails` was not returning the `dailyHoursTarget` field, causing the UI to fall back to the default value.

### Solution:
Added `dailyHoursTarget` field to the response object in `getUserFullDetails` function.

### Changed Files:
- `functions/admin/master-admin-wrappers.js` (Line 700)

### Impact:
✅ Daily performance tab now shows correct employee target
✅ All calculations use the employee's personal target
✅ Works for all employees (with or without custom target)

### Testing:
- Tested with employee who has 9.5h target
- Verified fallback to 8.45h for employees without custom target
- Confirmed data consistency across all tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)