### PR TITLE
fix: Beit Midrash video playback + CSP media-src

### DIFF
--- a/apps/user-app/js/modules/components/beit-midrash/beit-midrash-viewer.js
+++ b/apps/user-app/js/modules/components/beit-midrash/beit-midrash-viewer.js
@@ -178,9 +178,7 @@ counter.textContent = `${this.totalSlides} / ${index + 1}`;
           </div>
           <div class="gh-bm-viewer-video-container" style="display: none;">
             ${hasVideo ? `
-              <video class="gh-bm-viewer-video" controls>
-                <source src="" type="video/mp4">
-              </video>
+              <video class="gh-bm-viewer-video" controls preload="none"></video>
             ` : ''}
           </div>
           <div class="gh-bm-viewer-infographic-container" style="display: none;">
@@ -254,9 +252,8 @@ infographicContainer.style.display = 'none';
         videoContainer.style.display = 'flex';
         const video = videoContainer.querySelector('video');
         if (video) {
-          const source = video.querySelector('source');
-          if (source && (!source.getAttribute('src') || source.getAttribute('src') === '')) {
-            source.setAttribute('src', this.presentation.videoUrl);
+          if (!video.src || video.src === '' || video.src === window.location.href) {
+            video.src = this.presentation.videoUrl;
             video.load();
           }
           video.play().catch(() => {});

--- a/apps/user-app/js/modules/components/beit-midrash/beit-midrash-viewer.js
+++ b/apps/user-app/js/modules/components/beit-midrash/beit-midrash-viewer.js
@@ -252,11 +252,15 @@ infographicContainer.style.display = 'none';
         videoContainer.style.display = 'flex';
         const video = videoContainer.querySelector('video');
         if (video) {
-          if (!video.src || video.src === '' || video.src === window.location.href) {
+          if (!video.src || video.src === window.location.href) {
             video.src = this.presentation.videoUrl;
+            video.addEventListener('canplay', () => {
+              video.play().catch(() => {});
+            }, { once: true });
             video.load();
+          } else {
+            video.play().catch(() => {});
           }
-          video.play().catch(() => {});
         }
       }
       arrows.forEach(a => a.style.display = 'none');

--- a/netlify.toml
+++ b/netlify.toml
@@ -140,6 +140,7 @@
         https://fonts.gstatic.com
         https://cdnjs.cloudflare.com;
       img-src 'self' data: https: blob:;
+      media-src 'self' https://storage.googleapis.com;
       connect-src 'self'
         https://*.firebaseio.com
         wss://*.firebaseio.com


### PR DESCRIPTION
## Summary
- Fixed video not playing in Beit Midrash viewer — removed empty `<source>` element that caused browser error state
- Added `canplay` event listener before calling `play()` to wait for data readiness
- Added `media-src` to CSP in netlify.toml — browser was blocking video from `storage.googleapis.com`

## Files changed
- `apps/user-app/js/modules/components/beit-midrash/beit-midrash-viewer.js` — video element + canplay fix
- `netlify.toml` — added `media-src 'self' https://storage.googleapis.com`

## Test plan
- [x] Video plays in new presentation (hakira-negdit-vhokhahot)
- [x] Video plays in existing presentations (edim-ubkashot, taanot-mukdamot)
- [x] No CSP errors in console
- [x] Verified in DEV

🤖 Generated with [Claude Code](https://claude.com/claude-code)