### PR TITLE
Hotfix: revert defer on logger.js — Logger not defined in PROD

### DIFF
--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -1180,7 +1180,7 @@
     <!-- SCRIPTS AND STYLES -->
     <!-- ===== 🔇 Production Logger - MUST BE FIRST ===== -->
     <!-- מערכת לוגים מרכזית - מצב ייצור (מינימום לוגים) -->
-    <script defer src="js/modules/logger.js?v=2ba1e81"></script>
+    <script src="js/modules/logger.js?v=2ba1e81"></script>
 
     <!-- ===== ⚡ Lazy Loader - Dynamic Script Loading ===== -->
     <!-- טעינה דינמית של סקריפטים - שיפור ביצועים -->


### PR DESCRIPTION
## Hotfix — Logger ReferenceError in PROD

6 scripts crash with 'Logger is not defined' because logger.js was deferred
but blocking scripts (cases.js, notification-system.js, etc.) call Logger at top level.

Fix: logger.js returns to blocking. 32 scripts remain deferred.

Errors fixed:
- cases.js:839
- cases-integration.js:258
- legal-procedures.js:1113
- notification-system.js:749
- modals-manager.js:767
- idle-timeout-manager.js:494