### PR TITLE
perf: remove unnecessary Firebase calls from budget tasks view

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -886,7 +886,7 @@ class LawOfficeManager {
       this.syncToggleState();
 
       // ✅ עדכון המונים בטעינה ראשונית
-      await this.updateTaskCountBadges();
+      this.updateTaskCountBadges();
 
       // 🔄 Update client validation and selectors (for old system)
       if (this.clientValidation) {
@@ -962,7 +962,6 @@ return false;
 
           // Re-filter and render
           this.filterBudgetTasks();
-          this.renderBudgetView();
 
           // Update task count badges
           this.updateTaskCountBadges();
@@ -1481,57 +1480,24 @@ return;
    * ✅ Update task count badges for both active and completed
    * 🚀 OPTIMIZED: Uses Firestore count() for accurate counts without loading all documents
    */
-  async updateTaskCountBadges() {
-    try {
-      const db = window.firebaseDB;
-      if (!db) {
-        console.warn('⚠️ Firebase DB not available for count badges');
-        return;
-      }
+  updateTaskCountBadges() {
+    const allTasks = this.budgetTasks || [];
+    const activeCount = allTasks.filter(t => t.status === 'פעיל').length;
+    const completedCount = allTasks.filter(t => t.status === 'הושלם').length;
 
-      // 🚀 Count queries - Firebase SDK 9.22.0 compatible (using .get() + .size)
-      const [activeSnapshot, completedSnapshot] = await Promise.all([
-        db.collection('budget_tasks')
-          .where('employee', '==', this.currentUser)
-          .where('status', '==', 'פעיל')
-          .get(),
-
-        db.collection('budget_tasks')
-          .where('employee', '==', this.currentUser)
-          .where('status', '==', 'הושלם')
-          .get()
-      ]);
-
-      const activeCount = activeSnapshot.size;
-      const completedCount = completedSnapshot.size;
-
-      // עדכון המונה של פעילות
-      const activeBadge = document.getElementById('activeCountBadge');
-      if (activeBadge) {
-        activeBadge.textContent = activeCount;
-        activeBadge.style.display = activeCount > 0 ? 'inline-flex' : 'none';
-      }
-
-      // עדכון המונה של מושלמות
-      const completedBadge = document.getElementById('completedCountBadge');
-      if (completedBadge) {
-        completedBadge.textContent = completedCount;
-        completedBadge.style.display = completedCount > 0 ? 'inline-flex' : 'none';
-      }
-
-      Logger.log(`✅ Count badges updated: ${activeCount} active, ${completedCount} completed`);
-    } catch (error) {
-      console.error('Error updating count badges:', error);
-      // Fallback: hide badges on error
-      const activeBadge = document.getElementById('activeCountBadge');
-      const completedBadge = document.getElementById('completedCountBadge');
-      if (activeBadge) {
-activeBadge.style.display = 'none';
-}
-      if (completedBadge) {
-completedBadge.style.display = 'none';
-}
+    const activeBadge = document.getElementById('activeCountBadge');
+    if (activeBadge) {
+      activeBadge.textContent = activeCount;
+      activeBadge.style.display = activeCount > 0 ? 'inline-flex' : 'none';
     }
+
+    const completedBadge = document.getElementById('completedCountBadge');
+    if (completedBadge) {
+      completedBadge.textContent = completedCount;
+      completedBadge.style.display = completedCount > 0 ? 'inline-flex' : 'none';
+    }
+
+    Logger.log(`✅ Count badges updated: ${activeCount} active, ${completedCount} completed`);
   }
 
   async renderBudgetView() {

--- a/apps/user-app/js/modules/statistics.js
+++ b/apps/user-app/js/modules/statistics.js
@@ -167,50 +167,8 @@ function _calculateBudgetStatisticsClient(tasks) {
  * @returns {Promise<Object>} אובייקט עם כל הסטטיסטיקה
  */
 async function calculateBudgetStatistics(tasks) {
-  // ✅ נסה לקרוא מהשרת קודם (אם Firebase זמין)
-  if (window.firebase && window.firebase.functions) {
-    try {
-      const functions = window.firebase.functions();
-      const getUserMetrics = functions.httpsCallable('getUserMetrics');
-
-      // Timeout של 3 שניות - אם השרת לא עונה, נעבור ל-fallback
-      const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Server timeout')), 3000)
-      );
-
-      const result = await Promise.race([
-        getUserMetrics(),
-        timeoutPromise
-      ]);
-
-      if (result?.data?.success && result.data.data) {
-        const serverMetrics = result.data.data;
-
-        // ✅ חישוב שדות נוספים שהשרת לא מספק (overBudget, progress, status)
-        // נעשה חישוב חלקי על המשימות
-        const clientStats = _calculateBudgetStatisticsClient(tasks);
-
-        // ✅ שילוב נתונים: שרת (total, active, completed, urgent) + לקוח (שאר השדות)
-        return {
-          ...clientStats, // כל השדות מהלקוח
-          // Override עם נתונים מהשרת
-          total: serverMetrics.total,
-          active: serverMetrics.active,
-          completed: serverMetrics.completed,
-          urgent: serverMetrics.urgent,
-          // סימן שהנתונים הגיעו מהשרת
-          source: serverMetrics.source || 'server'
-        };
-      }
-    } catch (error) {
-      // Silent fallback - אם השרת נכשל, נעבור ללקוח
-      Logger.log(`⚠️ Server metrics unavailable, using client calculation: ${error.message}`);
-    }
-  }
-
-  // ✅ Fallback: חישוב לקוח מלא
   const stats = _calculateBudgetStatisticsClient(tasks);
-  stats.source = 'client'; // סימן שהנתונים חושבו בלקוח
+  stats.source = 'client';
   return stats;
 }
 
@@ -221,9 +179,6 @@ async function calculateBudgetStatistics(tasks) {
  * @returns {string} HTML string
  */
 function createBudgetStatsBar(stats, currentFilter = 'all') {
-  const plannedHours = Math.round((stats.totalPlanned / 60) * 10) / 10;
-  const actualHours = Math.round((stats.totalActual / 60) * 10) / 10;
-
   return `
     <div class="stats-badge">
       <div class="stat-compact ${currentFilter === 'all' ? 'stat-highlight' : ''}">


### PR DESCRIPTION
## Summary
- Remove double `renderBudgetView()` call in onSnapshot callback (was called twice per Firestore update)
- Replace `getUserMetrics` Cloud Function call with client-side calculation in `calculateBudgetStatistics`
- Replace 2 Firestore count queries in `updateTaskCountBadges` with local array filter on `this.budgetTasks`
- Remove unused `plannedHours`/`actualHours` variables in `createBudgetStatsBar`

## Impact
- **Before:** Every render triggered a Cloud Function call + every onSnapshot triggered double render + every badge update fetched all documents twice from Firestore
- **After:** All stats computed from data already in memory. Zero additional Firebase calls per user action.
- **Files changed:** `main.js`, `statistics.js` only (‑96 lines, +17 lines)
- **No changes to:** Cloud Functions, Firestore triggers, DataCache, onSnapshot listener

## Test plan
- [ ] Open budget tasks screen — verify stats bar shows correct counts
- [ ] Toggle active/completed — verify badge counts update correctly
- [ ] Sort/filter tasks — verify no errors in console
- [ ] Change a task status — verify onSnapshot updates view once (not twice)
- [ ] Check Network tab — no `getUserMetrics` callable requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)