### PR TITLE
Hotfix: restore lottie CDN to head for animation feedback

### DIFF
--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -20,7 +20,8 @@
 
     <!-- ===== ספריות חיצוניות ו-Firebase ===== -->
     <!-- FIREBASE & EXTERNAL LIBRARIES -->
-    <!-- ⚡ xlsx, lottie, DOMPurify moved to end of body with defer (performance optimization) -->
+    <!-- ⚡ xlsx, DOMPurify moved to end of body with defer (performance optimization) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
@@ -1373,7 +1374,6 @@
 
     <!-- ⚡ CDN Libraries (deferred from head for performance) -->
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.8/dist/purify.min.js"></script>
 
     <!-- Additional CSS for animations -->


### PR DESCRIPTION
## Hotfix — Lottie animations missing

lottie-manager.js requires lottie library at load time for user feedback animations.
Moving it to defer broke all Lottie animations (task completion, time logging, etc.).

Fix: lottie.min.js restored to head (blocking). xlsx and DOMPurify remain deferred.
CDN cached after first visit — minimal performance impact on repeat loads.