### PR TITLE
fix: Ensure phone timer initializes for existing sessions

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -358,6 +358,17 @@ class LawOfficeManager {
   }
 
   /**
+   * Ensure Phone Timer is initialized - Called from showApp()
+   * Fallback for cases where user was already authenticated before code deployment
+   */
+  ensurePhoneTimerInitialized() {
+    if (!this.phoneCallTimer && typeof PhoneCallTimer !== 'undefined') {
+      console.log('📞 Phone timer not initialized - initializing now...');
+      this.initializePhoneCallTimer();
+    }
+  }
+
+  /**
    * Setup all event listeners
    */
   setupEventListeners() {

--- a/js/modules/authentication.js
+++ b/js/modules/authentication.js
@@ -347,6 +347,11 @@ bubblesContainer.classList.add('hidden');
   if (window.manager && typeof window.manager.initTicker === 'function') {
     window.manager.initTicker();
   }
+
+  // ✅ Ensure Phone Call Timer is initialized (fallback for existing sessions)
+  if (window.manager && typeof window.manager.ensurePhoneTimerInitialized === 'function') {
+    window.manager.ensurePhoneTimerInitialized();
+  }
 }
 
 function logout() {


### PR DESCRIPTION
## 🐛 Bug Fix: Phone Timer Auto-Initialization

### הבעיה:
משתמשים שהיו מחוברים **לפני** שה-PR המקורי עלה לא רואים את כפתור הטיימר.

**הסיבה:**
-  נקרא רק ב-
- משתמשים עם session פעיל מדלגים על זה
- לכן הטיימר לא מאותחל עבורם

### הפתרון:
הוספת **fallback initialization** ב-:
- בודק אם הטיימר לא אותחל
- אם לא - מאתחל אוטומטית
- עוקב אחרי אותו pattern כמו `initTicker()`

### שינויים טכניים:

**js/main.js:**
- `ensurePhoneTimerInitialized()` - פונקציה חדשה
- בודקת אם `phoneCallTimer` לא קיים
- מאתחלת רק אם צריך (מונעת כפילויות)

**js/modules/authentication.js:**
- קריאה ל-`ensurePhoneTimerInitialized()` ב-`showApp()`
- מיד אחרי `initTicker()` (consistency)

### תוצאה:
✅ משתמשים קיימים יראו את הכפתור אוטומטית
✅ אין צורך ב-logout/login
✅ עובד גם לדפלוי עתידי

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)