### PR TITLE
fix: fixed-service never blocked — exclude from isBlocked calc

### DIFF
--- a/apps/admin-panel/js/features/ServiceOverdraftResolution.js
+++ b/apps/admin-panel/js/features/ServiceOverdraftResolution.js
@@ -602,7 +602,8 @@
                     }
 
                     // בדיקה אם השירות בחריגה
-                    const hasOverdraft = (service.hoursRemaining || 0) < 0;
+                    const isFixed = service.type === 'legal_procedure' && service.pricingType === 'fixed';
+                    const hasOverdraft = !isFixed && (service.hoursRemaining || 0) < 0;
                     if (!hasOverdraft) {
                         // ✅ שחרור נעילה - אין חריגה
                         delete card.dataset.overdraftInjecting;

--- a/functions/triggers/timesheet-trigger.js
+++ b/functions/triggers/timesheet-trigger.js
@@ -186,7 +186,9 @@ function applyLegalProcedureDelta(services, serviceId, stageId, packageId, minut
     const svcHoursUsed = round2(
       updatedStages.reduce((sum, st) => sum + (st.pricingType === 'fixed' ? (st.totalHoursWorked || 0) : (st.hoursUsed || 0)), 0)
     );
-    const svcHoursRemaining = round2((svc.totalHours || 0) - svcHoursUsed);
+    const svcHoursRemaining = svc.pricingType === 'fixed'
+      ? null
+      : round2((svc.totalHours || 0) - svcHoursUsed);
 
     return {
       ...svc,
@@ -205,15 +207,17 @@ function applyLegalProcedureDelta(services, serviceId, stageId, packageId, minut
  * Calculate client-level aggregates from services array
  */
 function calcClientAggregates(services, clientTotalHours) {
+  const billableServices = services.filter(
+    svc => !(svc.type === 'legal_procedure' && svc.pricingType === 'fixed')
+  );
   const hoursUsed = round2(
-    services.reduce((sum, svc) => sum + (svc.hoursUsed || 0), 0)
+    billableServices.reduce((sum, svc) => sum + (svc.hoursUsed || 0), 0)
   );
   const hoursRemaining = round2((clientTotalHours || 0) - hoursUsed);
   const minutesUsed = round2(hoursUsed * 60);
   const minutesRemaining = round2(hoursRemaining * 60);
   const isBlocked = hoursRemaining <= 0;
   const isCritical = !isBlocked && hoursRemaining <= 5;
-
   return { hoursUsed, hoursRemaining, minutesUsed, minutesRemaining, isBlocked, isCritical };
 }
 


### PR DESCRIPTION
## Summary
- **timesheet-trigger.js**: `calcClientAggregates` now filters out `legal_procedure + fixed` services from `isBlocked` calculation
- **timesheet-trigger.js**: `applyLegalProcedureDelta` sets `svcHoursRemaining = null` for fixed-price services
- **ServiceOverdraftResolution.js**: Skip overdraft UI injection for fixed-price services

## Files Changed (2)
- `functions/triggers/timesheet-trigger.js`
- `apps/admin-panel/js/features/ServiceOverdraftResolution.js`

## Test plan
- [ ] Verify fixed-price legal_procedure service does NOT trigger `isBlocked=true` on client
- [ ] Verify fixed-price service does NOT show overdraft warning in admin panel
- [ ] Verify hourly services still correctly calculate `isBlocked`/`isCritical`
- [ ] No functions deploy needed yet — frontend-only check first via Netlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)