### PR TITLE
🐛 Fix: Increase bottom padding for pagination visibility

### DIFF
--- a/master-admin-panel/css/main.css
+++ b/master-admin-panel/css/main.css
@@ -769,7 +769,7 @@ body {
   max-width: 1600px;
   margin: 0 auto;
   padding: var(--space-6);
-  padding-bottom: calc(var(--space-6) * 2); /* Extra padding at bottom so pagination is fully visible */
+  padding-bottom: calc(var(--space-6) * 3); /* Extra padding at bottom so pagination is fully visible */
 }
 
 .welcome-message {


### PR DESCRIPTION
## 🐛 Bug Fix: More Space Needed for Pagination

### Problem:
After PR #48, pagination was visible but still needed more breathing room at the bottom. Users still had to scroll carefully to see all pagination controls comfortably.

### Solution:
Increased bottom padding from `calc(var(--space-6) * 2)` to `calc(var(--space-6) * 3)` - providing 50% more space at the bottom.

### Impact:
✅ Pagination controls have comfortable spacing
✅ No need to struggle with scrolling to see page numbers
✅ Better overall UX at bottom of page

### Changed Files:
- `master-admin-panel/css/main.css` (1 line)

### Visual Result:
```
📋 Users Table
│ Row 10          │
└─────────────────┘
                   ← Even more space (36px instead of 24px)
📄 [1] [2] [3] [4] ← Fully visible with comfort!
                   ← Plenty of breathing room
═══════════════════
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)