### PR TITLE
🎨 UI: Center pagination controls in users page

### DIFF
--- a/master-admin-panel/css/components.css
+++ b/master-admin-panel/css/components.css
@@ -582,7 +582,7 @@
 
 .pagination-wrapper {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   gap: var(--space-4);
   flex-wrap: wrap;


### PR DESCRIPTION
## 🎨 UI Fix: Center Pagination Controls

### Problem:
After PR #50 removed the card styling from pagination, the controls were still not centered - they were spread out to the sides (`space-between`) instead of centered like in the clients page.

### Root Cause:
The `.pagination-wrapper` class had `justify-content: space-between` which spreads child elements to opposite sides, while the clients page uses `justify-content: center`.

### Solution:
Changed `.pagination-wrapper` from `space-between` to `center` to match the clients page design.

### Before:
```
[פריטים בעמוד: 10]        [◀ הבא] [1][2][3] [הקודם ▶]
└─ Left side              Right side ─┘
```

### After:
```
          [◀ הבא] [1][2][3] [הקודם ▶]
          └─ Centered! ─┘
```

### Changed Files:
- `master-admin-panel/css/components.css` (1 line)

### Impact:
✅ Pagination controls now centered like clients page
✅ Consistent design across both pages
✅ Clean, minimal look

🤖 Generated with [Claude Code](https://claude.com/claude-code)