### PR TITLE
fix: add missing hoursUsed/minutesUsed increment

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3447,6 +3447,8 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
 
           clientUpdateData = {
             services: updatedServices,
+            hoursUsed: admin.firestore.FieldValue.increment(hoursWorked),
+            minutesUsed: admin.firestore.FieldValue.increment(data.minutes),
             minutesRemaining: admin.firestore.FieldValue.increment(-data.minutes),
             hoursRemaining: admin.firestore.FieldValue.increment(-hoursWorked),
             isBlocked: newIsBlocked,
@@ -3889,6 +3891,8 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
 
               transaction.update(clientRef, {
                 services: clientData.services,
+                hoursUsed: admin.firestore.FieldValue.increment(hoursWorked),
+                minutesUsed: admin.firestore.FieldValue.increment(data.minutes),
                 minutesRemaining: admin.firestore.FieldValue.increment(-data.minutes),
                 hoursRemaining: admin.firestore.FieldValue.increment(-hoursWorked),
                 isBlocked: newIsBlocked,


### PR DESCRIPTION
## Summary
- Adds `hoursUsed` and `minutesUsed` `FieldValue.increment()` to `createTimesheetEntry_v2` and `createQuickLogEntry` in `functions/index.js`
- These fields were missing, causing client card `hoursUsed` to drift from actual timesheet totals (e.g. חזי מאנע: 41.25 hour gap)

## Test plan
- [ ] Deploy functions to Firebase
- [ ] Create a timesheet entry via User App — verify `client.hoursUsed` increments
- [ ] Create a quick log entry via Admin Panel — verify `client.hoursUsed` increments
- [ ] Run dailyInvariantCheck — verify gap stops growing

🤖 Generated with [Claude Code](https://claude.com/claude-code)