### PR TITLE
feat: service override for blocked hours services

### DIFF
--- a/SYSTEM_STATUS.md
+++ b/SYSTEM_STATUS.md
@@ -2,7 +2,7 @@
 ## law-office-system-e4801
 
 **מנוהל על ידי:** טומי — ראש צוות הפיתוח
-**עדכון אחרון:** 2026-03-12
+**עדכון אחרון:** 2026-03-15
 **סטטוס:** הכל ב-PROD, branches מסונכרנים, מערכת יציבה
 **PRs:** #144 (Trigger + deduction removal + bug fixes), #145 (cache invalidation), #146 (service blocked enforcement), #147 (caseOpenDate)
 
@@ -13,8 +13,8 @@
 ### Branches
 
 ```
-main:               fbef860 — synced with production-stable
-production-stable:  fbef860 — PR #147 merged, live
+main:               06b87a5 — synced with production-stable
+production-stable:  06b87a5 — PR #147 merged, live
 אין branches פתוחים.
 ```
 
@@ -175,6 +175,23 @@ Client root: minutesUsed = hoursUsed * 60
 
 ---
 
+## 7א. ניקוי נתוני בדיקה — בוצע (2026-03-15)
+
+### מה נמצא
+רשומות על 5 לקוחות שלא קיימים ב-clients (נמחקו בעבר):
+2026021, 2026005, 2025003, 2025010, 2026020
+
+### מה נמחק
+- 12 timesheet_entries על לקוחות לא קיימים
+- 14 budget_tasks על לקוחות לא קיימים
+- 1 כפילות של marva על clientId 2026003 (26 דקות, 2026-01-27)
+- סה"כ: 27 רשומות, 0 שגיאות
+
+### מה נשאר פתוח
+- uzi — 330 דקות על משימה בוטלת (2025549, רעות ואוריאל חליבה) — ממתין לבירור עם עוזי
+
+---
+
 ## 8. ארכיטקטורת המערכת
 
 ### שני Netlify Sites מאותו Repo
@@ -236,6 +253,7 @@ Client root: minutesUsed = hoursUsed * 60
 | ניקוי branches ישנים | הושלם | feature/timesheet-triggers נמחק. סה"כ 2 branches בלבד. |
 | SMS Twilio | נמוך | TODO בקוד, +972549539238 |
 | AI integration ל-User App | נדחה | Cloud Function כ-proxy ל-Claude API |
+| חריגה מבוקרת — שלב ב׳ | קריטי | admin מאשר X שעות חריגה per service. כרגע שירות חסום = נעול לחלוטין |
 | מיגרציה מ-functions.config() ל-Secret Manager | נמוך | deadline מרץ 2027 |
 
 ---

