### PR TITLE
fix: serviceId validation + addServiceToClient transaction

### DIFF
--- a/apps/user-app/js/quick-log.js
+++ b/apps/user-app/js/quick-log.js
@@ -1259,8 +1259,10 @@ navigator.vibrate(10);
       document.getElementById('selectedServiceId').value = client.services[0].id;
       hideServiceSelector();
     } else {
-      // No services
+      // No services — block submission
+      document.getElementById('selectedServiceId').value = '';
       hideServiceSelector();
+      showError('ללקוח אין שירות פעיל — לא ניתן לרשום שעות');
     }
   }
 
@@ -1327,10 +1329,14 @@ navigator.vibrate(10);
       return;
     }
 
-    // Check if service selector is visible and required
-    const serviceSelectorGroup = document.getElementById('serviceSelectorGroup');
-    if (!serviceSelectorGroup.classList.contains('hidden') && !serviceId) {
-      showError('יש לבחור שירות/חבילה');
+    // serviceId is always required — whether auto-selected or manually chosen
+    if (!serviceId) {
+      const serviceSelectorGroup = document.getElementById('serviceSelectorGroup');
+      if (!serviceSelectorGroup.classList.contains('hidden')) {
+        showError('יש לבחור שירות/חבילה');
+      } else {
+        showError('ללקוח אין שירות פעיל — לא ניתן לרשום שעות');
+      }
       return;
     }
 
@@ -1373,10 +1379,8 @@ navigator.vibrate(10);
         branch: branch
       };
 
-      // Add serviceId if selected
-      if (serviceId) {
-        payload.serviceId = serviceId;
-      }
+      // serviceId is always required
+      payload.serviceId = serviceId;
 
       // Call Cloud Function
       const createQuickLogEntry = functions.httpsCallable('createQuickLogEntry');

--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -372,9 +372,27 @@ async function addTimeToTaskWithTransaction(db, data, user) {
           resolvedServiceId = services[0].id;
           console.log(`🔍 [addTimeToTask] Auto-selected single service: ${resolvedServiceId}`);
         } else if (!resolvedServiceId && services.length > 1) {
-          // Task was created without serviceId and client has multiple services
-          // Cannot ERROR here — task already exists. Log warning, skip deduction.
-          console.warn(`⚠️ [addTimeToTask] No serviceId on task, client has ${services.length} services — skipping in-transaction deduction`);
+          throw new functions.https.HttpsError(
+            'invalid-argument',
+            'המשימה חסרה שיוך לשירות — יש לעדכן את המשימה לפני רישום זמן'
+          );
+        }
+
+        // ── GATE: serviceId is required (skip for internal tasks) ──
+        const isInternalTask = taskData.clientId === 'internal_office';
+        if (!isInternalTask && clientData && !resolvedServiceId) {
+          throw new functions.https.HttpsError(
+            'invalid-argument',
+            'לא ניתן לרשום שעות ללקוח ללא שירות פעיל'
+          );
+        }
+
+        // ── GATE: serviceId must exist on client ──
+        if (!isInternalTask && resolvedServiceId && !services.some(s => s.id === resolvedServiceId)) {
+          throw new functions.https.HttpsError(
+            'not-found',
+            `שירות ${resolvedServiceId} לא נמצא אצל הלקוח`
+          );
         }
 
         // ── Perform deduction in transaction ──

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -45,164 +45,162 @@ exports.addServiceToClient = functions.https.onCall(async (data, context) => {
       );
     }
 
