### PR TITLE
Hotfix: restore feature-flags.js to blocking — lottie loading fix

### DIFF
--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -1238,7 +1238,7 @@
 
     <!-- ===== 🎯 NEW: Unified UI System - Step 1: Load Components ===== -->
     <!-- Feature Flags - Controls whether to use new or legacy system -->
-    <script defer src="shared/config/feature-flags.js"></script>
+    <script src="shared/config/feature-flags.js"></script>
     <!-- Unified Loading Overlay -->
     <link rel="stylesheet" href="shared/ui/styles/loading.css">
     <script src="shared/ui/loading/LoadingOverlay.js"></script>


### PR DESCRIPTION
## Hotfix — Lottie animations not showing

Root cause: feature-flags.js was deferred in PR #156 but loading-wrapper.js 
(blocking) reads SHARED_UI_CONFIG.USE_SHARED_LOADING at init time.

With defer, the flag is undefined when wrapper runs → defaults to legacy 
loading system → UnifiedLoadingOverlay never activated → lottie animations 
not displayed correctly.

Fix: feature-flags.js returns to blocking.
28 scripts remain deferred (was 36, reduced through 4 hotfixes).

Future: consolidate two loading systems into one (separate issue).