### PR TITLE
fix: admin email uri@ → roi@

### DIFF
--- a/apps/admin-panel/js/core/auth.js
+++ b/apps/admin-panel/js/core/auth.js
@@ -134,7 +134,7 @@
             // Admin emails list — sourced from SYSTEM_CONSTANTS
             this.adminEmails = window.SYSTEM_CONSTANTS?.ADMIN_EMAILS || [
                 'haim@ghlawoffice.co.il',
-                'uri@ghlawoffice.co.il',
+                'roi@ghlawoffice.co.il',
                 'guy@ghlawoffice.co.il'
             ];
         }

--- a/apps/admin-panel/js/core/system-constants.js
+++ b/apps/admin-panel/js/core/system-constants.js
@@ -89,7 +89,7 @@
     // Admin Emails (מיילים מורשים)
     ADMIN_EMAILS: [
       'haim@ghlawoffice.co.il',
-      'uri@ghlawoffice.co.il',
+      'roi@ghlawoffice.co.il',
       'guy@ghlawoffice.co.il'
     ],
 

--- a/apps/user-app/js/core/system-constants.js
+++ b/apps/user-app/js/core/system-constants.js
@@ -89,7 +89,7 @@
     // Admin Emails (מיילים מורשים)
     ADMIN_EMAILS: [
       'haim@ghlawoffice.co.il',
-      'uri@ghlawoffice.co.il',
+      'roi@ghlawoffice.co.il',
       'guy@ghlawoffice.co.il'
     ],
 

--- a/functions/shared/constants.js
+++ b/functions/shared/constants.js
@@ -87,7 +87,7 @@ const SYSTEM_CONSTANTS = {
   // Admin Emails (מיילים מורשים)
   ADMIN_EMAILS: [
     'haim@ghlawoffice.co.il',
-    'uri@ghlawoffice.co.il',
+    'roi@ghlawoffice.co.il',
     'guy@ghlawoffice.co.il'
   ],
 

--- a/shared/system-constants.js
+++ b/shared/system-constants.js
@@ -118,7 +118,7 @@ const SYSTEM_CONSTANTS = {
   // ═══════════════════════════════════════════
   ADMIN_EMAILS: [
     'haim@ghlawoffice.co.il',
-    'uri@ghlawoffice.co.il',
+    'roi@ghlawoffice.co.il',
     'guy@ghlawoffice.co.il'
   ],
 


### PR DESCRIPTION
## Summary
- Replace uri@ghlawoffice.co.il with roi@ghlawoffice.co.il in admin emails
- Updated in all 5 code files + Firestore system_config already updated

## Test plan
- [ ] PROD smoke: Settings page shows roi@ instead of uri@

🤖 Generated with [Claude Code](https://claude.com/claude-code)