### PR TITLE
fix: Beit Midrash first-click race condition

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -3148,15 +3148,15 @@ function initSidebar() {
 // Initialize Beit Midrash Component (lazy — first visit only)
 let beitMidrashInstance = null;
 
-function initBeitMidrash() {
+async function initBeitMidrash() {
   if (beitMidrashInstance) {
 return;
 }
   const root = document.getElementById('beitMidrashRoot');
   if (root) {
     beitMidrashInstance = new BeitMidrash(root);
-    beitMidrashInstance.init();
     window.beitMidrashInstance = beitMidrashInstance;
+    await beitMidrashInstance.init();
   }
 }
 

--- a/apps/user-app/js/modules/navigation.js
+++ b/apps/user-app/js/modules/navigation.js
@@ -9,7 +9,7 @@
 import { currentActiveTab } from './core-utils.js';
 // NotificationSystem is available globally on window object
 
-function switchTab(tabName) {
+async function switchTab(tabName) {
   const budgetFormContainer = document.getElementById('budgetFormContainer');
   const timesheetFormContainer = document.getElementById(
     'timesheetFormContainer'
@@ -57,14 +57,9 @@ window.beitMidrashInstance.hide();
       plusContainer.style.display = 'none';
     }
     if (!window.beitMidrashInstance && window.initBeitMidrash) {
-      window.initBeitMidrash();
-      // Give browser time to paint initial state before showing
-      setTimeout(() => {
-        if (window.beitMidrashInstance) {
-          window.beitMidrashInstance.show();
-        }
-      }, 50);
-    } else if (window.beitMidrashInstance) {
+      await window.initBeitMidrash();
+    }
+    if (window.beitMidrashInstance) {
       window.beitMidrashInstance.show();
     }
     window.currentActiveTab = tabName;


### PR DESCRIPTION
## Summary
- Fixed race condition where Beit Midrash required two clicks to display properly
- `initBeitMidrash()` now properly awaits async `init()` before calling `show()`
- Removed unreliable 50ms `setTimeout` workaround

## Files changed
- `apps/user-app/js/main.js` — async initBeitMidrash + await init()
- `apps/user-app/js/modules/navigation.js` — async switchTab + await initBeitMidrash

## Test plan
- [x] First click on Beit Midrash opens smoothly
- [x] Switching tabs and returning works
- [x] Verified in DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)