### PR TITLE
fix(csp): stop loading EventAnalyzer in runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -1354,8 +1354,8 @@
     <!-- ===== System Diagnostics & Snapshot Tool ===== -->
     <!-- Full system state comparison for debugging -->
     <script defer src="js/modules/system-snapshot.js?v=933e079"></script>
-    <!-- Event Flow Analyzer - ניתוח מערך האירועים -->
-    <script defer src="js/modules/event-analyzer.js?v=933e079"></script>
+    <!-- Event Flow Analyzer - DEV ONLY - removed to prevent CSP errors in production -->
+    <!-- <script defer src="js/modules/event-analyzer.js?v=933e079"></script> -->
 
     <!-- ===== SVG RINGS MODULE ===== -->
     <script src="js/modules/svg-rings.js?v=933e079"></script>


### PR DESCRIPTION
## Root Cause

**File:** `index.html:1358`
**Issue:** EventAnalyzer script loaded unconditionally in production, causing CSP violations

**Problem:**
- EventAnalyzer's `scanSourceCode()` attempts to fetch non-existent files including `.ts` sources
- This caused CSP errors: `Connecting to 'https://gh-law-office-system.netlify.app/js/core/event-bus.ts'`
- DEV environment tried to connect to PROD URLs

## Fix

Commented out EventAnalyzer script tag in `index.html`:
```diff
-    <!-- Event Flow Analyzer - ניתוח מערך האירועים -->
-    <script defer src="js/modules/event-analyzer.js?v=933e079"></script>
+    <!-- Event Flow Analyzer - DEV ONLY - removed to prevent CSP errors in production -->
+    <!-- <script defer src="js/modules/event-analyzer.js?v=933e079"></script> -->
```

## Impact

- ✅ EventAnalyzer not loaded in production/DEV by default
- ✅ No fetch attempts to non-existent `.ts` files
- ✅ 0 CSP errors expected after deploy to main
- ✅ Tool still available for manual debugging (load script manually in console if needed)

## Evidence

```bash
$ grep -n "event-analyzer" index.html
1358:    <!-- <script defer src="js/modules/event-analyzer.js?v=933e079"></script> -->
```

✅ Script is commented out - not loaded by default

## Testing

After merge to `main`, verify in DEV (`main--gh-law-office-system.netlify.app`):
1. Open Console with Preserve log
2. Refresh page (Ctrl+F5)
3. Confirm: **0 CSP errors** related to event-bus.ts or firebase-service.ts

---

**Related:** Follow-up to PR #92 (OAuth integration)
**Commit:** `527a4cd` (cherry-picked from `6972045`)