--- a/SYSTEM_STATUS.md
+++ b/SYSTEM_STATUS.md
@@ -1,0 +1,257 @@
+# SYSTEM STATUS — GH Law Office System
+## law-office-system-e4801
+
+**מנוהל על ידי:** טומי — ראש צוות הפיתוח
+**עדכון אחרון:** 2026-03-12
+**סטטוס:** הכל ב-PROD, branches מסונכרנים, מערכת יציבה
+**PRs:** #144 (Trigger + deduction removal + bug fixes), #145 (cache invalidation), #146 (service blocked enforcement), #147 (caseOpenDate)
+
+---
+
+## 1. מצב נוכחי
+
+### Branches
+
+```
+main:               fbef860 — synced with production-stable
+production-stable:  fbef860 — PR #147 merged, live
+אין branches פתוחים.
+```
+
+### PRs שמוזגו ל-production-stable (כרונולוגי)
+
+| PR | תאריך | תיאור |
+|----|--------|-------|
+| #110–#115, #118, #120 | עד 15/2 | atomicity, data reconciliation, auth fixes, UI |
+| #131 | ~20/2 | Refactor: services — כתיבה ישירה → Cloud Functions |
+| #133 | ~24/2 | Refactor: פיצול index.js גל 1 — ניקוי 2,543 שורות קוד מת |
+| #134 | ~25/2 | Refactor: פיצול index.js גל 2 — shared, scheduled, whatsapp, metrics, admin |
+| #135 | ~26/2 | Refactor: פיצול index.js גל 3 — auth, budget-tasks, clients, services, timesheet |
+| #144 | 4/3 | Trigger + הסרת deduction מ-4 פונקציות + 3 bug fixes |
+| #145 | 5/3 | Cache invalidation ב-5 callers אחרי timesheet operations |
+| #146 | 9/3 | Service blocked enforcement — כל 4 נקודות כניסה ל-timesheet_entries |
+| #147 | 12/3 | caseOpenDate — תיקון דוח "מההתחלה" + עריכת תאריך פתיחת תיק + מיגרציה (31 לקוחות) |
+
+---
+
+## 2. Timesheet Trigger Refactor — מה נבנה (PR #144)
+
+### הבעיה שהייתה
+4 פונקציות עם לוגיקת deduction משלהן. כשאחת נכשלה — נתונים נשברו בשקט. יצר פערים ב-77% מהלקוחות.
+
+### הפתרון
+**Trigger מרכזי** (`onTimesheetEntryChanged`) — מתעורר על כל CREATE/UPDATE/DELETE של timesheet entry ומחשב סיכומים מאפס.
+
+### Commits
+
+| Commit | תיאור |
+|--------|-------|
+| `b47a2ee` | feat: add onTimesheetEntryChanged trigger — hours + legal_procedure |
+| `a78ab31` | fix: infinite loop guard for trigger self-writes |
+| `3a6ceb4` | refactor: remove deduction from createTimesheetEntry_v2 |
+| `4ec859e` | refactor: remove deduction from createQuickLogEntry |
+| `2158776` | refactor: remove deduction from updateTimesheetEntry |
+| `76d807d` | refactor: remove deduction from addTimeToTask + lookupServiceIds |
+| `4bec3b0` | fix: always write isOverage on entry + remove debug logs |
+| `e42ccfe` | fix: use parentServiceId for legal_procedure service lookup |
+| `1af5fed` | fix: pass lookupServiceId to apply functions |
+| `1162960` | fix: invalidate clients cache after timesheet operations |
+
+### Flow
+
+```
+Entry נוצר/מתעדכן/נמחק ב-timesheet_entries
+  → onTimesheetEntryChanged (Firestore Trigger, Gen 2)
+    → מזהה eventType (CREATE/UPDATE/DELETE)
+    → מחשב delta
+    → self-write guard (אם רק isOverage השתנה → skip)
+    → קורא client doc
+    → hours → applyHoursDelta(services, serviceId, packageId, delta)
+    → legal_procedure → applyLegalProcedureDelta(services, serviceId, stageId, packageId, delta)
+    → calcClientAggregates → סיכומי root
+    → Transaction: כותב client + entry (isOverage) + task (actualMinutes)
+```
+
+### Service lookup
+- `hours`: serviceId מה-entry → service ישירות
+- `legal_procedure`: `lookupServiceId = parentServiceId || serviceId`
+
+---
+
+## 3. פיצול functions/index.js — הושלם (PRs #133–135)
+
+**לפני:** 9,614 שורות, 66 exports, הכל בקובץ אחד
+**אחרי:** 104 שורות, registry בלבד
+
+```
+functions/
+├── index.js              ← 104 שורות, registry בלבד
+├── shared/               ← auth, audit, validators
+├── auth/                 ← 5 פונקציות
+├── budget-tasks/         ← 7 פונקציות
+├── clients/              ← 7 פונקציות + helper
+├── services/             ← 7 פונקציות
+├── timesheet/            ← 4 פונקציות + 8 helpers + internal-case
+├── scheduled/            ← 3 פונקציות (כולל dailyInvariantCheck)
+├── whatsapp/             ← 4 פונקציות
+├── metrics/              ← 2 פונקציות
+├── fee-agreements/       ← 2 פונקציות
+├── admin/                ← 9 פונקציות
+├── triggers/             ← onTimesheetEntryChanged
+├── addTimeToTask_v2.js   ← פונקציה עצמאית
+└── src/                  ← מודולים פנימיים
+```
+
+---
+
+## 4. מצב אטומיות — כל הפונקציות
+
+| פונקציה | אטומי? | סיכומים | סטטוס |
+|---------|--------|---------|-------|
+| `createTimesheetEntry_v2` | ✅ כן | Trigger | פעיל |
+| `createQuickLogEntry` | ✅ כן | Trigger | פעיל |
+| `updateTimesheetEntry` | ✅ כן | Trigger | פעיל |
+| `addTimeToTask` | ✅ כן | Trigger | פעיל |
+| `completeTask` | ✅ כן | — | פעיל |
+| `cancelBudgetTask` | ✅ כן | — | פעיל |
+| `createBudgetTask` | ✅ כן | — | פעיל |
+| `adjustTaskBudget` | ✅ כן | — | פעיל |
+| `onTimesheetEntryChanged` | ✅ Trigger | מקור יחיד | פעיל |
+| `dailyInvariantCheck` | ✅ Scheduled | בקרה | פעיל |
+| `createTimesheetEntry` (v1) | ❌ | — | **נמחק** (`e9333f0`) |
+
+---
+
+## 5. ארכיטקטורת Transaction
+
+| סוג | בתוך Transaction? | סיבה |
+|-----|-------------------|------|
+| Data עיקרי (task, entry, client) | ✅ כן | חייב להיות עקבי |
+| Approval records | ✅ כן | משפיע על UI |
+| Audit log | ❌ לא | Secondary — לא חוסם משתמש |
+| Alerts / Notifications | ❌ לא | Secondary — לא חוסם משתמש |
+
+---
+
+## 6. החלטות ארכיטקטוניות (לא לשנות בלי דיון)
+
+| החלטה | סיבה |
+|-------|------|
+| **Trigger = מקור יחיד לסיכומים** | מקום אחד, לוגיקה אחת. הפונקציות לא מחשבות סיכומים |
+| **lookupServiceId = parentServiceId ‖ serviceId** | ב-legal_procedure, serviceId ב-entry = stageId, לא service ID |
+| **Self-write guard מפורש** | אם רק isOverage/overageMinutes השתנו → skip. מונע infinite loop |
+| **timesheet_entries = מקור אמת** | כל פער מתוקן לפי entries |
+| **Immutable pattern ב-transactions** | spread operator, לא mutation — מונע double-update ב-retry |
+| **Eventarc authentication לוקח זמן** | Gen 2 — שגיאה שקטה ראשונה אחרי deploy אינה באג קוד |
+| **cache invalidation מיד, בלי setTimeout** | onSnapshot listener תופס את העדכון |
+| **dist/ ב-git** | Netlify לא בונה — לא להסיר בלי לתקן build |
+| **v1 לא fallback** | Fail-fast עדיף על fallback לקוד לא אטומי |
+| **Audit log מחוץ ל-Transaction** | Secondary — לא חוסם משתמש |
+| **Functions deploy אחרון, לא ראשון** | Frontend חייב להיות מעודכן לפני שינוי Functions |
+| **set+merge במקום dot notation** | Firestore מפרש נקודות ב-field path כ-nested objects |
+| **auth-guard ממתין ל-firebase:ready event** | מונע הבהוב login screen לפני ש-Firebase מסיים init |
+| **Pre-flight auth check בכל דף Admin** | Optimistic loading — sessionStorage check לפני Firebase |
+| **auth-optimistic class pattern ל-index.html** | index.html הוא גם login page — לא ניתן להחליף AuthSystem |
+| **readBy ב-Firestore — field שטוח** | email כ-key, לא nested. set+merge בלבד |
+| **Netlify build = echo** | Workaround ל-tsc Permission denied. חוב טכני |
+
+---
+
+## 7. Reconciliation — תיקון נתונים היסטוריים
+
+| תאריך | סקריפט | תוצאה |
+|-------|--------|-------|
+| 2026-02-09 | `reconciliation-fix-execute.js` | 13 שירותים, 12 לקוחות |
+| 2026-02-09 | `reconciliation-fix-remaining.js` | 18 שירותים, 66 לקוחות |
+| 2026-03-04 | `reconciliation-execute-2026-03-04.js` | 84 לקוחות, 0 שגיאות |
+
+**עיקרון:**
+```
+Service: hoursUsed = SUM(timesheet_entries.minutes) / 60
+Service: hoursRemaining = totalHours - hoursUsed
+Client root: hoursUsed = SUM(services[].hoursUsed)
+Client root: minutesUsed = hoursUsed * 60
+```
+
+---
+
+## 8. ארכיטקטורת המערכת
+
+### שני Netlify Sites מאותו Repo
+
+| Site | URL PROD | Build |
+|------|----------|-------|
+| User App | `gh-law-office-system.netlify.app` | `npm run cache-bust && npm run type-check && npm run compile-ts` (prod: echo) |
+| Admin Panel | `admin-gh-law-office-system.netlify.app` | `echo` (static) |
+
+### Firebase
+
+| רכיב | כמות |
+|------|------|
+| Firestore Collections | 19 |
+| Cloud Functions | 73 |
+| onCall | ~65 |
+| onSchedule | 3 |
+| onDocumentWritten (Trigger) | 2 |
+| onRequest | 3 |
+
+### URLs
+
+| סביבה | User App | Admin Panel |
+|-------|----------|-------------|
+| DEV | `https://main--gh-law-office-system.netlify.app` | `https://main--admin-gh-law-office-system.netlify.app` |
+| PROD | `https://gh-law-office-system.netlify.app` | `https://admin-gh-law-office-system.netlify.app` |
+
+---
+
+## 9. תהליך Deploy (חובה)
+
+```
+1. Push ל-main + Netlify DEV build ירוק
+2. Smoke test על DEV
+3. PR + Merge ל-production-stable
+4. ⚠️ ודא Netlify PROD build ירוק + Published
+5. רק אחרי Frontend מעודכן → firebase deploy --only functions
+6. Smoke test על PROD
+7. Cache bust (Ctrl+Shift+R) + בדיקת Console
+```
+
+**כלל: Functions deploy אחרון, לא ראשון!**
+
+---
+
+## 10. נושאים פתוחים
+
+| נושא | עדיפות | הערות |
+|------|--------|-------|
+| CI Pipeline (GitHub Actions) | קריטי | טרם נעשה |
+| ביצועי index.html (~10s) | גבוה | profiling + אופטימיזציה |
+| בדיקת UI progress ב-PROD | הושלם | cache invalidation אומת — כל נתיבי דיווח מכוסים (2026-03-06) |
+| שדרוג invariant check לכל רמה | גבוה | כרגע בודק רק root |
+| dailyInvariantCheck — בדיקת חריגות על שירותים חסומים | גבוה | sentinel לתפיסת נתיבים עתידיים |
+| feature/new-sidebar | ממתין | sidebar + BeitMidrash + topbar. ממתין לאישור חיים |
+| caseOpenDate — לקוחות חדשים (ללא entries) | נמוך | 20 לקוחות ללא entries — caseOpenDate יוגדר ידנית בעת הצורך |
+| 9 שירותים manual review | בינוני | 0 רשומות timesheet — בדיקה ידנית |
+| tsc permission denied ב-Netlify | נמוך | עקפנו עם skip build — חוב טכני |
+| ניקוי branches ישנים | הושלם | feature/timesheet-triggers נמחק. סה"כ 2 branches בלבד. |
+| SMS Twilio | נמוך | TODO בקוד, +972549539238 |
+| AI integration ל-User App | נדחה | Cloud Function כ-proxy ל-Claude API |
+| מיגרציה מ-functions.config() ל-Secret Manager | נמוך | deadline מרץ 2027 |
+
+---
+
+## 11. שרשרת קריאות — דיווח שעות (Flow קריטי)
+
+```
+main.js → createTimesheetEntryV2()
+  → timesheet-adapter.js → FirebaseService.call('createTimesheetEntry_v2')
+    → Cloud Function: createTimesheetEntry_v2 (יוצר entry בלבד)
+      → Trigger: onTimesheetEntryChanged (מחשב סיכומים)
+```
+
+**אין שום נתיב שקורא ל-v1.**
+
+---
+
+*מנוהל על ידי טומי — ראש צוות הפיתוח | GH Law Office System*
+*לעדכן בסוף כל עבודה — לא ליצור קובץ חדש*