-    // ✅ שליפת הלקוח (בארכיטקטורה החדשה: clientId = caseNumber = Document ID)
-    const clientRef = db.collection('clients').doc(data.clientId);
-    const clientDoc = await clientRef.get();
-
-    if (!clientDoc.exists) {
-      throw new functions.https.HttpsError(
-        'not-found',
-        `לקוח ${data.clientId} לא נמצא`
-      );
-    }
-
-    const clientData = clientDoc.data();
-    const now = new Date().toISOString();
-    const serviceId = `srv_${Date.now()}`;
-
-    // יצירת השירות החדש
-    let newService = {
-      id: serviceId,
-      type: data.serviceType,
-      name: sanitizeString(data.serviceName.trim()),
-      description: data.description ? sanitizeString(data.description.trim()) : '',
-      status: 'active',
-      createdAt: now,
-      createdBy: user.username
-    };
-
-    // הוספת שדות ספציפיים לסוג השירות
+    // ── Validate type-specific fields before transaction ──
     if (data.serviceType === 'hours') {
-      // תוכנית שעות
       if (!data.hours || typeof data.hours !== 'number' || data.hours < 1) {
         throw new functions.https.HttpsError(
           'invalid-argument',
           'כמות שעות חייבת להיות מספר חיובי'
         );
       }
-
-      const packageId = `pkg_${Date.now()}`;
-
-      newService.packages = [
-        {
-          id: packageId,
-          type: 'initial',
-          hours: data.hours,
-          hoursUsed: 0,
-          hoursRemaining: data.hours,
-          purchaseDate: now,
-          status: 'active',
-          description: 'חבילה ראשונית'
-        }
-      ];
-
-      newService.totalHours = data.hours;
-      newService.hoursUsed = 0;
-      newService.hoursRemaining = data.hours;
-
     } else if (data.serviceType === 'legal_procedure') {
-      // הליך משפטי - נדרש אימות נוסף
       if (!data.stages || !Array.isArray(data.stages) || data.stages.length !== 3) {
         throw new functions.https.HttpsError(
           'invalid-argument',
           'הליך משפטי דורש בדיוק 3 שלבים'
         );
       }
-
       if (!data.pricingType || !['hourly', 'fixed'].includes(data.pricingType)) {
         throw new functions.https.HttpsError(
           'invalid-argument',
           'סוג תמחור חייב להיות "hourly" או "fixed"'
         );
       }
-
-      newService.pricingType = data.pricingType;
-      newService.currentStage = 'stage_a';
-
-      // ✅ שמירת השלבים עם מזהים וסטטוסים
-      newService.stages = data.stages.map((stage, index) => {
-        const stageId = `stage_${['a', 'b', 'c'][index]}`;
-        const stageName = ['שלב א\'', 'שלב ב\'', 'שלב ג\''][index];
-
-        const processedStage = {
-          id: stageId,
-          name: stageName,
-          description: sanitizeString(stage.description || ''),
-          pricingType: data.pricingType,
-          status: index === 0 ? 'active' : 'pending',
-          order: index + 1
-        };
-
-        if (data.pricingType === 'hourly') {
-          // תמחור שעתי - יצירת חבילת שעות ראשונית
-          const packageId = `pkg_${stageId}_${Date.now()}`;
-          processedStage.packages = [
-            {
-              id: packageId,
-              type: 'initial',
-              hours: stage.hours,
-              hoursUsed: 0,
-              hoursRemaining: stage.hours,
-              purchaseDate: now,
-              status: 'active',
-              description: 'חבילה ראשונית'
-            }
-          ];
-          processedStage.totalHours = stage.hours;
-          processedStage.hoursUsed = 0;
-          processedStage.hoursRemaining = stage.hours;
-        } else {
-          // תמחור פיקס
-          processedStage.fixedPrice = stage.fixedPrice;
-          processedStage.paid = false;
-        }
-
-        return processedStage;
-      });
-
-      // חישוב סיכומי שעות (אם שעתי)
-      if (data.pricingType === 'hourly') {
-        newService.totalHours = newService.stages.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-        newService.hoursUsed = 0;
-        newService.hoursRemaining = newService.totalHours;
-      } else {
-        newService.totalPrice = newService.stages.reduce((sum, s) => sum + (s.fixedPrice || 0), 0);
-        newService.totalPaid = 0;
-      }
     }
 
-    // הוספת השירות למערך services[]
-    const services = clientData.services || [];
-    services.push(newService);
+    // ── Transaction: read client → build service → write atomically ──
+    const clientRef = db.collection('clients').doc(data.clientId);
+    const now = new Date().toISOString();
+    const serviceId = `srv_${Date.now()}`;
 
