### PR TITLE
Hotfix: restore lottie-animations + lottie-manager to blocking

### DIFF
--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -1228,8 +1228,8 @@
 
     <!-- ===== Lottie Animations Configuration ===== -->
     <!-- MUST BE LOADED BEFORE NotificationSystem -->
-    <script defer src="js/modules/lottie-animations.js?v=2ba1e81"></script>
-    <script defer src="js/modules/lottie-manager.js?v=2ba1e81"></script>
+    <script src="js/modules/lottie-animations.js?v=2ba1e81"></script>
+    <script src="js/modules/lottie-manager.js?v=2ba1e81"></script>
 
     <!-- ===== Notification System ===== -->
     <!-- Toast notifications with Lottie animations -->


### PR DESCRIPTION
## Hotfix — Lottie animations not firing

lottie-animations.js and lottie-manager.js were deferred in PR #156.
Animation triggers fire before the deferred scripts load, so animations never play.

Fix: both scripts return to blocking. 30 scripts remain deferred.

Regression introduced in: PR #156
Reported: animations missing when adding time to task