--- a/apps/admin-panel/css/clients.css
+++ b/apps/admin-panel/css/clients.css
@@ -316,6 +316,11 @@
     color: var(--gray-700);
 }
 
+.status-badge.warning {
+    background: rgb(245 158 11 / 10%);
+    color: #d97706;
+}
+
 .status-badge.inactive {
     background: var(--gray-100);
     color: var(--gray-500);

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -204,27 +204,70 @@ return;
             });
         }
 
+        showOverrideModal(active, serviceName) {
+            return new Promise((resolve) => {
+                const overlay = document.createElement('div');
+                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:9999;';
+
+                const modal = document.createElement('div');
+                modal.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:24px;border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,0.15);z-index:10000;min-width:300px;direction:rtl;';
+
+                if (active) {
+                    modal.innerHTML = `
+                        <div style="font-weight:600;margin-bottom:12px;font-size:15px;">אישור חריגה — ${serviceName}</div>
+                        <input type="text" id="overrideNoteInput" placeholder="הערה (אופציונלי)" style="width:100%;padding:8px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;margin-bottom:16px;box-sizing:border-box;">
+                        <div style="display:flex;gap:8px;justify-content:flex-end;">
+                            <button id="overrideCancel" style="padding:8px 16px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;">ביטול</button>
+                            <button id="overrideConfirm" style="padding:8px 16px;background:#f59e0b;color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600;">אשר חריגה</button>
+                        </div>`;
+                } else {
+                    modal.innerHTML = `
+                        <div style="font-weight:600;margin-bottom:12px;font-size:15px;">ביטול חריגה — ${serviceName}</div>
+                        <div style="color:#6b7280;margin-bottom:16px;font-size:14px;">האם לבטל את אישור החריגה לשירות זה?</div>
+                        <div style="display:flex;gap:8px;justify-content:flex-end;">
+                            <button id="overrideCancel" style="padding:8px 16px;border:1px solid #d1d5db;border-radius:6px;background:#fff;cursor:pointer;">ביטול</button>
+                            <button id="overrideConfirm" style="padding:8px 16px;background:#ef4444;color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600;">בטל חריגה</button>
+                        </div>`;
+                }
+
+                const cleanup = () => {
+ overlay.remove(); modal.remove();
+};
+
+                document.body.appendChild(overlay);
+                document.body.appendChild(modal);
+
+                document.getElementById('overrideCancel').addEventListener('click', () => {
+ cleanup(); resolve(null);
+});
+                overlay.addEventListener('click', () => {
+ cleanup(); resolve(null);
+});
+                document.getElementById('overrideConfirm').addEventListener('click', () => {
+                    const note = active ? (document.getElementById('overrideNoteInput')?.value || '') : '';
+                    cleanup();
+                    resolve(note);
+                });
+            });
+        }
+
         async setServiceOverride(serviceId, active, serviceName) {
-            let note = '';
-            if (active) {
-                const result = prompt(`אישור חריגה לשירות "${serviceName}"\nהערה (אופציונלי):`);
-                if (result === null) {
+            const note = await this.showOverrideModal(active, serviceName);
+            if (note === null) {
 return;
 }
-                note = result || '';
-            } else {
-                if (!confirm(`לבטל אישור חריגה לשירות "${serviceName}"?`)) {
-return;
-}
-            }
 
             try {
-                await FirebaseService.call('setServiceOverride', {
+                const setOverrideFn = window.firebaseFunctions.httpsCallable('setServiceOverride');
+                const result = await setOverrideFn({
                     clientId: this.currentClient.id,
                     serviceId,
                     active,
                     note
                 });
+                if (!result.data.success) {
+                    throw new Error(result.data.message || 'שגיאה באישור חריגה');
+                }
 
                 // עדכון מקומי
                 const services = this.currentClient.services || [];

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -207,10 +207,10 @@ return;
         showOverrideModal(active, serviceName) {
             return new Promise((resolve) => {
                 const overlay = document.createElement('div');
-                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:9999;';
+                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.4);z-index:10300;';
 
                 const modal = document.createElement('div');
-                modal.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:24px;border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,0.15);z-index:10000;min-width:300px;direction:rtl;';
+                modal.style.cssText = 'position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:#fff;padding:24px;border-radius:12px;box-shadow:0 4px 24px rgba(0,0,0,0.15);z-index:10400;min-width:300px;direction:rtl;';
 
                 if (active) {
                     modal.innerHTML = `
@@ -260,7 +260,7 @@ return;
             try {
                 const setOverrideFn = window.firebaseFunctions.httpsCallable('setServiceOverride');
                 const result = await setOverrideFn({
-                    clientId: this.currentClient.id,
+                    clientId: this.currentClient?.id || this.currentClient?.clientId,
                     serviceId,
                     active,
                     note

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -204,6 +204,51 @@ return;
             });
         }
 
+        async setServiceOverride(serviceId, active, serviceName) {
+            let note = '';
+            if (active) {
+                const result = prompt(`אישור חריגה לשירות "${serviceName}"\nהערה (אופציונלי):`);
+                if (result === null) {
+return;
+}
+                note = result || '';
+            } else {
+                if (!confirm(`לבטל אישור חריגה לשירות "${serviceName}"?`)) {
+return;
+}
+            }
+
+            try {
+                await FirebaseService.call('setServiceOverride', {
+                    clientId: this.currentClient.id,
+                    serviceId,
+                    active,
+                    note
+                });
+
+                // עדכון מקומי
+                const services = this.currentClient.services || [];
+                const idx = services.findIndex(s => s.id === serviceId);
+                if (idx !== -1) {
+                    services[idx].overrideActive = active;
+                    if (active) {
+                        services[idx].overrideNote = note;
+                        services[idx].overrideApprovedAt = { seconds: Math.floor(Date.now() / 1000) };
+                    }
+                }
+
+                this.renderClientInfo();
+                this.renderServices();
+                this.showNotification(
+                    active ? `חריגה אושרה לשירות "${serviceName}"` : 'אישור חריגה בוטל',
+                    'success'
+                );
+            } catch (e) {
+                console.error('Error in setServiceOverride:', e);
+                this.showNotification('שגיאה בעדכון החריגה', 'error');
+            }
+        }
+
         renderClientInfo() {
             if (!this.currentClient) {
 return;
@@ -444,6 +489,29 @@ return;
                     });
                 }
 
+                // Override UI for blocked services (admin only)
+                let overrideHTML = '';
+                const isAdmin = window.AuthSystem && window.AuthSystem.isCurrentUserAdmin();
+                if (isAdmin && hoursRemaining <= 0) {
+                    if (service.overrideActive) {
+                        const overrideDate = service.overrideApprovedAt
+                            ? new Date(service.overrideApprovedAt.seconds * 1000).toLocaleDateString('he-IL')
+                            : '';
+                        overrideHTML = `
+                            <div style="margin-top:8px;padding:8px 12px;background:#fffbeb;border:1px solid #f59e0b;border-radius:8px;">
+                                <span style="background:#f59e0b;color:#fff;padding:2px 8px;border-radius:12px;font-size:12px;">⚡ חריגה מאושרת</span>
+                                <small style="color:#6b7280;display:block;margin-top:4px;">אושר ע"י: ${service.overrideApprovedBy || ''} | ${overrideDate}</small>
+                                ${service.overrideNote ? `<small style="color:#6b7280;display:block;">הערה: ${service.overrideNote}</small>` : ''}
+                                <button class="override-btn" data-service-id="${service.id}" data-active="false" data-name="${(service.name || '').replace(/"/g, '&quot;')}" style="padding:4px 10px;background:#ef4444;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:12px;margin-top:4px;">בטל חריגה</button>
+                            </div>`;
+                    } else {
+                        overrideHTML = `
+                            <div style="margin-top:8px;">
+                                <button class="override-btn" data-service-id="${service.id}" data-active="true" data-name="${(service.name || '').replace(/"/g, '&quot;')}" style="padding:4px 10px;background:#f59e0b;color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:12px;">אפשר חריגה</button>
+                            </div>`;
+                    }
+                }
+
                 return `
                     <div class="management-service-info">
                         <div class="management-service-info-item">
@@ -477,6 +545,7 @@ return;
                             </div>
                         </div>
                     </div>
+                    ${overrideHTML}
                 `;
             } else if (service.type === 'legal_procedure') {
                 const stages = service.stages || [];
@@ -645,6 +714,15 @@ return '';
                     const action = e.currentTarget.dataset.serviceAction;
                     const serviceId = e.currentTarget.dataset.serviceId;
                     this.handleServiceAction(action, serviceId);
+                });
+            });
+
+            // Override buttons
+            this.servicesListContainer.querySelectorAll('.override-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const active = btn.dataset.active === 'true';
+                    this.setServiceOverride(btn.dataset.serviceId, active, btn.dataset.name);
                 });
             });
         }

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -489,10 +489,9 @@ return;
                     });
                 }
 
-                // Override UI for blocked services (admin only)
+                // Override UI for blocked services
                 let overrideHTML = '';
-                const isAdmin = window.AuthSystem && window.AuthSystem.isCurrentUserAdmin();
-                if (isAdmin && hoursRemaining <= 0) {
+                if (hoursRemaining <= 0) {
                     if (service.overrideActive) {
                         const overrideDate = service.overrideApprovedAt
                             ? new Date(service.overrideApprovedAt.seconds * 1000).toLocaleDateString('he-IL')

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -272,7 +272,15 @@ return;
             let statusText = 'פעיל';
             let icon = 'fa-check-circle';
 
-            if (client.isBlocked) {
+            const hasActiveOverride = client.services?.some(s =>
+                s.type === 'hours' && s.overrideActive === true
+            );
+
+            if (client.isBlocked && hasActiveOverride) {
+                statusClass = 'warning';
+                statusText = 'חריגה מאושרת';
+                icon = 'fa-bolt';
+            } else if (client.isBlocked) {
                 statusClass = 'blocked';
                 statusText = 'חסום';
                 icon = 'fa-ban';

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -279,7 +279,7 @@ return;
             if (client.isBlocked && hasActiveOverride) {
                 statusClass = 'warning';
                 statusText = 'חריגה מאושרת';
-                icon = 'fa-bolt';
+                icon = '';
             } else if (client.isBlocked) {
                 statusClass = 'blocked';
                 statusText = 'חסום';
@@ -295,8 +295,8 @@ return;
             }
 
             return `
-                <span class="status-badge ${statusClass}">
-                    <i class="fas ${icon}"></i>
+                <span class="status-badge ${statusClass}" style="white-space:nowrap;">
+                    ${icon ? `<i class="fas ${icon}"></i>` : ''}
                     ${statusText}
                 </span>
             `;

--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -346,7 +346,7 @@ async function addTimeToTaskWithTransaction(db, data, user) {
         if (clientData && taskData.serviceId) {
           const lookupId = taskData.parentServiceId || taskData.serviceId;
           const targetService = (clientData.services || []).find(s => s.id === lookupId);
-          if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0) {
+          if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0 && !targetService.overrideActive) {
             throw new functions.https.HttpsError(
               'failed-precondition',
               `השירות "${targetService.name || lookupId}" חסום — נגמרה יתרת השעות`

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -1077,3 +1077,93 @@ exports.deleteClient = functions.https.onCall(async (data, context) => {
     );
   }
 });
+
+/**
+ * אישור/ביטול חריגה מבוקרת על שירות חסום
+ */
+exports.setServiceOverride = functions.https.onCall(async (data, context) => {
+  try {
+    const user = await checkUserPermissions(context);
+
+    if (user.role !== 'admin') {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'רק מנהל יכול לאשר חריגה'
+      );
+    }
+
+    if (!data.clientId || !data.serviceId || typeof data.active !== 'boolean') {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'חסרים פרמטרים: clientId, serviceId, active'
+      );
+    }
+
+    const clientRef = db.collection('clients').doc(data.clientId);
+
+    await db.runTransaction(async (transaction) => {
+      const clientDoc = await transaction.get(clientRef);
+
+      if (!clientDoc.exists) {
+        throw new functions.https.HttpsError('not-found', 'לקוח לא נמצא');
+      }
+
+      const clientData = clientDoc.data();
+      const services = clientData.services || [];
+      const serviceIndex = services.findIndex(s => s.id === data.serviceId);
+
+      if (serviceIndex === -1) {
+        throw new functions.https.HttpsError('not-found', 'שירות לא נמצא');
+      }
+
+      const service = services[serviceIndex];
+
+      if (service.type !== 'hours') {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'חריגה מבוקרת זמינה רק לשירותי שעות'
+        );
+      }
+
+      const updatedService = {
+        ...service,
+        overrideActive: data.active,
+        overrideApprovedBy: data.active ? user.username : service.overrideApprovedBy,
+        overrideApprovedAt: data.active ? admin.firestore.FieldValue.serverTimestamp() : service.overrideApprovedAt,
+        overrideNote: data.active ? (data.note || '') : service.overrideNote
+      };
+
+      const updatedServices = [...services];
+      updatedServices[serviceIndex] = updatedService;
+
+      transaction.update(clientRef, {
+        services: updatedServices,
+        lastModifiedBy: user.username,
+        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp()
+      });
+    });
+
+    await logAction(
+      data.active ? 'SET_SERVICE_OVERRIDE' : 'REMOVE_SERVICE_OVERRIDE',
+      user.uid,
+      user.username,
+      {
+        clientId: data.clientId,
+        serviceId: data.serviceId,
+        overrideActive: data.active,
+        note: data.note || ''
+      }
+    );
+
+    return {
+      success: true,
+      serviceId: data.serviceId,
+      overrideActive: data.active
+    };
+
+  } catch (error) {
+    console.error('Error in setServiceOverride:', error);
+    if (error instanceof functions.https.HttpsError) throw error;
+    throw new functions.https.HttpsError('internal', 'שגיאה פנימית');
+  }
+});

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -1129,7 +1129,7 @@ exports.setServiceOverride = functions.https.onCall(async (data, context) => {
         ...service,
         overrideActive: data.active,
         overrideApprovedBy: data.active ? user.username : service.overrideApprovedBy,
-        overrideApprovedAt: data.active ? admin.firestore.FieldValue.serverTimestamp() : service.overrideApprovedAt,
+        overrideApprovedAt: data.active ? admin.firestore.Timestamp.now() : service.overrideApprovedAt,
         overrideNote: data.active ? (data.note || '') : service.overrideNote
       };
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -83,6 +83,7 @@ exports.updateClient = clients.updateClient;
 exports.deleteClient = clients.deleteClient;
 exports.changeClientStatus = clients.changeClientStatus;
 exports.closeCase = clients.closeCase;
+exports.setServiceOverride = clients.setServiceOverride;
 
 // Services Functions (imported from ./services)
 const services = require('./services');

--- a/functions/timesheet/index.js
+++ b/functions/timesheet/index.js
@@ -168,7 +168,7 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
       const lookupId = data.serviceId;
       if (lookupId) {
         const targetService = (clientData.services || []).find(s => s.id === lookupId);
-        if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0) {
+        if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0 && !targetService.overrideActive) {
           throw new functions.https.HttpsError(
             'failed-precondition',
             `השירות "${targetService.name || lookupId}" חסום — נגמרה יתרת השעות`
@@ -506,7 +506,7 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
       const lookupId = data.parentServiceId || data.serviceId;
       if (lookupId) {
         const targetService = (clientData.services || []).find(s => s.id === lookupId);
-        if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0) {
+        if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0 && !targetService.overrideActive) {
           throw new functions.https.HttpsError(
             'failed-precondition',
             `השירות "${targetService.name || lookupId}" חסום — נגמרה יתרת השעות`
@@ -962,7 +962,7 @@ exports.updateTimesheetEntry = functions.https.onCall(async (data, context) => {
         const lookupId = data.parentServiceId || data.serviceId || entryData.serviceId;
         if (lookupId) {
           const targetService = (clientData2.services || []).find(s => s.id === lookupId);
-          if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0) {
+          if (targetService && targetService.type === 'hours' && (targetService.hoursRemaining || 0) <= 0 && !targetService.overrideActive) {
             throw new functions.https.HttpsError(
               'failed-precondition',
               `השירות "${targetService.name || lookupId}" חסום — נגמרה יתרת השעות`


### PR DESCRIPTION
## Summary
- **Service Override System**: Admins can approve continued time tracking on services that exhausted their hours allocation
- New `setServiceOverride` Cloud Function (admin-only, transaction-based, with audit log)
- Modified blocking checks in `addTimeToTask_v2` and 3 timesheet functions to respect `overrideActive` flag
- Admin Panel UI: override toggle button in ClientManagementModal with custom modal (not prompt/confirm)
- ClientsTable: "חריגה מאושרת" warning badge for clients with active overrides
- Timesheet entries continue to be marked `isOverage: true` for billing purposes

## Files Changed
- `functions/clients/index.js` — new `setServiceOverride` CF
- `functions/index.js` — export
- `functions/addTimeToTask_v2.js` — override bypass
- `functions/timesheet/index.js` — override bypass (3 locations)
- `apps/admin-panel/js/ui/ClientManagementModal.js` — override UI + modal
- `apps/admin-panel/js/ui/ClientsTable.js` — warning badge
- `apps/admin-panel/css/clients.css` — `.status-badge.warning` style

## Test plan
- [x] Cloud Function deployed and tested on DEV (Firestore verified)
- [x] Admin Panel tested on DEV Netlify
- [x] `serverTimestamp()` → `Timestamp.now()` fix deployed
- [ ] Verify override toggle works on PROD after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)