-    // עדכון הלקוח
-    const clientTotalHours = services.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-    const agg = calcClientAggregates(services, clientTotalHours);
+    const result = await db.runTransaction(async (transaction) => {
+      const clientDoc = await transaction.get(clientRef);
 
-    const updates = {
-      services: services,
-      totalServices: services.length,
-      activeServices: services.filter(s => s.status === 'active').length,
-      totalHours: clientTotalHours,
-      hoursUsed: agg.hoursUsed,
-      hoursRemaining: agg.hoursRemaining,
-      minutesUsed: agg.minutesUsed,
-      minutesRemaining: agg.minutesRemaining,
-      isBlocked: agg.isBlocked,
-      isCritical: agg.isCritical,
-      lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-      lastModifiedBy: user.username
-    };
+      if (!clientDoc.exists) {
+        throw new functions.https.HttpsError(
+          'not-found',
+          `לקוח ${data.clientId} לא נמצא`
+        );
+      }
 
-    await clientRef.update(updates);
+      const clientData = clientDoc.data();
 
-    // Audit log
+      // יצירת השירות החדש
+      let newService = {
+        id: serviceId,
+        type: data.serviceType,
+        name: sanitizeString(data.serviceName.trim()),
+        description: data.description ? sanitizeString(data.description.trim()) : '',
+        status: 'active',
+        createdAt: now,
+        createdBy: user.username
+      };
+
+      // הוספת שדות ספציפיים לסוג השירות
+      if (data.serviceType === 'hours') {
+        const packageId = `pkg_${Date.now()}`;
+
+        newService.packages = [
+          {
+            id: packageId,
+            type: 'initial',
+            hours: data.hours,
+            hoursUsed: 0,
+            hoursRemaining: data.hours,
+            purchaseDate: now,
+            status: 'active',
+            description: 'חבילה ראשונית'
+          }
+        ];
+
+        newService.totalHours = data.hours;
+        newService.hoursUsed = 0;
+        newService.hoursRemaining = data.hours;
+
+      } else if (data.serviceType === 'legal_procedure') {
+        newService.pricingType = data.pricingType;
+        newService.currentStage = 'stage_a';
+
+        newService.stages = data.stages.map((stage, index) => {
+          const stageId = `stage_${['a', 'b', 'c'][index]}`;
+          const stageName = ['שלב א\'', 'שלב ב\'', 'שלב ג\''][index];
+
+          const processedStage = {
+            id: stageId,
+            name: stageName,
+            description: sanitizeString(stage.description || ''),
+            pricingType: data.pricingType,
+            status: index === 0 ? 'active' : 'pending',
+            order: index + 1
+          };
+
+          if (data.pricingType === 'hourly') {
+            const packageId = `pkg_${stageId}_${Date.now()}`;
+            processedStage.packages = [
+              {
+                id: packageId,
+                type: 'initial',
+                hours: stage.hours,
+                hoursUsed: 0,
+                hoursRemaining: stage.hours,
+                purchaseDate: now,
+                status: 'active',
+                description: 'חבילה ראשונית'
+              }
+            ];
+            processedStage.totalHours = stage.hours;
+            processedStage.hoursUsed = 0;
+            processedStage.hoursRemaining = stage.hours;
+          } else {
+            processedStage.fixedPrice = stage.fixedPrice;
+            processedStage.paid = false;
+          }
+
+          return processedStage;
+        });
+
+        if (data.pricingType === 'hourly') {
+          newService.totalHours = newService.stages.reduce((sum, s) => sum + (s.totalHours || 0), 0);
+          newService.hoursUsed = 0;
+          newService.hoursRemaining = newService.totalHours;
+        } else {
+          newService.totalPrice = newService.stages.reduce((sum, s) => sum + (s.fixedPrice || 0), 0);
+          newService.totalPaid = 0;
+        }
+      }
+
+      // הוספת השירות למערך services[]
+      const services = [...(clientData.services || []), newService];
+
+      // עדכון הלקוח
+      const clientTotalHours = services.reduce((sum, s) => sum + (s.totalHours || 0), 0);
+      const agg = calcClientAggregates(services, clientTotalHours);
+
+      transaction.update(clientRef, {
+        services: services,
+        totalServices: services.length,
+        activeServices: services.filter(s => s.status === 'active').length,
+        totalHours: clientTotalHours,
+        hoursUsed: agg.hoursUsed,
+        hoursRemaining: agg.hoursRemaining,
+        minutesUsed: agg.minutesUsed,
+        minutesRemaining: agg.minutesRemaining,
+        isBlocked: agg.isBlocked,
+        isCritical: agg.isCritical,
+        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastModifiedBy: user.username
+      });
+
+      return { newService };
+    });
+
+    // Audit log — outside transaction (same pattern as other functions in this file)
     await logAction('ADD_SERVICE_TO_CLIENT', user.uid, user.username, {
       clientId: data.clientId,
-      caseNumber: data.clientId,  // ✅ clientId = caseNumber
+      caseNumber: data.clientId,
       serviceId: serviceId,
       serviceType: data.serviceType,
-      serviceName: newService.name
+      serviceName: result.newService.name
     });
 
     console.log(`✅ Added service ${serviceId} to client ${data.clientId}`);
