### PR TITLE
Deploy: caseOpenDate via updateClient Cloud Function

### DIFF
--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -144,15 +144,78 @@
          * Render client info header
          * רינדור כותרת מידע לקוח
          */
+        async editCaseOpenDate() {
+            const client = this.currentClient;
+            const current = client.caseOpenDate
+                ? new Date(client.caseOpenDate.seconds * 1000).toISOString().split('T')[0]
+                : (client.createdAt
+                    ? new Date(client.createdAt.seconds * 1000).toISOString().split('T')[0]
+                    : '');
+
+            const input = document.createElement('div');
+            input.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:24px;border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,0.15);z-index:10000;min-width:280px;';
+            input.innerHTML = `
+                <div style="font-weight:600;margin-bottom:12px;font-size:15px;">עדכון תאריך פתיחת תיק</div>
+                <input type="date" id="caseOpenDateInput" value="${current}" style="width:100%;padding:8px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;margin-bottom:16px;">
+                <div style="display:flex;gap:8px;justify-content:flex-end;">
+                    <button id="caseOpenDateCancel" style="padding:8px 16px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;">ביטול</button>
+                    <button id="caseOpenDateSave" style="padding:8px 16px;background:#3b82f6;color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600;">שמור</button>
+                </div>
+            `;
+
+            const overlay = document.createElement('div');
+            overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:9999;';
+            document.body.appendChild(overlay);
+            document.body.appendChild(input);
+
+            const cleanup = () => {
+ overlay.remove(); input.remove();
+};
+
+            document.getElementById('caseOpenDateCancel').addEventListener('click', cleanup);
+            overlay.addEventListener('click', cleanup);
+
+            document.getElementById('caseOpenDateSave').addEventListener('click', async () => {
+                const val = document.getElementById('caseOpenDateInput').value;
+                if (!val) {
+return;
+}
+
+                const newDate = new Date(val);
+                if (isNaN(newDate.getTime())) {
+                    alert('תאריך לא תקין');
+                    return;
+                }
+
+                try {
+                    await FirebaseService.call('updateClient', {
+                        clientId: client.id,
+                        caseOpenDate: newDate.toISOString()
+                    });
+
+                    this.currentClient.caseOpenDate = { seconds: Math.floor(newDate.getTime() / 1000), nanoseconds: 0 };
+                    cleanup();
+                    this.renderClientInfo();
+                    this.showNotification('תאריך פתיחת תיק עודכן', 'success');
+                } catch (e) {
+                    console.error('Error updating caseOpenDate:', e);
+                    this.showNotification('שגיאה בעדכון התאריך', 'error');
+                }
+            });
+        }
+
         renderClientInfo() {
             if (!this.currentClient) {
 return;
 }
 
             const client = this.currentClient;
-            const createdDate = client.createdAt
+            const caseOpenDate = client.caseOpenDate
+                ? new Date(client.caseOpenDate.seconds * 1000).toLocaleDateString('he-IL')
+                : null;
+            const createdDate = caseOpenDate || (client.createdAt
                 ? new Date(client.createdAt.seconds * 1000).toLocaleDateString('he-IL')
-                : '-';
+                : '-');
 
             const totalServices = client.services?.length || 0;
             const activeServices = client.services?.filter(s => s.status === 'active').length || 0;
@@ -179,7 +242,7 @@ return;
                     </div>
                     <div class="management-client-meta-item">
                         <i class="fas fa-calendar"></i>
-                        <span>נפתח: ${createdDate}</span>
+                        <span>נפתח: ${createdDate} <button class="edit-case-open-date-btn" title="ערוך תאריך פתיחה" style="background:none;border:none;cursor:pointer;padding:0 4px;color:#6b7280;">✏️</button></span>
                     </div>
                     <div class="management-client-meta-item">
                         <i class="fas fa-briefcase"></i>
@@ -187,6 +250,11 @@ return;
                     </div>
                 </div>
             `;
+
+            const editBtn = this.clientInfoContainer.querySelector('.edit-case-open-date-btn');
+            if (editBtn) {
+                editBtn.addEventListener('click', () => this.editCaseOpenDate());
+            }
         }
 
         /**

--- a/apps/admin-panel/js/ui/ClientReportModal.js
+++ b/apps/admin-panel/js/ui/ClientReportModal.js
@@ -1056,7 +1056,10 @@ return '';
 
                 case 'all':
                     // Set to client creation date or 1 year ago
-                    const clientCreated = this.currentClient?.createdAt?.toDate?.() || new Date(now.getFullYear() - 1, 0, 1);
+                    const clientCreated =
+                        this.currentClient?.caseOpenDate?.toDate?.() ||
+                        this.currentClient?.createdAt?.toDate?.() ||
+                        new Date(now.getFullYear() - 1, 0, 1);
                     startDate = clientCreated;
                     endDate = now;
                     break;

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -970,6 +970,21 @@ exports.updateClient = functions.https.onCall(async (data, context) => {
       updates.email = data.email ? sanitizeString(data.email.trim()) : '';
     }
 
+    if (data.caseOpenDate !== undefined) {
+      if (data.caseOpenDate === null) {
+        updates.caseOpenDate = admin.firestore.FieldValue.delete();
+      } else {
+        const d = new Date(data.caseOpenDate);
+        if (isNaN(d.getTime())) {
+          throw new functions.https.HttpsError(
+            'invalid-argument',
+            'תאריך פתיחת תיק לא תקין'
+          );
+        }
+        updates.caseOpenDate = admin.firestore.Timestamp.fromDate(d);
+      }
+    }
+
     updates.lastModifiedBy = user.username;
     updates.lastModifiedAt = admin.firestore.FieldValue.serverTimestamp();
 

--- a/scripts/set-case-open-date.js
+++ b/scripts/set-case-open-date.js
@@ -1,0 +1,107 @@
+const admin = require('firebase-admin');
+const serviceAccount = require('../service-account-key.json');
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+const db = admin.firestore();
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function getEarliestEntryDate(clientId) {
+  const snap = await db.collection('timesheet_entries')
+    .where('clientId', '==', clientId)
+    .get();
+
+  if (snap.empty) {
+return null;
+}
+
+  let earliest = null;
+  snap.forEach(doc => {
+    const d = doc.data();
+    let entryDate;
+    if (d.date && d.date.toDate) {
+      entryDate = d.date.toDate();
+    } else if (typeof d.date === 'string') {
+      entryDate = new Date(d.date);
+    } else if (typeof d.date === 'number') {
+      entryDate = new Date(d.date * 1000);
+    } else {
+return;
+}
+
+    if (!earliest || entryDate < earliest) {
+earliest = entryDate;
+}
+  });
+
+  return earliest;
+}
+
+async function run() {
+  console.log(DRY_RUN ? '🔍 DRY RUN — לא כותב' : '✍️ LIVE — כותב ל-Firestore');
+  console.log('---');
+
+  const clientsSnap = await db.collection('clients').get();
+
+  let updated = 0;
+  let skipped = 0;
+  let noEntries = 0;
+  let alreadyHas = 0;
+  let errors = 0;
+
+  for (const doc of clientsSnap.docs) {
+    const d = doc.data();
+    const name = d.clientName || d.name || doc.id;
+
+    // idempotent — לא מחליף קיים
+    if (d.caseOpenDate) {
+      alreadyHas++;
+      continue;
+    }
+
+    if (doc.id.startsWith('internal_')) {
+      skipped++;
+      continue;
+    }
+
+    try {
+      const earliest = await getEarliestEntryDate(doc.id);
+
+      if (!earliest) {
+        noEntries++;
+        continue;
+      }
+
+      const clientCreatedAt = d.createdAt?.toDate ? d.createdAt.toDate() : null;
+
+      if (clientCreatedAt && earliest >= clientCreatedAt) {
+        skipped++;
+        continue;
+      }
+
+      console.log(`📅 ${doc.id} | ${name} | createdAt: ${clientCreatedAt?.toISOString().split('T')[0]} | earliest: ${earliest.toISOString().split('T')[0]}`);
+
+      if (!DRY_RUN) {
+        await doc.ref.update({
+          caseOpenDate: admin.firestore.Timestamp.fromDate(earliest),
+          updatedAt: new Date().toISOString()
+        });
+      }
+
+      updated++;
+    } catch (e) {
+      console.error(`❌ ${doc.id} | ${name} | ${e.message}`);
+      errors++;
+    }
+  }
+
+  console.log('---');
+  console.log(`✅ יעודכנו: ${updated}`);
+  console.log(`⏭️  createdAt <= earliest (לא צריך): ${skipped}`);
+  console.log(`📭 ללא entries: ${noEntries}`);
+  console.log(`🔄 כבר יש caseOpenDate: ${alreadyHas}`);
+  console.log(`❌ שגיאות: ${errors}`);
+}
+
+run().then(() => process.exit(0)).catch(e => {
+ console.error(e.message); process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **updateClient**: added `caseOpenDate` field support with validation (null to delete, ISO string to set)
- **ClientManagementModal**: replaced direct Firestore write with `FirebaseService.call('updateClient')` + edit button UI
- **ClientReportModal**: "מההתחלה" uses `caseOpenDate` with `createdAt` fallback
- **scripts/set-case-open-date.js**: migration script for existing clients

## Test plan
- [x] node --check passed on all modified files
- [x] Pushed and tested on main preview
- [ ] Verify caseOpenDate edit in admin panel
- [ ] Verify report date range with caseOpenDate

🤖 Generated with [Claude Code](https://claude.com/claude-code)