### PR TITLE
🐛 Fix: Pagination visibility at bottom of page

### DIFF
--- a/master-admin-panel/css/main.css
+++ b/master-admin-panel/css/main.css
@@ -768,7 +768,8 @@ body {
 .dashboard-content {
   max-width: 1600px;
   margin: 0 auto;
-  padding: var(--space-6); /* Padding moved here so scroll reaches the bottom */
+  padding: var(--space-6);
+  padding-bottom: calc(var(--space-6) * 2); /* Extra padding at bottom so pagination is fully visible */
 }
 
 .welcome-message {


### PR DESCRIPTION
## 🐛 Bug Fix: Pagination Controls Not Fully Visible

### Problem:
When scrolling to the bottom of the admin panel users table, the pagination controls were cut off and not fully visible. The scroll would end before showing the complete pagination section.

### Root Cause:
The `.dashboard-content` had equal padding on all sides (`var(--space-6)`), which wasn't enough space at the bottom to display the pagination controls comfortably when scrolling.

### Solution:
Increased the bottom padding to `calc(var(--space-6) * 2)` to provide extra breathing room at the bottom of the page.

### Before:
```
📋 Users Table
│ Row 10          │
└─────────────────┘
📄 [1] [2] [3]     ← Cut off! Can't see fully
```

### After:
```
📋 Users Table
│ Row 10          │
└─────────────────┘
                   ← Extra space
📄 [1] [2] [3] [4] ← Fully visible!
                   ← More space
```

### Impact:
✅ Pagination controls fully visible when scrolling to bottom
✅ Better user experience - no need to struggle to see page numbers
✅ Consistent spacing throughout the interface

### Changed Files:
- `master-admin-panel/css/main.css` (+1 line)

### Testing:
- Scroll to bottom of users table
- Verify all pagination buttons are fully visible
- Check that there's comfortable spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)