### PR TITLE
fix(build): Move cache-bust to Netlify build only

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,9 +19,10 @@
 # ════════════════════════════════════════════════════════════════
 [build]
   publish = "."
-  # שלבים: TypeScript → Lint → Build
+  # שלבים: Cache-bust → TypeScript → Lint → Build
+  # Cache-bust רץ רק ב-Netlify (לא ב-git commits!)
   # אם אחד נכשל - הכל נעצר!
-  command = "npm run type-check && npm run compile-ts"
+  command = "npm run cache-bust && npm run type-check && npm run compile-ts"
 
 # Production environment variables
 [context.production.environment]

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
     "cache-bust": "node update-cache-busting.js",
-    "compile-ts": "npm run cache-bust && tsc",
+    "compile-ts": "tsc",
     "compile:watch": "tsc --watch",
     "clean": "rm -rf dist",
     "lint": "eslint . --ext .js,.ts,.tsx",


### PR DESCRIPTION
## 🔧 Fix: Cache-bust Configuration

Prevents future merge conflicts by moving cache-bust from pre-push hook to Netlify build.

---

## 🎯 Problem Solved

**Before:**
- `compile-ts` script ran `cache-bust` during pre-push
- Every push updated HTML files with new commit hash
- Created merge conflicts between branches

**After:**
- `cache-bust` runs only during Netlify deployment
- No git commits contain cache token changes
- Clean merges between branches

---

## 📝 Changes

**File**: [package.json](https://github.com/Chaim2045/law-office-system/blob/main/package.json#L12)
```diff
- "compile-ts": "npm run cache-bust && tsc",
+ "compile-ts": "tsc",
```

**File**: [netlify.toml](https://github.com/Chaim2045/law-office-system/blob/main/netlify.toml#L25)
```diff
- command = "npm run type-check && npm run compile-ts"
+ command = "npm run cache-bust && npm run type-check && npm run compile-ts"
```

---

## ✅ Benefits

1. No more merge conflicts from cache tokens
2. Cleaner git history
3. Cache-bust still works (via Netlify)
4. Easier branch management
5. Same end result for users (cache is busted)

---

## 🧪 Testing

✅ Tested on main - no cache-bust during push
✅ TypeScript compilation passes
✅ Ready for PROD deployment

---

**Commit**: `aced90d`
