### PR TITLE
fix: Update approval counter to track auto-approved tasks and fix load-more

### DIFF
--- a/master-admin-panel/components/task-approval-system/services/task-approval-service.js
+++ b/master-admin-panel/components/task-approval-system/services/task-approval-service.js
@@ -84,17 +84,7 @@ export class TaskApprovalService {
         requestedAt: doc.data().requestedAt?.toDate() || doc.data().createdAt?.toDate() || null,
         reviewedAt: doc.data().reviewedAt?.toDate() || null,
         createdAt: doc.data().createdAt?.toDate() || null
-      }))
-      // ✅ Filter out old pending approvals (before auto-approval system)
-      // Only show: auto-approved, rejected, or approved tasks
-      .filter(approval => {
-        // If status is 'pending', only show if it has autoApproved flag
-        if (approval.status === 'pending') {
-          return approval.autoApproved === true;
-        }
-        // Show all approved/rejected
-        return true;
-      });
+      }));
 
       // ✅ Get last document for next pagination
       const lastDocument = docs.length > 0 ? docs[docs.length - 1] : null;
@@ -134,14 +124,7 @@ export class TaskApprovalService {
             requestedAt: doc.data().requestedAt?.toDate() || doc.data().createdAt?.toDate() || null,
             reviewedAt: doc.data().reviewedAt?.toDate() || null,
             createdAt: doc.data().createdAt?.toDate() || null
-          }))
-          // ✅ Filter out old pending approvals (before auto-approval system)
-          .filter(approval => {
-            if (approval.status === 'pending') {
-              return approval.autoApproved === true;
-            }
-            return true;
-          });
+          }));
 
           const lastDocument = docs.length > 0 ? docs[docs.length - 1] : null;
 
@@ -240,14 +223,7 @@ export class TaskApprovalService {
         ...doc.data(),
         requestedAt: doc.data().requestedAt?.toDate() || null,
         reviewedAt: doc.data().reviewedAt?.toDate() || null
-      }))
-      // ✅ Filter out old pending approvals (before auto-approval system)
-      .filter(approval => {
-        if (approval.status === 'pending') {
-          return approval.autoApproved === true;
-        }
-        return true;
-      });
+      }));
       callback(approvals);
     }, error => {
       console.error('❌ Real-time listener error:', error);

--- a/master-admin-panel/js/ui/TaskApprovalSidePanel.js
+++ b/master-admin-panel/js/ui/TaskApprovalSidePanel.js
@@ -21,8 +21,8 @@
             this.realtimeUnsubscribe = null;
             this.approvalDialog = null;
             // ✅ Cursor-based pagination settings
-            this.initialLimit = 5; // Initial load: 5 items
-            this.loadMoreIncrement = 10; // Load more: 10 items each time
+            this.initialLimit = 4; // Initial load: 4 items
+            this.loadMoreIncrement = 20; // Load more: 20 items each time
             this.lastDocument = null; // Firestore cursor for pagination
             this.hasMoreData = true; // Flag to indicate if more data exists
         }
@@ -77,6 +77,22 @@
             }
 
             console.log('🔓 Opening Task Approval Side Panel...');
+
+            // Update lastViewedAt timestamp
+            const currentUser = window.currentUser || window.firebaseAuth?.currentUser;
+            if (currentUser && window.firebaseDB) {
+                try {
+                    await window.firebaseDB
+                        .collection('employees')
+                        .doc(currentUser.email)
+                        .set({
+                            approvalsPanelLastViewed: firebase.firestore.FieldValue.serverTimestamp()
+                        }, { merge: true });
+                    console.log('✅ Updated lastViewedAt timestamp');
+                } catch (error) {
+                    console.error('❌ Error updating lastViewedAt:', error);
+                }
+            }
 
             // Create overlay and panel
             this.createPanel();


### PR DESCRIPTION
## Summary
- Update approval counter to show only auto-approved tasks from today that haven't been viewed
- Add lastViewedAt timestamp tracking when opening approval panel
- Remove client-side filtering in task-approval-service to fix load-more functionality
- Change pagination: 4 items initial load, 20 items per load-more
- Implement simple polling approach (30s interval) for optimal performance

## Changes
- Navigation.js: Updated counter logic to track auto-approved unviewed tasks
- TaskApprovalSidePanel.js: Added lastViewedAt timestamp update + pagination changes
- task-approval-service.js: Removed client-side filtering for better load-more

## Test Plan
- [ ] Counter displays correct number of unviewed auto-approved tasks
- [ ] Counter resets when opening approval panel
- [ ] Load more button loads 20 items at a time
- [ ] Pagination works correctly without filtering issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)