### PR TITLE
fix: move initializeApp() before module requires

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,6 +7,12 @@
 
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
+
+// אתחול Admin SDK — חייב להיות לפני כל require שמשתמש ב-admin.firestore()
+admin.initializeApp();
+const db = admin.firestore();
+const auth = admin.auth();
+
 const { onRequest } = require('firebase-functions/v2/https');
 const { addTimeToTaskWithTransaction } = require('./addTimeToTask_v2');
 const { updateBudgetTask, markNotificationAsRead } = require('./task-update-realtime');
@@ -19,11 +25,6 @@ const DeductionSystem = require('./src/modules/deduction');
 
 // ✅ NEW: Import case number transaction module
 const { generateCaseNumberWithTransaction } = require('./case-number-transaction');
-
-// אתחול Admin SDK
-admin.initializeApp();
-const db = admin.firestore();
-const auth = admin.auth();
 
 // ===============================
 // CORS Configuration


### PR DESCRIPTION
## Summary
- Move `admin.initializeApp()` before all `require()` calls that use `admin.firestore()` at module level
- Fixes Firebase deploy crash: `The default Firebase app does not exist`

## Root cause
Wave 2 extracted modules (`shared/auth.js`, `shared/audit.js`, etc.) call `admin.firestore()` at top level during `require()`, but `initializeApp()` was called after those requires.

## Test plan
- [ ] Firebase deploy succeeds