@@ -210,8 +208,8 @@ exports.addServiceToClient = functions.https.onCall(async (data, context) => {
     return {
       success: true,
       serviceId: serviceId,
-      service: newService,
-      message: `שירות "${newService.name}" נוסף בהצלחה`
+      service: result.newService,
+      message: `שירות "${result.newService.name}" נוסף בהצלחה`
     };
 
   } catch (error) {

--- a/functions/tests/serviceId-validation.test.js
+++ b/functions/tests/serviceId-validation.test.js
@@ -1,0 +1,613 @@
+/**
+ * Tests for branch fix/serviceId-validation-and-transaction
+ *
+ * Covers the new GATE validations and transaction wrapping:
+ *
+ * 1. addTimeToTask_v2.js — 3 GATEs + isInternal exemption
+ *    GATE 1: multiple services without serviceId → error
+ *    GATE 2: no serviceId on non-internal client → error
+ *    GATE 3: serviceId not found on client → error
+ *    EXEMPT: internal tasks (clientId === 'internal_office') bypass GATE 2+3
+ *
+ * 2. timesheet/index.js — createQuickLogEntry 2 GATEs
+ *    GATE 1: no resolvedServiceId → error
+ *    GATE 2: serviceId not found on client → error
+ *
+ * 3. timesheet/index.js — createTimesheetEntry_v2 2 GATEs + isInternal exemption
+ *    GATE 1: no resolvedServiceId (non-internal) → error
+ *    GATE 2: serviceId not found on client → error
+ *    EXEMPT: isInternal === true skips entire validation block
+ *
+ * 4. services/index.js — addServiceToClient wrapped in db.runTransaction
+ *
+ * 5. quick-log.js — client-side serviceId submit block
+ */
+
+// ═══════════════════════════════════════════════════════════════
+// Mocks — must precede require()
+// ═══════════════════════════════════════════════════════════════
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({
+      id,
+      collection: jest.fn(() => ({
+        doc: jest.fn(() => ({ id: 'auto_id' }))
+      }))
+    }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => ({
+  firestore: Object.assign(() => mockDb, {
+    FieldValue: {
+      serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+      increment: jest.fn((n) => ({ _increment: n })),
+      arrayUnion: jest.fn((...args) => ({ _arrayUnion: args }))
+    },
+    Timestamp: {
+      fromDate: jest.fn((d) => ({ seconds: Math.floor(d.getTime() / 1000), nanoseconds: 0 }))
+    }
+  }),
+  initializeApp: jest.fn()
+}));
+
+jest.mock('firebase-functions', () => ({
+  https: {
+    HttpsError: class HttpsError extends Error {
+      constructor(code, message, details) {
+        super(message);
+        this.code = code;
+        this.details = details;
+      }
+    },
+    onCall: jest.fn((fn) => fn)
+  }
+}));
+
+jest.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentWritten: jest.fn(() => jest.fn())
+}));
+
+// ═══════════════════════════════════════════════════════════════
+// Imports
+// ═══════════════════════════════════════════════════════════════
+
+const { addTimeToTaskWithTransaction } = require('../addTimeToTask_v2');
+const functions = require('firebase-functions');
+
+// ═══════════════════════════════════════════════════════════════
+// Fixtures
+// ═══════════════════════════════════════════════════════════════
+
+function makeHoursService(id, { totalHours = 20, hoursUsed = 5 } = {}) {
+  return {
+    id,
+    type: 'hours',
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    isBlocked: false,
+    isCritical: false,
+    packages: [{
+      id: `${id}_pkg1`,
+      hours: totalHours,
+      hoursUsed,
+      hoursRemaining: totalHours - hoursUsed,
+      status: 'active'
+    }]
+  };
+}
+
+function makeTaskDoc(overrides = {}) {
+  return {
+    exists: true,
+    data: () => ({
+      employee: 'user@test.com',
+      clientId: 'client_1',
+      clientName: 'Test Client',
+      description: 'Test task',
+      actualMinutes: 0,
+      estimatedMinutes: 120,
+      serviceId: 'svc_1',
+      ...overrides
+    })
+  };
+}
+
+function makeClientDoc(overrides = {}) {
+  return {
+    exists: true,
+    data: () => ({
+      clientName: 'Test Client',
+      services: [makeHoursService('svc_1')],
+      totalHours: 20,
+      ...overrides
+    })
+  };
+}
+
+const defaultUser = {
+  uid: 'uid_1',
+  email: 'user@test.com',
+  username: 'testuser',
+  role: 'employee'
+};
+
+const defaultData = {
+  taskId: 'task_1',
+  minutes: 60,
+  date: '2026-03-30',
+  description: 'Work done'
+};
+
+// ═══════════════════════════════════════════════════════════════
+// Reset mocks before each test
+// ═══════════════════════════════════════════════════════════════
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRunTransaction.mockImplementation(async (fn) => fn(mockTransaction));
+});
+
+
+// ═══════════════════════════════════════════════════════════════
+// 1. addTimeToTaskWithTransaction — serviceId GATEs
+// ═══════════════════════════════════════════════════════════════
+
+describe('addTimeToTaskWithTransaction — serviceId validation GATEs', () => {
+
+  // ── GATE 1: multiple services, no serviceId on task ──
+
+  test('GATE 1: rejects when client has multiple services and task has no serviceId', async () => {
+    const taskDoc = makeTaskDoc({ serviceId: null });
+    const clientDoc = makeClientDoc({
+      services: [makeHoursService('svc_1'), makeHoursService('svc_2')]
+    });
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)    // task read
+      .mockResolvedValueOnce(clientDoc); // client read
+
+    await expect(
+      addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser)
+    ).rejects.toMatchObject({
+      code: 'invalid-argument',
+      message: expect.stringContaining('חסרה שיוך לשירות')
+    });
+  });
+
+  // ── GATE 2: no serviceId on non-internal client ──
+
+  test('GATE 2: rejects when non-internal client has no services and task has no serviceId', async () => {
+    const taskDoc = makeTaskDoc({ serviceId: null });
+    const clientDoc = makeClientDoc({ services: [] });
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    await expect(
+      addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser)
+    ).rejects.toMatchObject({
+      code: 'invalid-argument',
+      message: expect.stringContaining('ללא שירות פעיל')
+    });
+  });
+
+  // ── GATE 3: serviceId not found on client ──
+
+  test('GATE 3: rejects when task serviceId does not exist on client', async () => {
+    const taskDoc = makeTaskDoc({ serviceId: 'svc_nonexistent' });
+    const clientDoc = makeClientDoc({
+      services: [makeHoursService('svc_1')]
+    });
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    await expect(
+      addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser)
+    ).rejects.toMatchObject({
+      code: 'not-found',
+      message: expect.stringContaining('svc_nonexistent')
+    });
+  });
+
+  // ── EXEMPT: internal task bypasses GATE 2 ──
+
+  test('EXEMPT: internal task (clientId=internal_office) bypasses serviceId requirement', async () => {
+    const taskDoc = makeTaskDoc({
+      clientId: 'internal_office',
+      clientName: 'פנימי',
+      serviceId: null
+    });
+    // No client doc found (internal_office doesn't have a real client doc)
+    const clientDoc = { exists: false };
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    // Should succeed — no serviceId error
+    const result = await addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser);
+    expect(result.success).toBe(true);
+    expect(result.taskId).toBe('task_1');
+  });
+
+  // ── EXEMPT: internal task bypasses GATE 3 ──
+
+  test('EXEMPT: internal task bypasses serviceId-exists-on-client check', async () => {
+    const taskDoc = makeTaskDoc({
+      clientId: 'internal_office',
+      clientName: 'פנימי',
+      serviceId: 'svc_nonexistent'
+    });
+    const clientDoc = { exists: false };
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser);
+    expect(result.success).toBe(true);
+  });
+
+  // ── Happy path: valid serviceId passes all gates ──
+
+  test('Happy path: valid serviceId passes all gates and deducts', async () => {
+    const taskDoc = makeTaskDoc({ serviceId: 'svc_1' });
+    const clientDoc = makeClientDoc({
+      services: [makeHoursService('svc_1')]
+    });
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser);
+
+    expect(result.success).toBe(true);
+    expect(result.newActualMinutes).toBe(60);
+    expect(result.timesheetAutoCreated).toBe(true);
+
+    // Verify writes happened
+    expect(mockTransaction.update).toHaveBeenCalled();
+    expect(mockTransaction.set).toHaveBeenCalled();
+  });
+
+  // ── Auto-select: single service, no serviceId on task ──
+
+  test('Auto-select: when client has exactly 1 service and task has no serviceId, auto-selects', async () => {
+    const taskDoc = makeTaskDoc({ serviceId: null });
+    const clientDoc = makeClientDoc({
+      services: [makeHoursService('svc_only')]
+    });
+
+    mockTransaction.get
+      .mockResolvedValueOnce(taskDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await addTimeToTaskWithTransaction(mockDb, defaultData, defaultUser);
+
+    expect(result.success).toBe(true);
+  });
+});
+
+
+// ═══════════════════════════════════════════════════════════════
+// 2. createQuickLogEntry — serviceId validation GATEs
+// ═══════════════════════════════════════════════════════════════
+
+describe('createQuickLogEntry — serviceId validation GATEs (logic verification)', () => {
+
+  /**
+   * createQuickLogEntry is an onCall function that runs inside a transaction.
+   * We verify the GATE logic by simulating the same conditions:
+   *
+   *   const services = clientData.services || [];
+   *   let resolvedServiceId = data.serviceId || null;
+   *   if (!resolvedServiceId && services.length === 1) resolvedServiceId = services[0].id;
+   *   if (!resolvedServiceId && services.length > 1) → throw 'invalid-argument'
+   *   if (!resolvedServiceId) → throw 'invalid-argument' (GATE 1)
+   *   if (!services.some(s => s.id === resolvedServiceId)) → throw 'not-found' (GATE 2)
+   */
+
+  function simulateQuickLogServiceResolution(services, inputServiceId) {
+    let resolvedServiceId = inputServiceId || null;
+
+    if (!resolvedServiceId && services.length === 1) {
+      resolvedServiceId = services[0].id;
+    } else if (!resolvedServiceId && services.length > 1) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'חובה לבחור שירות — ללקוח יש מספר שירותים'
+      );
+    }
+
+    // GATE 1: serviceId required
+    if (!resolvedServiceId) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'לא ניתן לרשום שעות ללקוח ללא שירות פעיל'
+      );
+    }
+
+    // GATE 2: serviceId must exist
+    if (!services.some(s => s.id === resolvedServiceId)) {
+      throw new functions.https.HttpsError(
+        'not-found',
+        `שירות ${resolvedServiceId} לא נמצא אצל הלקוח`
+      );
+    }
+
+    return resolvedServiceId;
+  }
+
+  test('GATE 1: rejects when client has no services and no serviceId', () => {
+    expect(() => simulateQuickLogServiceResolution([], null))
+      .toThrow(expect.objectContaining({
+        code: 'invalid-argument',
+        message: expect.stringContaining('ללא שירות פעיל')
+      }));
+  });
+
+  test('GATE 1b: rejects when client has multiple services and no serviceId', () => {
+    const services = [makeHoursService('svc_1'), makeHoursService('svc_2')];
+    expect(() => simulateQuickLogServiceResolution(services, null))
+      .toThrow(expect.objectContaining({
+        code: 'invalid-argument',
+        message: expect.stringContaining('חובה לבחור שירות')
+      }));
+  });
+
+  test('GATE 2: rejects when serviceId does not exist on client', () => {
+    const services = [makeHoursService('svc_1')];
+    expect(() => simulateQuickLogServiceResolution(services, 'svc_wrong'))
+      .toThrow(expect.objectContaining({
+        code: 'not-found',
+        message: expect.stringContaining('svc_wrong')
+      }));
+  });
+
+  test('Happy path: auto-selects single service', () => {
+    const services = [makeHoursService('svc_1')];
+    const result = simulateQuickLogServiceResolution(services, null);
+    expect(result).toBe('svc_1');
+  });
+
+  test('Happy path: explicit serviceId found on client', () => {
+    const services = [makeHoursService('svc_1'), makeHoursService('svc_2')];
+    const result = simulateQuickLogServiceResolution(services, 'svc_2');
+    expect(result).toBe('svc_2');
+  });
+});
+
+
+// ═══════════════════════════════════════════════════════════════
+// 3. createTimesheetEntry_v2 — serviceId validation GATEs
+// ═══════════════════════════════════════════════════════════════
+
+describe('createTimesheetEntry_v2 — serviceId validation GATEs (logic verification)', () => {
+
+  /**
+   * v2 wraps the GATE logic in: if (data.isInternal !== true && clientData) { ... }
+   * So internal entries skip the entire block.
+   */
+
+  function simulateV2ServiceResolution(services, inputServiceId, isInternal) {
+    // v2 skips everything for internal
+    if (isInternal) {
+      return { resolved: inputServiceId || null, skipped: true };
+    }
+
+    let resolvedServiceId = inputServiceId || null;
+
+    if (!resolvedServiceId && services.length === 1) {
+      resolvedServiceId = services[0].id;
+    } else if (!resolvedServiceId && services.length > 1) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'חובה לבחור שירות — ללקוח יש מספר שירותים'
+      );
+    }
+
+    // GATE 1: serviceId required for non-internal
+    if (!resolvedServiceId) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'לא ניתן לרשום שעות ללקוח ללא שירות פעיל'
+      );
+    }
+
+    // GATE 2: serviceId must exist
+    if (!services.some(s => s.id === resolvedServiceId)) {
+      throw new functions.https.HttpsError(
+        'not-found',
+        `שירות ${resolvedServiceId} לא נמצא אצל הלקוח`
+      );
+    }
+
+    return { resolved: resolvedServiceId, skipped: false };
+  }
+
+  test('GATE 1: rejects non-internal entry with no services', () => {
+    expect(() => simulateV2ServiceResolution([], null, false))
+      .toThrow(expect.objectContaining({
+        code: 'invalid-argument',
+        message: expect.stringContaining('ללא שירות פעיל')
+      }));
+  });
+
+  test('GATE 2: rejects non-internal entry with wrong serviceId', () => {
+    const services = [makeHoursService('svc_1')];
+    expect(() => simulateV2ServiceResolution(services, 'svc_bad', false))
+      .toThrow(expect.objectContaining({
+        code: 'not-found',
+        message: expect.stringContaining('svc_bad')
+      }));
+  });
+
+  test('EXEMPT: internal entry skips all serviceId validation', () => {
+    // No services, no serviceId — would fail for non-internal
+    const result = simulateV2ServiceResolution([], null, true);
+    expect(result.skipped).toBe(true);
+  });
+
+  test('EXEMPT: internal entry with bad serviceId still passes', () => {
+    const services = [makeHoursService('svc_1')];
+    const result = simulateV2ServiceResolution(services, 'svc_nonexistent', true);
+    expect(result.skipped).toBe(true);
+    expect(result.resolved).toBe('svc_nonexistent');
+  });
+
+  test('Happy path: auto-selects single service for non-internal', () => {
+    const services = [makeHoursService('svc_1')];
+    const result = simulateV2ServiceResolution(services, null, false);
+    expect(result.resolved).toBe('svc_1');
+    expect(result.skipped).toBe(false);
+  });
+});
+
+
+// ═══════════════════════════════════════════════════════════════
+// 4. addServiceToClient — transaction wrapping
+// ═══════════════════════════════════════════════════════════════
+
+describe('addServiceToClient — transaction wrapping verification', () => {
+
+  /**
+   * The key change: addServiceToClient was refactored to use db.runTransaction.
+   * Before: clientRef.get() → services.push(newService) → clientRef.update()
+   * After:  db.runTransaction → transaction.get(clientRef) → transaction.update(clientRef)
+   *
+   * We verify:
+   * 1. db.runTransaction is called (not direct read/update)
+   * 2. Inside transaction: transaction.get is used for reads
+   * 3. Inside transaction: transaction.update is used for writes
+   * 4. Immutable array: services = [...existing, newService] (not push)
+   */
+
+  // We can't easily require the actual module because it calls functions.https.onCall
+  // at module level. Instead we verify the pattern at the code level.
+
+  const fs = require('fs');
+  const path = require('path');
+  const servicesCode = fs.readFileSync(
+    path.join(__dirname, '..', 'services', 'index.js'),
+    'utf8'
+  );
+
+  // Extract the full addServiceToClient function block (up to next exports.)
+  const fnStart = servicesCode.indexOf('exports.addServiceToClient');
+  const fnEnd = servicesCode.indexOf('\nexports.', fnStart + 1);
+  const fnBlock = servicesCode.substring(fnStart, fnEnd > fnStart ? fnEnd : fnStart + 8000);
+
+  test('addServiceToClient uses db.runTransaction', () => {
+
+    expect(fnBlock).toContain('db.runTransaction');
+  });
+
+  test('addServiceToClient uses transaction.get inside transaction', () => {
+    expect(fnBlock).toContain('transaction.get(clientRef)');
+  });
+
+  test('addServiceToClient uses transaction.update inside transaction', () => {
+    expect(fnBlock).toContain('transaction.update(clientRef');
+  });
+
+  test('addServiceToClient uses immutable spread for services array', () => {
+    // Must use spread: [...(clientData.services || []), newService]
+    expect(fnBlock).toContain('[...(clientData.services || []), newService]');
+    // Must NOT use mutable push
+    expect(fnBlock).not.toContain('services.push(');
+  });
+
+  test('addServiceToClient does NOT use direct clientRef.get()', () => {
+    expect(fnBlock).not.toMatch(/await\s+clientRef\.get\(\)/);
+  });
+
+  test('addServiceToClient does NOT use direct clientRef.update()', () => {
+    expect(fnBlock).not.toMatch(/await\s+clientRef\.update\(/);
+  });
+});
+
+
+// ═══════════════════════════════════════════════════════════════
+// 5. quick-log.js — client-side serviceId submit block
+// ═══════════════════════════════════════════════════════════════
+
+describe('quick-log.js — client-side serviceId validation', () => {
+
+  const fs = require('fs');
+  const path = require('path');
+  const quickLogCode = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'apps', 'user-app', 'js', 'quick-log.js'),
+    'utf8'
+  );
+
+  test('submit handler always requires serviceId (not conditional on visibility)', () => {
+    // The new code: if (!serviceId) { ... } — unconditional check
+    // The old code: if (!serviceSelectorGroup.classList.contains('hidden') && !serviceId)
+    //   — was conditional on visibility
+
+    // Verify the new unconditional pattern exists
+    expect(quickLogCode).toContain("// serviceId is always required — whether auto-selected or manually chosen");
+    expect(quickLogCode).toContain("if (!serviceId) {");
+  });
+
+  test('serviceId is always sent in payload (not conditional)', () => {
+    // New code: payload.serviceId = serviceId; (always)
+    // Old code: if (serviceId) { payload.serviceId = serviceId; }
+
+    expect(quickLogCode).toContain("// serviceId is always required");
+    expect(quickLogCode).toContain("payload.serviceId = serviceId;");
+
+    // The old conditional "if (serviceId) { payload.serviceId" should not exist
+    expect(quickLogCode).not.toMatch(/if\s*\(serviceId\)\s*\{\s*\n?\s*payload\.serviceId/);
+  });
+
+  test('client with no services shows error and blocks submission', () => {
+    // When selecting a client with 0 services:
+    //   document.getElementById('selectedServiceId').value = '';
+    //   showError('ללקוח אין שירות פעיל — לא ניתן לרשום שעות');
+    expect(quickLogCode).toContain("ללקוח אין שירות פעיל — לא ניתן לרשום שעות");
+  });
+
+  test('selectedServiceId is cleared when client has no services', () => {
+    // Verify that when a client has no services, the hidden input is explicitly cleared
+    // This pattern: else { selectedServiceId.value = ''; hideServiceSelector(); showError(...) }
+    const noServicesBlock = quickLogCode.indexOf("// No services — block submission");
+    expect(noServicesBlock).toBeGreaterThan(-1);
+
+    const blockSection = quickLogCode.substring(noServicesBlock, noServicesBlock + 200);
+    expect(blockSection).toContain("selectedServiceId");
+    expect(blockSection).toContain("= ''");
+  });
+
+  test('submit shows contextual error when serviceId missing with visible selector', () => {
+    // When selector is visible (multiple services) but none selected → 'יש לבחור שירות/חבילה'
+    expect(quickLogCode).toContain('יש לבחור שירות/חבילה');
+  });
+
+  test('submit shows contextual error when serviceId missing with hidden selector', () => {
+    // When selector is hidden (0 services) → 'ללקוח אין שירות פעיל'
+    // This appears in the submit handler's else branch
+    const submitSection = quickLogCode.substring(
+      quickLogCode.indexOf('quickLogForm.addEventListener'),
+      quickLogCode.indexOf('quickLogForm.addEventListener') + 2000
+    );
+    expect(submitSection).toContain('ללקוח אין שירות פעיל');
+  });
+});

