### PR TITLE
fix: activate PresenceSystem — Firestore rules, CSP, connect fields

### DIFF
--- a/apps/user-app/js/modules/authentication.js
+++ b/apps/user-app/js/modules/authentication.js
@@ -155,8 +155,6 @@ async function handleLogin() {
       console.warn('lastLogin update:', err);
     }
 
-    // TODO: PresenceSystem.connect also writes lastLogin+loginCount —
-    // if PresenceSystem is fixed, remove the direct update above to avoid double increment
     if (window.PresenceSystem) {
       window.PresenceSystem.connect(
         this.currentUid, this.currentUsername, this.currentUser

--- a/apps/user-app/js/modules/presence-system.js
+++ b/apps/user-app/js/modules/presence-system.js
@@ -161,14 +161,14 @@ os = 'iOS';
           disconnectedAt: firebase.database.ServerValue.TIMESTAMP
         });
 
-        // ✅ עדכון lastLogin ב-Firestore (employees collection - לפי EMAIL)
+        // ✅ עדכון isOnline ב-Firestore (employees collection - לפי EMAIL)
         try {
           await this.firestore.collection('employees').doc(email).update({
-            lastLogin: firebase.firestore.FieldValue.serverTimestamp(),
-            loginCount: firebase.firestore.FieldValue.increment(1)
+            isOnline: true,
+            lastSeen: firebase.firestore.FieldValue.serverTimestamp()
           });
         } catch (firestoreError) {
-          console.warn('[PresenceSystem] Failed to update lastLogin:', firestoreError);
+          console.warn('[PresenceSystem] Failed to update Firestore:', firestoreError);
           // לא נכשל בגלל זה - זה רק metadata
         }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -92,7 +92,7 @@ service cloud.firestore {
       allow update: if isAuthenticated() &&
                        employeeId == request.auth.token.email &&
                        request.resource.data.diff(resource.data).affectedKeys()
-                         .hasOnly(['lastLogin', 'loginCount', 'phone', 'phoneVerified', 'phoneAddedAt', 'phoneAddedBy', 'phoneUpdatedAt', 'approvalsPanelLastViewed']);
+                         .hasOnly(['lastLogin', 'loginCount', 'phone', 'phoneVerified', 'phoneAddedAt', 'phoneAddedBy', 'phoneUpdatedAt', 'approvalsPanelLastViewed', 'lastSeen', 'isOnline']);
     }
 
     // ✅ Clients: READ for all authenticated, WRITE for admins only

--- a/netlify.toml
+++ b/netlify.toml
@@ -142,6 +142,7 @@
       img-src 'self' data: https: blob:;
       connect-src 'self'
         https://*.firebaseio.com
+        wss://*.firebaseio.com
         https://*.googleapis.com
         https://identitytoolkit.googleapis.com
         https://securetoken.googleapis.com


### PR DESCRIPTION
## Summary
- **firestore.rules**: add `lastSeen` + `isOnline` to employees update `hasOnly` list
- **netlify.toml**: add `wss://*.firebaseio.com` to `connect-src` CSP (RTDB WebSocket)
- **presence-system.js**: `connect()` writes `isOnline`+`lastSeen` instead of `lastLogin`+`loginCount` (handleLogin owns those)
- **authentication.js**: remove stale TODO comment

## Test plan
- [ ] Login to User App in PROD — verify no console errors from PresenceSystem
- [ ] Check Firestore `employees/{email}` — `isOnline: true` + `lastSeen` updated
- [ ] Check RTDB `presence/{uid}` — `online: true` + all fields written
- [ ] Wait 5 min — verify heartbeat updates `lastSeen` in both RTDB + Firestore
- [ ] Admin Panel Users table — verify "פעיל עכשיו" shows for online users

🤖 Generated with [Claude Code](https://claude.com/claude-code)