### PR TITLE
fix: enforce -10h overdraft guard on addTimeToTask_v2

### DIFF
--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -427,6 +427,17 @@ async function addTimeToTaskWithTransaction(db, data, user) {
               }
 
               if (resolvedPackageId) {
+                // Guard: enforce -10h floor before deduction
+                const targetPkg = (targetService.packages || []).find(p => p.id === resolvedPackageId);
+                if (targetPkg) {
+                  const currentRemaining = targetPkg.hoursRemaining || 0;
+                  const afterDeduction = currentRemaining - (minutesDelta / 60);
+                  if (afterDeduction < -10) {
+                    throw new functions.https.HttpsError('resource-exhausted',
+                      'הלקוח בחריגה נא לעדכן בהקדם את גיא',
+                      { clientId: taskData.clientId, currentRemaining, requestedHours: minutesDelta / 60, wouldBe: afterDeduction });
+                  }
+                }
                 deductionResult = applyHoursDelta(services, lookupServiceId, resolvedPackageId, minutesDelta);
               } else {
                 deductionResult = applyHoursDeltaServiceOnly(services, lookupServiceId, minutesDelta);
@@ -450,6 +461,17 @@ async function addTimeToTaskWithTransaction(db, data, user) {
                     if (fallbackStagePkg) resolvedPackageId = fallbackStagePkg.id;
                   }
                   if (resolvedPackageId) {
+                    // Guard: enforce -10h floor before deduction (stage.packages for legal_procedure)
+                    const targetPkg = (stage.packages || []).find(p => p.id === resolvedPackageId);
+                    if (targetPkg) {
+                      const currentRemaining = targetPkg.hoursRemaining || 0;
+                      const afterDeduction = currentRemaining - (minutesDelta / 60);
+                      if (afterDeduction < -10) {
+                        throw new functions.https.HttpsError('resource-exhausted',
+                          'הלקוח בחריגה נא לעדכן בהקדם את גיא',
+                          { clientId: taskData.clientId, currentRemaining, requestedHours: minutesDelta / 60, wouldBe: afterDeduction });
+                      }
+                    }
                     deductionResult = applyLegalProcedureDelta(services, lookupServiceId, resolvedStageId, resolvedPackageId, minutesDelta);
                   } else {
                     deductionResult = applyLegalProcedureDeltaStageOnly(services, lookupServiceId, resolvedStageId, minutesDelta);


### PR DESCRIPTION
## Summary
- **addTimeToTask_v2** was missing the `-10h` overdraft floor check that exists in `createQuickLogEntry` and `createTimesheetEntry_v2`
- Without it, packages could go deeply negative when lawyers report hours via tasks
- Adds guard on both **hours service** (`targetService.packages`) and **legal_procedure hourly** (`stage.packages`) paths

## Changes
- `functions/addTimeToTask_v2.js` — two guards added (lines 430-440, 464-474)

## Test plan
- [x] `node --check` passed
- [x] Gatekeeper review — PASS
- [x] `firebase deploy --only functions` successful
- [x] Manual testing in DEV — happy path verified (add time to task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)