--- a/functions/timesheet/index.js
+++ b/functions/timesheet/index.js
@@ -188,6 +188,22 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
         );
       }
 
+      // ── GATE: serviceId is required ──
+      if (!resolvedServiceId) {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'לא ניתן לרשום שעות ללקוח ללא שירות פעיל'
+        );
+      }
+
+      // ── GATE: serviceId must exist on client ──
+      if (!services.some(s => s.id === resolvedServiceId)) {
+        throw new functions.https.HttpsError(
+          'not-found',
+          `שירות ${resolvedServiceId} לא נמצא אצל הלקוח`
+        );
+      }
+
       // ── Blocked service check ──
       if (resolvedServiceId) {
         const targetService = services.find(s => s.id === resolvedServiceId);
@@ -630,6 +646,22 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
           throw new functions.https.HttpsError(
             'invalid-argument',
             'חובה לבחור שירות — ללקוח יש מספר שירותים'
+          );
+        }
+
+        // ── GATE: serviceId is required for non-internal entries ──
+        if (!resolvedServiceId) {
+          throw new functions.https.HttpsError(
+            'invalid-argument',
+            'לא ניתן לרשום שעות ללקוח ללא שירות פעיל'
+          );
+        }
+
+        // ── GATE: serviceId must exist on client ──
+        if (!services.some(s => s.id === resolvedServiceId)) {
+          throw new functions.https.HttpsError(
+            'not-found',
+            `שירות ${resolvedServiceId} לא נמצא אצל הלקוח`
           );
         }
 


### PR DESCRIPTION
## Summary
- **serviceId validation**: all 3 timesheet entry creation paths (createQuickLogEntry, createTimesheetEntry_v2, addTimeToTask_v2) now reject entries without a valid serviceId. Internal entries exempt. Frontend quick-log blocks submission for clients with 0 services.
- **addServiceToClient transaction**: wrapped in db.runTransaction() to prevent race conditions on concurrent service additions.

## Test plan
- [x] Unit tests: 29/29 PASS (functions/tests/serviceId-validation.test.js)
- [x] Syntax check: 4/4 files PASS
- [x] DEV deploy: Firebase Functions + Netlify
- [x] Manual DEV testing: quick-log, timer, service addition
- [x] Gatekeeper review: PASS (2 rounds plan + 1 round code)
- [ ] PROD smoke test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)