### PR TITLE
fix: report hours filter by serviceId

### DIFF
--- a/master-admin-panel/js/managers/ReportGenerator.js
+++ b/master-admin-panel/js/managers/ReportGenerator.js
@@ -86,13 +86,24 @@
 
             // Filter by service if selected
             if (formData.service !== 'all') {
-                timesheetEntries = timesheetEntries.filter(entry =>
-                    entry.service === formData.service || entry.serviceName === formData.service
-                );
+                const matchService = (entry) => {
+                    if (formData.serviceId && entry.serviceId === formData.serviceId) {
+return true;
+}
+                    if (formData.serviceId && entry.service === formData.serviceId) {
+return true;
+}
+                    if (entry.service === formData.service) {
+return true;
+}
+                    if (entry.serviceName === formData.service) {
+return true;
+}
+                    return false;
+                };
 
-                budgetTasks = budgetTasks.filter(task =>
-                    task.service === formData.service || task.serviceName === formData.service
-                );
+                timesheetEntries = timesheetEntries.filter(matchService);
+                budgetTasks = budgetTasks.filter(matchService);
             }
 
             // Calculate statistics

--- a/master-admin-panel/js/ui/ClientReportModal.js
+++ b/master-admin-panel/js/ui/ClientReportModal.js
@@ -758,6 +758,7 @@ card.classList.add('resolved');
 
             // Data attributes for selection
             card.dataset.serviceName = serviceInfo.displayName;
+            card.dataset.serviceId = serviceInfo.stage || serviceInfo.serviceKey;
             card.dataset.serviceIndex = index;
             card.dataset.serviceType = serviceInfo.type;
 
@@ -982,8 +983,9 @@ card.classList.add('resolved');
 
             // Update hidden input with sanitized value
             this.selectedServiceInput.value = this.sanitizeInput(serviceName);
+            this.selectedServiceInput.dataset.serviceId = card.dataset.serviceId || '';
 
-            console.log('✅ Selected service:', serviceName);
+            console.log('✅ Selected service:', serviceName, '| serviceId:', card.dataset.serviceId);
         }
 
         /**
@@ -1078,6 +1080,7 @@ return '';
                 startDate: this.startDateInput?.value,
                 endDate: this.endDateInput?.value,
                 service: this.selectedServiceInput?.value || '',
+                serviceId: this.selectedServiceInput?.dataset.serviceId || '',
                 reportType,
                 reportFormat
             };


### PR DESCRIPTION
## Summary
- ClientReportModal passes `serviceId` (stage key) alongside `displayName` in formData
- ReportGenerator filters deterministically by serviceId first, then falls back to displayName
- Fixes legal-procedure reports returning zero timesheet entries

## Root Cause
`formData.service` carried the display name (e.g. "הליך משפטי - שלב א'") but timesheet entries store the technical key (`stage_a`). The filter in ReportGenerator compared only against displayName → no match → empty report.

## Changes
| File | Change |
|------|--------|
| `ClientReportModal.js` | Added `dataset.serviceId` to card, propagate through selection to `formData.serviceId` |
| `ReportGenerator.js` | Deterministic match order: `serviceId` → `service` → `serviceName` with fallback |

## Filter priority (deterministic)
1. `entry.serviceId === formData.serviceId`
2. `entry.service === formData.serviceId`
3. `entry.service === formData.service` (fallback for hourly packages)
4. `entry.serviceName === formData.service` (fallback for legacy)

## Test Plan
- [ ] Legal procedure: הליך משפטי - שלב א' → דוח מציג טבלת שעות
- [ ] Hourly package: תוכנית שעות → דוח מציג טבלת שעות
- [ ] No new Console errors during report generation
- [ ] Confirm `formData.serviceId = stage_a` in Console log

🤖 Generated with [Claude Code](https://claude.com/claude-code)