### PR TITLE
fix: increase client cache limit from 100 to 1000

### DIFF
--- a/js/modules/client-case-selector.js
+++ b/js/modules/client-case-selector.js
@@ -170,7 +170,7 @@
       ClientCaseSelector.cacheListener = db.collection('clients')
         .where('status', '==', 'active')
         .orderBy('createdAt', 'desc')
-        .limit(100)
+        .limit(1000)
         .onSnapshot(
         (snapshot) => {
           snapshot.docChanges().forEach((change) => {


### PR DESCRIPTION
## Summary
- Increases the client cache limit in `client-case-selector.js` from 100 to 1000
- Fixes bug where older clients (e.g. אהוד ולטר) were not appearing in search because they exceeded the 100-client cache limit
- Already verified in DEV

## Test plan
- [x] Verified in DEV that אהוד ולטר now appears in client search
- [ ] After merge, verify in PROD that all clients appear in search

🤖 Generated with [Claude Code](https://claude.com/claude-code)