### PR TITLE
fix: invalidate clients cache after timesheet operations

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -1641,6 +1641,7 @@ completedBadge.style.display = 'none';
 
         // Invalidate cache to force fresh data on next load
         this.dataCache.invalidate(`timesheetEntries:${this.currentUser}`);
+        this.dataCache.invalidate('clients');
 
         // Reload entries with cache (will fetch fresh because invalidated)
         this.timesheetEntries = await this.dataCache.get(`timesheetEntries:${this.currentUser}`, () =>
@@ -1960,6 +1961,7 @@ existingError.remove();
 
         // Invalidate cache to force fresh data on next load
         this.dataCache.invalidate(`timesheetEntries:${this.currentUser}`);
+        this.dataCache.invalidate('clients');
 
         // Reload entries with cache (will fetch fresh because invalidated)
         this.timesheetEntries = await this.dataCache.get(`timesheetEntries:${this.currentUser}`, () =>
@@ -2810,6 +2812,9 @@ return;
         if (!result.success) {
           throw new Error(result.error || 'שגיאה בהוספת זמן');
         }
+
+        // Invalidate clients cache so loadData() fetches fresh from Firestore
+        this.dataCache.invalidate('clients');
 
         // Reload all data (loadData() refreshes selectors automatically)
         await this.loadData();  // Loads clients + budgetTasks + timesheet + refreshes selectors

--- a/apps/user-app/js/modules/break-manager.js
+++ b/apps/user-app/js/modules/break-manager.js
@@ -501,6 +501,10 @@ timeInput.value = '';
       });
 
       this._showSuccessToast(minutes);
+
+      if (window.app && window.app.dataCache) {
+        window.app.dataCache.invalidate('clients');
+      }
     } catch (error) {
       console.error('BreakManager: Failed to record timesheet', error);
       this._showErrorToast();

--- a/apps/user-app/js/quick-log.js
+++ b/apps/user-app/js/quick-log.js
@@ -1391,6 +1391,10 @@ navigator.vibrate(10);
 
         showSuccess(`✅ נרשמו ${hoursText} עבור ${clientName}`);
         resetForm();
+
+        if (window.app && window.app.dataCache) {
+          window.app.dataCache.invalidate('clients');
+        }
       } else {
         showError(result.data.message || 'שגיאה בשליחת הדיווח');
       }


### PR DESCRIPTION
## Summary
- Add `dataCache.invalidate('clients')` after all 5 timesheet operation callers
- Ensures UI shows updated progress/hours immediately after trigger writes

## Files changed
- `apps/user-app/js/main.js` — 3 callers (createTimesheetEntry_v2, addTimeToTask, updateTimesheetEntry)
- `apps/user-app/js/quick-log.js` — 1 caller (createQuickLogEntry)
- `apps/user-app/js/modules/break-manager.js` — 1 caller (createTimesheetEntry_v2)

## Test plan
- [ ] Submit hours via main form → verify progress bar updates immediately
- [ ] Submit via quick-log → verify client hours refresh
- [ ] End break → verify break time recorded and reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)