### PR TITLE
feat: Audit Trail page + Settings UI fixes

### DIFF
--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>לוג פעילות | Admin Panel</title>
+
+    <script>
+        (function() {
+            'use strict';
+            try {
+                var authState = sessionStorage.getItem('authState');
+                if (authState) {
+                    var state = JSON.parse(authState);
+                    var age = Date.now() - (state.timestamp || 0);
+                    window._auditOptimistic = state.isAuthenticated && age < 5 * 60 * 1000;
+                } else {
+                    window._auditOptimistic = false;
+                }
+            } catch (e) {
+                window._auditOptimistic = false;
+            }
+        })();
+    </script>
+
+    <!-- ===== Firebase SDK ===== -->
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <!-- ===== Font Awesome Icons ===== -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    <!-- ===== Design System ===== -->
+    <link rel="stylesheet" href="css/design-system.css">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/components.css">
+    <link rel="stylesheet" href="css/audit-trail.css">
+</head>
+
+<body class="admin-page">
+    <div id="navigationContainer"></div>
+
+    <main class="dashboard-main">
+        <div id="audit-trail-section" class="dashboard-content">
+        </div>
+    </main>
+
+    <div id="loadingOverlay" class="loading-overlay" style="display: none;">
+        <div class="loading-spinner">
+            <div class="spinner-circle"></div>
+            <p class="loading-text">טוען...</p>
+        </div>
+    </div>
+
+    <!-- ===== Core Scripts ===== -->
+    <script src="js/core/firebase.js"></script>
+    <script src="js/core/system-constants.js"></script>
+    <script src="js/core/config-loader.js"></script>
+    <script src="js/core/auth.js"></script>
+    <script src="js/core/constants.js"></script>
+
+    <script src="js/core/auth-guard.js?v=20250103"></script>
+    <script src="js/ui/Navigation.js"></script>
+    <script src="js/ui/AuditTrailPage.js"></script>
+    <script src="js/ui/Notifications.js"></script>
+
+    <script>
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'logoutEvent') {
+                sessionStorage.removeItem('authState');
+                window.location.replace('index.html');
+            }
+        });
+
+        document.addEventListener('DOMContentLoaded', () => {
+            window.initAuthGuard({
+                pageName: 'audit-trail',
+                timeoutMs: 5000,
+
+                onAuthenticated: async (user) => {
+                    if (window.Navigation) {
+                        window.Navigation.init('audit-trail');
+                    }
+                    if (window.AuditTrailPage) {
+                        window.AuditTrailPage.init('audit-trail-section');
+                    }
+                },
+
+                onUnauthenticated: () => {
+                    window.location.replace('index.html');
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -1,0 +1,360 @@
+/* ═══════════════════════════════════════════
+   Audit Trail Page Styles
+   ═══════════════════════════════════════════ */
+
+.audit-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
+}
+
+.audit-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-5);
+}
+
+.audit-header h1 {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin: 0;
+}
+
+.audit-header h1 i {
+  margin-left: var(--space-2);
+  color: var(--gray-400);
+}
+
+.audit-stats {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.audit-stat {
+  padding: 4px 12px;
+  background: var(--gray-100);
+  border-radius: 20px;
+  font-size: 12px;
+  color: var(--gray-600);
+  font-weight: 500;
+}
+
+.audit-stat strong {
+  color: var(--gray-900);
+}
+
+/* ═══════════════════════════════════════════
+   Filters Bar
+   ═══════════════════���═══════════════════════ */
+
+.audit-filters {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-4);
+}
+
+.audit-filter-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.audit-filter-group label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  white-space: nowrap;
+}
+
+.audit-filter-select,
+.audit-filter-input {
+  padding: 6px 10px;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--gray-800);
+  background: white;
+  min-width: 130px;
+}
+
+.audit-filter-input[type="date"] {
+  min-width: 140px;
+}
+
+.audit-filter-select:focus,
+.audit-filter-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgb(59 130 246 / 10%);
+}
+
+.audit-filter-btn {
+  padding: 6px 14px;
+  background: #2563eb;
+  color: white;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.audit-filter-btn:hover {
+  background: #1d4ed8;
+}
+
+.audit-filter-btn.secondary {
+  background: var(--gray-100);
+  color: var(--gray-700);
+  border: 1px solid var(--gray-300);
+}
+
+.audit-filter-btn.secondary:hover {
+  background: var(--gray-200);
+}
+
+/* ═══════════════════════════════════════════
+   Source Tabs
+   ═══════════════════════════════════════════ */
+
+.audit-source-tabs {
+  display: flex;
+  gap: 4px;
+  background: var(--gray-100);
+  padding: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.audit-source-tab {
+  padding: 5px 12px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-600);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.audit-source-tab.active {
+  background: white;
+  color: var(--gray-900);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+}
+
+/* ═══════════════════════════════════════════
+   Log Table
+   ═══════════════════════════════════════════ */
+
+.audit-table-wrapper {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.audit-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.audit-table th {
+  padding: 10px var(--space-3);
+  text-align: right;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  background: var(--gray-50);
+  border-bottom: 1px solid var(--gray-200);
+  white-space: nowrap;
+}
+
+.audit-table td {
+  padding: 10px var(--space-3);
+  font-size: 13px;
+  color: var(--gray-700);
+  border-bottom: 1px solid var(--gray-100);
+  vertical-align: middle;
+}
+
+.audit-table tr:last-child td {
+  border-bottom: none;
+}
+
+.audit-table tr:hover td {
+  background: var(--gray-50);
+}
+
+/* ═══════════════════════════════════════════
+   Action Badges
+   ═══════════════════════════════════════════ */
+
+.audit-action-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.audit-action-badge.create { background: #dcfce7; color: #166534; }
+
+.audit-action-badge.update { background: #dbeafe; color: #1e40af; }
+
+.audit-action-badge.delete { background: #fee2e2; color: #991b1b; }
+
+.audit-action-badge.block { background: #fef3c7; color: #92400e; }
+
+.audit-action-badge.login { background: #f3e8ff; color: #6b21a8; }
+
+.audit-action-badge.config { background: #e0e7ff; color: #3730a3; }
+
+.audit-action-badge.other { background: var(--gray-100); color: var(--gray-600); }
+
+/* Severity indicators */
+.audit-severity {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 6px;
+}
+
+.audit-severity.info { background: #3b82f6; }
+
+.audit-severity.warning { background: #f59e0b; }
+
+.audit-severity.critical { background: #ef4444; }
+
+/* ═══════════════════════════════════════════
+   Details Cell
+   ═══════════════════════════════════════════ */
+
+.audit-details {
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--gray-500);
+}
+
+.audit-details-expand {
+  cursor: pointer;
+  color: #3b82f6;
+  font-size: 11px;
+  margin-right: 4px;
+}
+
+.audit-details-expand:hover {
+  text-decoration: underline;
+}
+
+.audit-user-cell {
+  direction: ltr;
+  text-align: left;
+  font-family: monospace;
+  font-size: 12px;
+}
+
+.audit-time-cell {
+  font-size: 12px;
+  color: var(--gray-500);
+  white-space: nowrap;
+}
+
+/* ═══════════════════════════════════════════
+   Pagination
+   ════════════���══════════════════════════════ */
+
+.audit-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--gray-100);
+}
+
+.audit-pagination-info {
+  font-size: 12px;
+  color: var(--gray-500);
+}
+
+.audit-pagination-btns {
+  display: flex;
+  gap: 4px;
+}
+
+.audit-page-btn {
+  padding: 5px 10px;
+  border: 1px solid var(--gray-300);
+  background: white;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  cursor: pointer;
+  color: var(--gray-700);
+  transition: all 0.15s;
+}
+
+.audit-page-btn:hover {
+  background: var(--gray-50);
+}
+
+.audit-page-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.audit-page-btn.active {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+
+/* ═══════════════════════════════════════════
+   Empty State
+   ═══════════════════════════════════════════ */
+
+.audit-empty {
+  text-align: center;
+  padding: var(--space-10) var(--space-4);
+  color: var(--gray-400);
+}
+
+.audit-empty i {
+  font-size: 48px;
+  margin-bottom: var(--space-3);
+  display: block;
+}
+
+.audit-empty p {
+  font-size: 14px;
+  margin: 0;
+}
+
+/* ═══════════════════════════════════════════
+   Loading
+   ═══════════════════���═══════════════════════ */
+
+.audit-loading {
+  text-align: center;
+  padding: var(--space-8);
+  color: var(--gray-400);
+  font-size: 14px;
+}

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -168,7 +168,6 @@
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
-  min-width: 700px;
 }
 
 .audit-table th {

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -161,17 +161,18 @@
   background: white;
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-lg);
-  overflow: hidden;
+  overflow-x: auto;
 }
 
 .audit-table {
   width: 100%;
   border-collapse: collapse;
   table-layout: fixed;
+  min-width: 700px;
 }
 
 .audit-table th {
-  padding: 10px var(--space-3);
+  padding: 8px var(--space-3);
   text-align: right;
   font-size: 11px;
   font-weight: 600;
@@ -181,14 +182,17 @@
   background: var(--gray-50);
   border-bottom: 1px solid var(--gray-200);
   white-space: nowrap;
+  overflow: hidden;
 }
 
 .audit-table td {
-  padding: 10px var(--space-3);
+  padding: 8px var(--space-3);
   font-size: 13px;
   color: var(--gray-700);
   border-bottom: 1px solid var(--gray-100);
-  vertical-align: middle;
+  vertical-align: top;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .audit-table tr:last-child td {
@@ -248,33 +252,24 @@
    ═══════════════════════════════════════════ */
 
 .audit-details {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   font-size: 12px;
   color: var(--gray-500);
-  direction: rtl;
-  text-align: right;
-}
-
-.audit-details-expand {
-  cursor: pointer;
-  color: #3b82f6;
-  font-size: 11px;
-  margin-right: 4px;
-}
-
-.audit-details-expand:hover {
-  text-decoration: underline;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .audit-user-cell {
+  font-size: 13px;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+}
+
+/* Email addresses need LTR inside RTL context */
+.audit-user-cell.email-cell {
   direction: ltr;
   text-align: left;
-  font-family: monospace;
   font-size: 12px;
 }
 

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -53,12 +53,13 @@
   display: flex;
   gap: var(--space-3);
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   padding: var(--space-3) var(--space-4);
   background: white;
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-lg);
   margin-bottom: var(--space-4);
+  overflow-x: auto;
 }
 
 .audit-filter-group {
@@ -148,9 +149,9 @@
 }
 
 .audit-source-tab.active {
-  background: white;
-  color: var(--gray-900);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  background: #2563eb;
+  color: white;
+  box-shadow: 0 1px 3px rgb(37 99 235 / 30%);
 }
 
 /* ═══════════════════════════════════════════

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -167,6 +167,7 @@
 .audit-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .audit-table th {
@@ -247,12 +248,13 @@
    ═══════════════════════════════════════════ */
 
 .audit-details {
-  max-width: 300px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12px;
   color: var(--gray-500);
+  direction: rtl;
+  text-align: right;
 }
 
 .audit-details-expand {
@@ -267,6 +269,9 @@
 }
 
 .audit-user-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   direction: ltr;
   text-align: left;
   font-family: monospace;

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -473,13 +473,16 @@
           ? '<i class="fas fa-shield-alt" style="color:#9333ea;font-size:11px" title="פעולת מנהל"></i>'
           : '<i class="fas fa-user" style="color:#6b7280;font-size:11px" title="פעילות משתמש"></i>';
 
+        const userCls = entry.user && entry.user.includes('@') ? 'audit-user-cell email-cell' : 'audit-user-cell';
+        const targetCls = entry.target && entry.target.includes('@') ? 'audit-user-cell email-cell' : 'audit-user-cell';
+
         rows += '<tr>' +
-          '<td>' + sourceIcon + '</td>' +
+          '<td style="text-align:center">' + sourceIcon + '</td>' +
           '<td class="audit-time-cell">' + timeStr + '</td>' +
           '<td><span class="audit-action-badge ' + cat + '">' + _escapeHtml(actionLabel) + '</span></td>' +
-          '<td class="audit-user-cell">' + _escapeHtml(entry.user) + '</td>' +
-          '<td class="audit-user-cell">' + _escapeHtml(entry.target || '') + '</td>' +
-          '<td class="audit-details">' + detailsStr + '</td>' +
+          '<td class="' + userCls + '" title="' + _escapeHtml(entry.user) + '">' + _escapeHtml(entry.user) + '</td>' +
+          '<td class="' + targetCls + '" title="' + _escapeHtml(entry.target || '') + '">' + _escapeHtml(entry.target || '') + '</td>' +
+          '<td class="audit-details" title="' + _escapeHtml(detailsStr) + '">' + detailsStr + '</td>' +
           '</tr>';
       });
 
@@ -487,11 +490,11 @@
         <table class="audit-table">
           <thead>
             <tr>
-              <th style="width:30px"></th>
-              <th style="width:80px">זמן</th>
-              <th style="width:130px">פעולה</th>
-              <th style="width:80px">בוצע ע"י</th>
-              <th style="width:140px">נוגע ל</th>
+              <th style="width:28px">סוג</th>
+              <th style="width:75px">זמן</th>
+              <th style="width:120px">פעולה</th>
+              <th style="width:70px">בוצע ע"י</th>
+              <th style="width:130px">נוגע ל</th>
               <th>פרטים</th>
             </tr>
           </thead>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -492,9 +492,9 @@
             <tr>
               <th style="width:28px">סוג</th>
               <th style="width:75px">זמן</th>
-              <th style="width:120px">פעולה</th>
-              <th style="width:70px">בוצע ע"י</th>
-              <th style="width:130px">נוגע ל</th>
+              <th style="width:115px">פעולה</th>
+              <th style="width:85px">בוצע ע"י</th>
+              <th style="width:120px">נוגע ל</th>
               <th>פרטים</th>
             </tr>
           </thead>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -72,6 +72,10 @@
     'ADD_SERVICE': 'הוספת שירות',
     'ADD_PACKAGE': 'הוספת חבילה',
     'delete_user_data_selective': 'מחיקת נתוני משתמש',
+    'UPLOAD_FEE_AGREEMENT': 'העלאת הסכם שכ"ט',
+    'DELETE_FEE_AGREEMENT': 'מחיקת הסכם שכ"ט',
+    'ADD_TIME_TO_TASK': 'הוספת שעות למשימה',
+    'CANCEL_TASK': 'ביטול משימה',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
   };
@@ -79,12 +83,13 @@
   // Hebrew labels for detail keys
   const DETAIL_KEY_LABELS = {
     'targetEmail': 'משתמש יעד',
-    'taskId': 'מזהה משימה',
-    'clientId': 'מזהה לקוח',
-    'caseNumber': 'מספר תיק',
+    'taskId': 'משימה',
+    'clientId': 'לקוח',
+    'clientName': 'לקוח',
+    'caseNumber': 'תיק',
     'estimatedHours': 'שעות מוערכות',
     'actualMinutes': 'דקות בפועל',
-    'gapPercent': 'אחוז חריגה',
+    'gapPercent': 'חריגה %',
     'oldEstimate': 'הערכה קודמת',
     'newEstimate': 'הערכה חדשה',
     'addedMinutes': 'דקות שנוספו',
@@ -92,10 +97,19 @@
     'role': 'תפקיד',
     'status': 'סטטוס',
     'message': 'הודעה',
-    'username': 'שם משתמש',
+    'username': 'שם',
     'changes': 'שינויים',
-    'isCritical': 'קריטי'
+    'fileName': 'קובץ',
+    'fileSize': 'גודל',
+    'fileType': 'סוג קובץ'
   };
+
+  // Keys to skip in details (shown elsewhere or internal)
+  const DETAIL_SKIP_KEYS = [
+    'entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds',
+    'targetEmail', 'targetUser', 'clientName', 'agreementId',
+    'fileType', 'userAgent', 'ipAddress'
+  ];
 
   const AuditTrailPage = {
     container: null,
@@ -301,13 +315,13 @@
           const auditDocs = await this._queryCollection('audit_log');
           auditDocs.forEach(function(doc) {
             const data = doc.data();
-            // Prefer name over email over UID
-            const displayUser = data.performedByName || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
+            // Prefer name (Hebrew) over email, never show raw UID
+            const displayUser = data.performedByName || data.username || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
             // Extract target from details if not in top-level field
+            const det = _parseDetails(data.details);
             let target = data.targetUser || data.targetUserEmail || '';
-            if (!target && data.details) {
-              const det = _parseDetails(data.details);
-              target = det.targetEmail || det.targetUser || '';
+            if (!target) {
+              target = det.targetEmail || det.targetUser || det.clientName || '';
             }
             results.push({
               id: doc.id,
@@ -610,19 +624,21 @@
  return '';
 }
     const parts = [];
-    // Skip internal/non-useful keys
-    const skipKeys = ['entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds'];
     keys.forEach(function(key) {
-      if (skipKeys.includes(key)) {
- return;
-}
-      const val = obj[key];
-      if (val === null || val === undefined || typeof val === 'object') {
+      if (DETAIL_SKIP_KEYS.includes(key)) {
  return;
 }
       if (parts.length >= 3) {
  return;
 }
+      let val = obj[key];
+      if (val === null || val === undefined || typeof val === 'object') {
+ return;
+}
+      // Format file size
+      if (key === 'fileSize' && typeof val === 'number') {
+        val = val > 1048576 ? (val / 1048576).toFixed(1) + ' MB' : Math.round(val / 1024) + ' KB';
+      }
       const label = DETAIL_KEY_LABELS[key] || key;
       parts.push(label + ': ' + val);
     });

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -31,6 +31,7 @@
 
   // Hebrew action labels
   const ACTION_LABELS = {
+    // User activity (lowercase)
     'login': 'כניסה',
     'logout': 'יציאה',
     'create_task': 'יצירת משימה',
@@ -40,15 +41,16 @@
     'extend_deadline': 'הארכת דדליין',
     'update_progress': 'עדכון התקדמות',
     'create_timesheet': 'רישום שעות',
-    'edit_timesheet': 'עריכת ש��ות',
+    'edit_timesheet': 'עריכת שעות',
     'delete_timesheet': 'מחיקת שעות',
-    'create_client': '��צירת לקוח',
+    'create_client': 'יצירת לקוח',
     'edit_client': 'עריכת לקוח',
     'delete_client': 'מחיקת לקוח',
     'block_client': 'חסימת לקוח',
     'unblock_client': 'ביטול חסימת לקוח',
     'generate_report': 'הפקת דוח',
     'export_data': 'ייצוא נתונים',
+    // Admin actions (UPPERCASE — from audit_log)
     'USER_CREATED': 'יצירת משתמש',
     'USER_UPDATED': 'עדכון משתמש',
     'USER_DELETED': 'מחיקת משתמש',
@@ -57,9 +59,42 @@
     'CREATE_USER': 'יצירת משתמש',
     'UPDATE_USER': 'עדכון משתמש',
     'DELETE_USER': 'מחיקת משתמש',
+    'VIEW_USER_DETAILS': 'צפייה בפרטי משתמש',
+    'CREATE_TASK': 'יצירת משימה',
+    'COMPLETE_TASK': 'השלמת משימה',
+    'ADJUST_BUDGET': 'התאמת תקציב',
+    'EXTEND_TASK_DEADLINE': 'הארכת דדליין',
+    'CREATE_CLIENT': 'יצירת לקוח',
+    'UPDATE_CLIENT': 'עדכון לקוח',
+    'DELETE_CLIENT': 'מחיקת לקוח',
+    'CHANGE_CLIENT_STATUS': 'שינוי סטטוס לקוח',
+    'CLOSE_CASE': 'סגירת תיק',
+    'ADD_SERVICE': 'הוספת שירות',
+    'ADD_PACKAGE': 'הוספת חבילה',
     'delete_user_data_selective': 'מחיקת נתוני משתמש',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
+  };
+
+  // Hebrew labels for detail keys
+  const DETAIL_KEY_LABELS = {
+    'targetEmail': 'משתמש יעד',
+    'taskId': 'מזהה משימה',
+    'clientId': 'מזהה לקוח',
+    'caseNumber': 'מספר תיק',
+    'estimatedHours': 'שעות מוערכות',
+    'actualMinutes': 'דקות בפועל',
+    'gapPercent': 'אחוז חריגה',
+    'oldEstimate': 'הערכה קודמת',
+    'newEstimate': 'הערכה חדשה',
+    'addedMinutes': 'דקות שנוספו',
+    'reason': 'סיבה',
+    'role': 'תפקיד',
+    'status': 'סטטוס',
+    'message': 'הודעה',
+    'username': 'שם משתמש',
+    'changes': 'שינויים',
+    'isCritical': 'קריטי'
   };
 
   const AuditTrailPage = {
@@ -244,11 +279,13 @@
           const activityDocs = await this._queryCollection('activity_log');
           activityDocs.forEach(function(doc) {
             const data = doc.data();
+            // Prefer username (Hebrew) over email, never show raw UID
+            const displayUser = data.username || data.userEmail || _emailFromUid(data.userId) || '';
             results.push({
               id: doc.id,
               source: 'activity',
               action: data.action || data.type || '',
-              user: data.userEmail || data.userId || '',
+              user: displayUser,
               username: data.username || '',
               target: data.targetUser || '',
               details: data.details || '',
@@ -264,13 +301,21 @@
           const auditDocs = await this._queryCollection('audit_log');
           auditDocs.forEach(function(doc) {
             const data = doc.data();
+            // Prefer name over email over UID
+            const displayUser = data.performedByName || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
+            // Extract target from details if not in top-level field
+            let target = data.targetUser || data.targetUserEmail || '';
+            if (!target && data.details) {
+              const det = _parseDetails(data.details);
+              target = det.targetEmail || det.targetUser || '';
+            }
             results.push({
               id: doc.id,
               source: 'audit',
               action: data.action || '',
-              user: data.performedBy || data.adminEmail || data.userId || '',
+              user: displayUser,
               username: data.performedByName || data.username || '',
-              target: data.targetUser || data.targetUserEmail || '',
+              target: target,
               details: data.details || '',
               severity: data.severity || 'info',
               timestamp: data.timestamp,
@@ -486,6 +531,42 @@
   // Utility Functions
   // ═══════════════════════════════════════════
 
+  /**
+   * If a field contains a raw Firebase UID (no @ sign, long alphanumeric),
+   * return empty string so we don't show it to the user.
+   */
+  function _emailFromUid(val) {
+    if (!val) {
+ return '';
+}
+    // If it looks like an email, return it
+    if (val.includes('@')) {
+ return val;
+}
+    // Raw UID — don't display it
+    return '';
+  }
+
+  /**
+   * Parse details field — can be string (JSON) or object
+   */
+  function _parseDetails(details) {
+    if (!details) {
+ return {};
+}
+    if (typeof details === 'object') {
+ return details;
+}
+    if (typeof details === 'string') {
+      try {
+ return JSON.parse(details);
+} catch (e) {
+ return {};
+}
+    }
+    return {};
+  }
+
   function _formatTimestamp(ts, localStr) {
     if (!ts && !localStr) {
  return '-';
@@ -507,16 +588,12 @@
     if (!details) {
  return '';
 }
-    if (typeof details === 'string') {
-      try {
-        const parsed = JSON.parse(details);
-        return _escapeHtml(_summarizeObject(parsed));
-      } catch (e) {
-        return _escapeHtml(details.substring(0, 80));
-      }
+    const obj = _parseDetails(details);
+    if (typeof obj === 'object' && Object.keys(obj).length > 0) {
+      return _escapeHtml(_summarizeObject(obj));
     }
-    if (typeof details === 'object') {
-      return _escapeHtml(_summarizeObject(details));
+    if (typeof details === 'string') {
+      return _escapeHtml(details.substring(0, 80));
     }
     return '';
   }
@@ -533,13 +610,23 @@
  return '';
 }
     const parts = [];
-    keys.slice(0, 3).forEach(function(key) {
+    // Skip internal/non-useful keys
+    const skipKeys = ['entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds'];
+    keys.forEach(function(key) {
+      if (skipKeys.includes(key)) {
+ return;
+}
       const val = obj[key];
-      if (val !== null && val !== undefined && typeof val !== 'object') {
-        parts.push(key + ': ' + val);
-      }
+      if (val === null || val === undefined || typeof val === 'object') {
+ return;
+}
+      if (parts.length >= 3) {
+ return;
+}
+      const label = DETAIL_KEY_LABELS[key] || key;
+      parts.push(label + ': ' + val);
     });
-    return parts.join(', ');
+    return parts.join(' | ');
   }
 
   function _escapeHtml(str) {

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -488,10 +488,10 @@
           <thead>
             <tr>
               <th style="width:30px"></th>
-              <th>זמן</th>
-              <th>פעולה</th>
-              <th>בוצע ע"י</th>
-              <th>יעד</th>
+              <th style="width:80px">זמן</th>
+              <th style="width:130px">פעולה</th>
+              <th style="width:80px">בוצע ע"י</th>
+              <th style="width:140px">נוגע ל</th>
               <th>פרטים</th>
             </tr>
           </thead>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -13,7 +13,7 @@
   // Action categories for badge colors
   const ACTION_CATEGORIES = {
     create: ['USER_CREATED', 'create_task', 'create_timesheet', 'create_client', 'CREATE_USER'],
-    update: ['USER_UPDATED', 'edit_task', 'edit_timesheet', 'edit_client', 'UPDATE_USER', 'extend_deadline', 'update_progress', 'system_config_updated'],
+    update: ['USER_UPDATED', 'edit_task', 'edit_timesheet', 'edit_client', 'UPDATE_USER', 'extend_deadline', 'update_progress'],
     delete: ['USER_DELETED', 'delete_task', 'delete_timesheet', 'delete_client', 'DELETE_USER', 'delete_user_data_selective'],
     block: ['USER_BLOCKED', 'USER_UNBLOCKED', 'block_client', 'unblock_client'],
     login: ['login', 'logout'],

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -84,6 +84,11 @@
     'COMPLETE_SERVICE': 'השלמת שירות',
     'DELETE_SERVICE': 'מחיקת שירות',
     'SET_SERVICE_OVERRIDE': 'ביטול חסימת שירות',
+    'REMOVE_SERVICE_OVERRIDE': 'הסרת ביטול חסימה',
+    'RESOLVE_SERVICE_OVERDRAFT': 'פתרון חריגת שירות',
+    'UNRESOLVE_SERVICE_OVERDRAFT': 'ביטול פתרון חריגה',
+    'CREATE_TIMESHEET_ENTRY_V2': 'רישום שעות',
+    'CREATE_USER': 'יצירת משתמש',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
   };
@@ -91,6 +96,8 @@
   // Hebrew labels for detail keys
   const DETAIL_KEY_LABELS = {
     'targetEmail': 'משתמש',
+    'targetName': 'שם',
+    'targetRole': 'תפקיד',
     'clientId': 'לקוח',
     'clientName': 'לקוח',
     'caseNumber': 'תיק',
@@ -102,6 +109,7 @@
     'newEstimate': 'הערכה חדשה',
     'addedMinutes': 'דקות שנוספו',
     'reason': 'סיבה',
+    'note': 'הערה',
     'role': 'תפקיד',
     'status': 'סטטוס',
     'message': 'הודעה',
@@ -111,9 +119,15 @@
     'fileSize': 'גודל',
     'serviceName': 'שירות',
     'serviceType': 'סוג שירות',
+    'procedureType': 'סוג הליך',
     'newDeadline': 'דדליין חדש',
     'oldDeadline': 'דדליין קודם',
-    'date': 'תאריך'
+    'date': 'תאריך',
+    'isInternal': 'פנימי',
+    'fromStageName': 'משלב',
+    'toStageName': 'לשלב',
+    'overrideActive': 'חסימה מבוטלת',
+    'resolved': 'נפתר'
   };
 
   // Keys to skip in details (shown elsewhere or internal/technical)
@@ -121,7 +135,9 @@
     'entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds',
     'targetEmail', 'targetUser', 'clientName', 'agreementId',
     'fileType', 'userAgent', 'ipAddress',
-    'taskId', 'entryId', 'autoTimesheetCreated', 'clientUpdated'
+    'taskId', 'entryId', 'autoTimesheetCreated', 'clientUpdated',
+    'idempotencyKey', 'reservationId', 'version',
+    'serviceId', 'fromStageId', 'toStageId'
   ];
 
   const AuditTrailPage = {
@@ -214,11 +230,11 @@
 
             <div class="audit-filter-group">
               <label>מ:</label>
-              <input type="date" class="audit-filter-input" id="filter-date-from">
+              <input type="date" class="audit-filter-input" id="filter-date-from" lang="en">
             </div>
             <div class="audit-filter-group">
               <label>עד:</label>
-              <input type="date" class="audit-filter-input" id="filter-date-to">
+              <input type="date" class="audit-filter-input" id="filter-date-to" lang="en">
             </div>
 
             <button class="audit-filter-btn" id="btn-apply-filters"><i class="fas fa-search"></i> סנן</button>
@@ -687,11 +703,16 @@
         }
       } catch (e) { /* fall through */ }
     }
-    if (key === 'serviceType' && window.SystemConstantsHelpers) {
-      const label = window.SystemConstantsHelpers.getServiceTypeLabel(val);
-      if (label !== val) {
+    if (key === 'serviceType' || key === 'procedureType') {
+      if (window.SystemConstantsHelpers) {
+        const label = window.SystemConstantsHelpers.getServiceTypeLabel(val);
+        if (label !== val) {
  return label;
 }
+      }
+    }
+    if (typeof val === 'boolean') {
+      return val ? 'כן' : 'לא';
     }
     return val;
   }

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -75,21 +75,29 @@
     'UPLOAD_FEE_AGREEMENT': 'העלאת הסכם שכ"ט',
     'DELETE_FEE_AGREEMENT': 'מחיקת הסכם שכ"ט',
     'ADD_TIME_TO_TASK': 'הוספת שעות למשימה',
+    'ADD_SERVICE_TO_CLIENT': 'הוספת שירות ללקוח',
+    'CREATE_QUICK_LOG_ENTRY': 'רישום שעות מהיר',
     'CANCEL_TASK': 'ביטול משימה',
+    'MOVE_TO_NEXT_STAGE': 'מעבר לשלב הבא',
+    'ADD_PACKAGE_TO_SERVICE': 'הוספת חבילה לשירות',
+    'CHANGE_SERVICE_STATUS': 'שינוי סטטוס שירות',
+    'COMPLETE_SERVICE': 'השלמת שירות',
+    'DELETE_SERVICE': 'מחיקת שירות',
+    'SET_SERVICE_OVERRIDE': 'ביטול חסימת שירות',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
   };
 
   // Hebrew labels for detail keys
   const DETAIL_KEY_LABELS = {
-    'targetEmail': 'משתמש יעד',
-    'taskId': 'משימה',
+    'targetEmail': 'משתמש',
     'clientId': 'לקוח',
     'clientName': 'לקוח',
     'caseNumber': 'תיק',
     'estimatedHours': 'שעות מוערכות',
     'actualMinutes': 'דקות בפועל',
-    'gapPercent': 'חריגה %',
+    'minutes': 'זמן',
+    'gapPercent': 'חריגה',
     'oldEstimate': 'הערכה קודמת',
     'newEstimate': 'הערכה חדשה',
     'addedMinutes': 'דקות שנוספו',
@@ -101,14 +109,19 @@
     'changes': 'שינויים',
     'fileName': 'קובץ',
     'fileSize': 'גודל',
-    'fileType': 'סוג קובץ'
+    'serviceName': 'שירות',
+    'serviceType': 'סוג שירות',
+    'newDeadline': 'דדליין חדש',
+    'oldDeadline': 'דדליין קודם',
+    'date': 'תאריך'
   };
 
-  // Keys to skip in details (shown elsewhere or internal)
+  // Keys to skip in details (shown elsewhere or internal/technical)
   const DETAIL_SKIP_KEYS = [
     'entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds',
     'targetEmail', 'targetUser', 'clientName', 'agreementId',
-    'fileType', 'userAgent', 'ipAddress'
+    'fileType', 'userAgent', 'ipAddress',
+    'taskId', 'entryId', 'autoTimesheetCreated', 'clientUpdated'
   ];
 
   const AuditTrailPage = {
@@ -632,17 +645,52 @@
  return;
 }
       let val = obj[key];
-      if (val === null || val === undefined || typeof val === 'object') {
+      if (val === null || val === undefined) {
  return;
 }
-      // Format file size
-      if (key === 'fileSize' && typeof val === 'number') {
-        val = val > 1048576 ? (val / 1048576).toFixed(1) + ' MB' : Math.round(val / 1024) + ' KB';
-      }
+      if (typeof val === 'object') {
+ return;
+}
+      val = _formatValue(key, val);
       const label = DETAIL_KEY_LABELS[key] || key;
       parts.push(label + ': ' + val);
     });
     return parts.join(' | ');
+  }
+
+  function _formatValue(key, val) {
+    if (key === 'fileSize' && typeof val === 'number') {
+      return val > 1048576 ? (val / 1048576).toFixed(1) + ' MB' : Math.round(val / 1024) + ' KB';
+    }
+    if ((key === 'minutes' || key === 'actualMinutes' || key === 'addedMinutes' || key === 'oldEstimate' || key === 'newEstimate') && typeof val === 'number') {
+      if (val >= 60) {
+        const h = Math.floor(val / 60);
+        const m = val % 60;
+        return m > 0 ? h + ' שעות ' + m + ' דקות' : h + ' שעות';
+      }
+      return val + ' דקות';
+    }
+    if (key === 'estimatedHours' && typeof val === 'number') {
+      return Math.round(val * 10) / 10 + ' שעות';
+    }
+    if (key === 'gapPercent' && typeof val === 'number') {
+      return val + '%';
+    }
+    if ((key === 'date' || key === 'newDeadline' || key === 'oldDeadline') && typeof val === 'string') {
+      try {
+        const d = new Date(val);
+        if (!isNaN(d.getTime())) {
+          return String(d.getDate()).padStart(2, '0') + '/' + String(d.getMonth() + 1).padStart(2, '0') + '/' + d.getFullYear();
+        }
+      } catch (e) { /* fall through */ }
+    }
+    if (key === 'serviceType' && window.SystemConstantsHelpers) {
+      const label = window.SystemConstantsHelpers.getServiceTypeLabel(val);
+      if (label !== val) {
+ return label;
+}
+    }
+    return val;
   }
 
   function _escapeHtml(str) {

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -225,7 +225,7 @@
 
             <div class="audit-filter-group">
               <label>משתמש:</label>
-              <input type="text" class="audit-filter-input" id="filter-user" placeholder="מייל או שם..." dir="ltr">
+              <input type="text" class="audit-filter-input" id="filter-user" placeholder="מייל או שם..." dir="rtl">
             </div>
 
             <div class="audit-filter-group">

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -490,12 +490,12 @@
         <table class="audit-table">
           <thead>
             <tr>
-              <th style="width:28px">סוג</th>
-              <th style="width:75px">זמן</th>
-              <th style="width:115px">פעולה</th>
-              <th style="width:85px">בוצע ע"י</th>
-              <th style="width:120px">נוגע ל</th>
-              <th>פרטים</th>
+              <th style="width:3%">סוג</th>
+              <th style="width:8%">זמן</th>
+              <th style="width:14%">פעולה</th>
+              <th style="width:10%">בוצע ע"י</th>
+              <th style="width:15%">נוגע ל</th>
+              <th style="width:50%">פרטים</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -1,0 +1,555 @@
+/**
+ * Audit Trail Page
+ * =================
+ * Displays activity_log and audit_log entries in a filterable table.
+ * Reads directly from Firestore collections.
+ */
+
+(function() {
+  'use strict';
+
+  const PAGE_SIZE = 50;
+
+  // Action categories for badge colors
+  const ACTION_CATEGORIES = {
+    create: ['USER_CREATED', 'create_task', 'create_timesheet', 'create_client', 'CREATE_USER'],
+    update: ['USER_UPDATED', 'edit_task', 'edit_timesheet', 'edit_client', 'UPDATE_USER', 'extend_deadline', 'update_progress', 'system_config_updated'],
+    delete: ['USER_DELETED', 'delete_task', 'delete_timesheet', 'delete_client', 'DELETE_USER', 'delete_user_data_selective'],
+    block: ['USER_BLOCKED', 'USER_UNBLOCKED', 'block_client', 'unblock_client'],
+    login: ['login', 'logout'],
+    config: ['system_config_updated', 'system_config_rollback']
+  };
+
+  function getActionCategory(action) {
+    for (const [cat, actions] of Object.entries(ACTION_CATEGORIES)) {
+      if (actions.includes(action)) {
+ return cat;
+}
+    }
+    return 'other';
+  }
+
+  // Hebrew action labels
+  const ACTION_LABELS = {
+    'login': 'כניסה',
+    'logout': 'יציאה',
+    'create_task': 'יצירת משימה',
+    'edit_task': 'עריכת משימה',
+    'delete_task': 'מחיקת משימה',
+    'complete_task': 'השלמת משימה',
+    'extend_deadline': 'הארכת דדליין',
+    'update_progress': 'עדכון התקדמות',
+    'create_timesheet': 'רישום שעות',
+    'edit_timesheet': 'עריכת ש��ות',
+    'delete_timesheet': 'מחיקת שעות',
+    'create_client': '��צירת לקוח',
+    'edit_client': 'עריכת לקוח',
+    'delete_client': 'מחיקת לקוח',
+    'block_client': 'חסימת לקוח',
+    'unblock_client': 'ביטול חסימת לקוח',
+    'generate_report': 'הפקת דוח',
+    'export_data': 'ייצוא נתונים',
+    'USER_CREATED': 'יצירת משתמש',
+    'USER_UPDATED': 'עדכון משתמש',
+    'USER_DELETED': 'מחיקת משתמש',
+    'USER_BLOCKED': 'חסימת משתמש',
+    'USER_UNBLOCKED': 'ביטול חסימה',
+    'CREATE_USER': 'יצירת משתמש',
+    'UPDATE_USER': 'עדכון משתמש',
+    'DELETE_USER': 'מחיקת משתמש',
+    'delete_user_data_selective': 'מחיקת נתוני משתמש',
+    'system_config_updated': 'עדכון הגדרות',
+    'system_config_rollback': 'שחזור הגדרות'
+  };
+
+  const AuditTrailPage = {
+    container: null,
+    db: null,
+    entries: [],
+    filteredEntries: [],
+    currentPage: 1,
+    totalLoaded: 0,
+    loading: false,
+    source: 'all', // 'all', 'activity', 'audit'
+    filters: {
+      action: '',
+      user: '',
+      dateFrom: '',
+      dateTo: ''
+    },
+
+    init: function(containerId) {
+      this.container = document.getElementById(containerId);
+      if (!this.container) {
+ return;
+}
+
+      this.db = window.firebaseDB;
+      if (!this.db) {
+        this.container.innerHTML = '<p>שגיאה: Firestore לא מאותחל</p>';
+        return;
+      }
+
+      this.render();
+      this.loadData();
+    },
+
+    render: function() {
+      this.container.innerHTML = `
+        <div class="audit-page">
+          <div class="audit-header">
+            <h1><i class="fas fa-history"></i> לוג פעילות</h1>
+            <div class="audit-stats" id="audit-stats"></div>
+          </div>
+
+          <div class="audit-filters">
+            <div class="audit-source-tabs" id="source-tabs">
+              <button class="audit-source-tab active" data-source="all">הכל</button>
+              <button class="audit-source-tab" data-source="activity">פעילות משתמשים</button>
+              <button class="audit-source-tab" data-source="audit">פעולות מנהל</button>
+            </div>
+
+            <div class="audit-filter-group">
+              <label>פעולה:</label>
+              <select class="audit-filter-select" id="filter-action">
+                <option value="">הכל</option>
+                <optgroup label="כניסה/יציאה">
+                  <option value="login">כניסה</option>
+                  <option value="logout">יציאה</option>
+                </optgroup>
+                <optgroup label="משימות">
+                  <option value="create_task">יצירת משימה</option>
+                  <option value="edit_task">עריכת משימה</option>
+                  <option value="delete_task">מחיקת משימה</option>
+                  <option value="complete_task">השלמת משימה</option>
+                </optgroup>
+                <optgroup label="שעתון">
+                  <option value="create_timesheet">רישום שעות</option>
+                  <option value="edit_timesheet">עריכת שעות</option>
+                  <option value="delete_timesheet">מחיקת שעות</option>
+                </optgroup>
+                <optgroup label="לקוחות">
+                  <option value="create_client">יצירת לקוח</option>
+                  <option value="edit_client">עריכת לקוח</option>
+                  <option value="delete_client">מחיקת לקוח</option>
+                </optgroup>
+                <optgroup label="ניהול משתמשים">
+                  <option value="USER_CREATED">יצירת משתמש</option>
+                  <option value="USER_UPDATED">עדכון משתמש</option>
+                  <option value="USER_DELETED">מחיקת משתמש</option>
+                  <option value="USER_BLOCKED">חסימת משתמש</option>
+                </optgroup>
+                <optgroup label="מערכת">
+                  <option value="system_config_updated">עדכון הגדרות</option>
+                </optgroup>
+              </select>
+            </div>
+
+            <div class="audit-filter-group">
+              <label>משתמש:</label>
+              <input type="text" class="audit-filter-input" id="filter-user" placeholder="מייל או שם..." dir="ltr">
+            </div>
+
+            <div class="audit-filter-group">
+              <label>מ:</label>
+              <input type="date" class="audit-filter-input" id="filter-date-from">
+            </div>
+            <div class="audit-filter-group">
+              <label>עד:</label>
+              <input type="date" class="audit-filter-input" id="filter-date-to">
+            </div>
+
+            <button class="audit-filter-btn" id="btn-apply-filters"><i class="fas fa-search"></i> סנן</button>
+            <button class="audit-filter-btn secondary" id="btn-reset-filters"><i class="fas fa-undo"></i> נקה</button>
+          </div>
+
+          <div class="audit-table-wrapper">
+            <div id="audit-table-content">
+              <div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> טוען נתונים...</div>
+            </div>
+          </div>
+        </div>
+      `;
+
+      this._bindEvents();
+    },
+
+    _bindEvents: function() {
+      const self = this;
+
+      // Source tabs
+      document.querySelectorAll('.audit-source-tab').forEach(function(tab) {
+        tab.addEventListener('click', function() {
+          document.querySelectorAll('.audit-source-tab').forEach(function(t) {
+ t.classList.remove('active');
+});
+          tab.classList.add('active');
+          self.source = tab.dataset.source;
+          self.currentPage = 1;
+          self.loadData();
+        });
+      });
+
+      // Apply filters
+      document.getElementById('btn-apply-filters').addEventListener('click', function() {
+        self._applyFilters();
+      });
+
+      // Reset filters
+      document.getElementById('btn-reset-filters').addEventListener('click', function() {
+        document.getElementById('filter-action').value = '';
+        document.getElementById('filter-user').value = '';
+        document.getElementById('filter-date-from').value = '';
+        document.getElementById('filter-date-to').value = '';
+        self.filters = { action: '', user: '', dateFrom: '', dateTo: '' };
+        self.currentPage = 1;
+        self.loadData();
+      });
+
+      // Enter key on user filter
+      document.getElementById('filter-user').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+ self._applyFilters();
+}
+      });
+    },
+
+    _applyFilters: function() {
+      this.filters.action = document.getElementById('filter-action').value;
+      this.filters.user = document.getElementById('filter-user').value.trim().toLowerCase();
+      this.filters.dateFrom = document.getElementById('filter-date-from').value;
+      this.filters.dateTo = document.getElementById('filter-date-to').value;
+      this.currentPage = 1;
+      this.loadData();
+    },
+
+    // ═══════════════════════════════════════════
+    // Data Loading
+    // ═══════════��═══════════════════════════════
+
+    loadData: async function() {
+      if (this.loading) {
+ return;
+}
+      this.loading = true;
+
+      const content = document.getElementById('audit-table-content');
+      content.innerHTML = '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> טוען נתונים...</div>';
+
+      try {
+        const results = [];
+
+        // Load from activity_log
+        if (this.source === 'all' || this.source === 'activity') {
+          const activityDocs = await this._queryCollection('activity_log');
+          activityDocs.forEach(function(doc) {
+            const data = doc.data();
+            results.push({
+              id: doc.id,
+              source: 'activity',
+              action: data.action || data.type || '',
+              user: data.userEmail || data.userId || '',
+              username: data.username || '',
+              target: data.targetUser || '',
+              details: data.details || '',
+              severity: data.severity || 'info',
+              timestamp: data.timestamp,
+              timestampLocal: data.timestampLocal || null
+            });
+          });
+        }
+
+        // Load from audit_log
+        if (this.source === 'all' || this.source === 'audit') {
+          const auditDocs = await this._queryCollection('audit_log');
+          auditDocs.forEach(function(doc) {
+            const data = doc.data();
+            results.push({
+              id: doc.id,
+              source: 'audit',
+              action: data.action || '',
+              user: data.performedBy || data.adminEmail || data.userId || '',
+              username: data.performedByName || data.username || '',
+              target: data.targetUser || data.targetUserEmail || '',
+              details: data.details || '',
+              severity: data.severity || 'info',
+              timestamp: data.timestamp,
+              timestampLocal: data.timestampLocal || null
+            });
+          });
+        }
+
+        // Sort by timestamp desc
+        results.sort(function(a, b) {
+          const ta = a.timestamp?.toMillis?.() || 0;
+          const tb = b.timestamp?.toMillis?.() || 0;
+          return tb - ta;
+        });
+
+        this.entries = results;
+        this.totalLoaded = results.length;
+        this._renderTable();
+        this._renderStats();
+
+      } catch (error) {
+        console.error('Error loading audit data:', error);
+        content.innerHTML = '<div class="audit-empty"><i class="fas fa-exclamation-triangle"></i><p>שגיאה בטעינת נתונים</p></div>';
+      }
+
+      this.loading = false;
+    },
+
+    _queryCollection: async function(collectionName) {
+      let query = this.db.collection(collectionName)
+        .orderBy('timestamp', 'desc')
+        .limit(500);
+
+      // Date filters
+      if (this.filters.dateFrom) {
+        const from = new Date(this.filters.dateFrom);
+        from.setHours(0, 0, 0, 0);
+        query = query.where('timestamp', '>=', from);
+      }
+
+      if (this.filters.dateTo) {
+        const to = new Date(this.filters.dateTo);
+        to.setHours(23, 59, 59, 999);
+        query = query.where('timestamp', '<=', to);
+      }
+
+      const snapshot = await query.get();
+      const docs = [];
+
+      snapshot.forEach(function(doc) {
+ docs.push(doc);
+});
+
+      // Client-side filtering (action and user)
+      return docs.filter(function(doc) {
+        const data = doc.data();
+
+        if (this.filters.action) {
+          const docAction = data.action || data.type || '';
+          if (docAction !== this.filters.action) {
+ return false;
+}
+        }
+
+        if (this.filters.user) {
+          const searchTerm = this.filters.user;
+          const userFields = [
+            data.userEmail, data.userId, data.username,
+            data.performedBy, data.adminEmail, data.performedByName,
+            data.targetUser, data.targetUserEmail
+          ].filter(Boolean).join(' ').toLowerCase();
+
+          if (!userFields.includes(searchTerm)) {
+ return false;
+}
+        }
+
+        return true;
+      }.bind(this));
+    },
+
+    // ═══════════════════════════════════════════
+    // Rendering
+    // ═══════════════════════════════════════════
+
+    _renderStats: function() {
+      const statsEl = document.getElementById('audit-stats');
+      if (!statsEl) {
+ return;
+}
+
+      const actCount = this.entries.filter(function(e) {
+ return e.source === 'activity';
+}).length;
+      const audCount = this.entries.filter(function(e) {
+ return e.source === 'audit';
+}).length;
+
+      statsEl.innerHTML =
+        '<span class="audit-stat"><strong>' + this.entries.length + '</strong> רשומות</span>' +
+        '<span class="audit-stat"><strong>' + actCount + '</strong> פעילות</span>' +
+        '<span class="audit-stat"><strong>' + audCount + '</strong> ניהול</span>';
+    },
+
+    _renderTable: function() {
+      const content = document.getElementById('audit-table-content');
+      if (!content) {
+ return;
+}
+
+      if (this.entries.length === 0) {
+        content.innerHTML = '<div class="audit-empty"><i class="fas fa-clipboard-list"></i><p>לא נמצאו רשומות</p></div>';
+        return;
+      }
+
+      // Pagination
+      const totalPages = Math.ceil(this.entries.length / PAGE_SIZE);
+      const start = (this.currentPage - 1) * PAGE_SIZE;
+      const pageEntries = this.entries.slice(start, start + PAGE_SIZE);
+
+      let rows = '';
+      pageEntries.forEach(function(entry) {
+        const cat = getActionCategory(entry.action);
+        const actionLabel = ACTION_LABELS[entry.action] || entry.action;
+        const timeStr = _formatTimestamp(entry.timestamp, entry.timestampLocal);
+        const detailsStr = _formatDetails(entry.details);
+        const sourceIcon = entry.source === 'audit'
+          ? '<i class="fas fa-shield-alt" style="color:#9333ea;font-size:11px" title="פעולת מנהל"></i>'
+          : '<i class="fas fa-user" style="color:#6b7280;font-size:11px" title="פעילות משתמש"></i>';
+
+        rows += '<tr>' +
+          '<td>' + sourceIcon + '</td>' +
+          '<td class="audit-time-cell">' + timeStr + '</td>' +
+          '<td><span class="audit-action-badge ' + cat + '">' + _escapeHtml(actionLabel) + '</span></td>' +
+          '<td class="audit-user-cell">' + _escapeHtml(entry.user) + '</td>' +
+          '<td class="audit-user-cell">' + _escapeHtml(entry.target || '') + '</td>' +
+          '<td class="audit-details">' + detailsStr + '</td>' +
+          '</tr>';
+      });
+
+      content.innerHTML = `
+        <table class="audit-table">
+          <thead>
+            <tr>
+              <th style="width:30px"></th>
+              <th>זמן</th>
+              <th>פעולה</th>
+              <th>בוצע ע"י</th>
+              <th>יעד</th>
+              <th>פרטים</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+        ${this._renderPagination(totalPages)}
+      `;
+
+      // Bind pagination
+      this._bindPagination();
+    },
+
+    _renderPagination: function(totalPages) {
+      if (totalPages <= 1) {
+ return '';
+}
+
+      const self = this;
+      let btns = '';
+
+      btns += '<button class="audit-page-btn" data-page="prev" ' + (self.currentPage <= 1 ? 'disabled' : '') + '><i class="fas fa-chevron-right"></i></button>';
+
+      const startPage = Math.max(1, self.currentPage - 2);
+      const endPage = Math.min(totalPages, startPage + 4);
+
+      for (let i = startPage; i <= endPage; i++) {
+        btns += '<button class="audit-page-btn ' + (i === self.currentPage ? 'active' : '') + '" data-page="' + i + '">' + i + '</button>';
+      }
+
+      btns += '<button class="audit-page-btn" data-page="next" ' + (self.currentPage >= totalPages ? 'disabled' : '') + '><i class="fas fa-chevron-left"></i></button>';
+
+      const start = (self.currentPage - 1) * PAGE_SIZE + 1;
+      const end = Math.min(self.currentPage * PAGE_SIZE, self.entries.length);
+
+      return '<div class="audit-pagination">' +
+        '<span class="audit-pagination-info">' + start + '-' + end + ' מתוך ' + self.entries.length + '</span>' +
+        '<div class="audit-pagination-btns">' + btns + '</div>' +
+        '</div>';
+    },
+
+    _bindPagination: function() {
+      const self = this;
+      const totalPages = Math.ceil(self.entries.length / PAGE_SIZE);
+
+      document.querySelectorAll('.audit-page-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          const page = btn.dataset.page;
+          if (page === 'prev' && self.currentPage > 1) {
+            self.currentPage--;
+          } else if (page === 'next' && self.currentPage < totalPages) {
+            self.currentPage++;
+          } else if (page !== 'prev' && page !== 'next') {
+            self.currentPage = parseInt(page);
+          }
+          self._renderTable();
+          // Scroll to top of table
+          document.querySelector('.audit-table-wrapper')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        });
+      });
+    }
+  };
+
+  // ═══════════════════════════════════════════
+  // Utility Functions
+  // ═══════════════════════════════════════════
+
+  function _formatTimestamp(ts, localStr) {
+    if (!ts && !localStr) {
+ return '-';
+}
+
+    try {
+      const date = ts?.toDate?.() || new Date(localStr);
+      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      const hours = String(date.getHours()).padStart(2, '0');
+      const minutes = String(date.getMinutes()).padStart(2, '0');
+      return day + '/' + month + ' ' + hours + ':' + minutes;
+    } catch (e) {
+      return '-';
+    }
+  }
+
+  function _formatDetails(details) {
+    if (!details) {
+ return '';
+}
+    if (typeof details === 'string') {
+      try {
+        const parsed = JSON.parse(details);
+        return _escapeHtml(_summarizeObject(parsed));
+      } catch (e) {
+        return _escapeHtml(details.substring(0, 80));
+      }
+    }
+    if (typeof details === 'object') {
+      return _escapeHtml(_summarizeObject(details));
+    }
+    return '';
+  }
+
+  function _summarizeObject(obj) {
+    if (!obj) {
+ return '';
+}
+    if (obj.message) {
+ return obj.message;
+}
+    const keys = Object.keys(obj);
+    if (keys.length === 0) {
+ return '';
+}
+    const parts = [];
+    keys.slice(0, 3).forEach(function(key) {
+      const val = obj[key];
+      if (val !== null && val !== undefined && typeof val !== 'object') {
+        parts.push(key + ': ' + val);
+      }
+    });
+    return parts.join(', ');
+  }
+
+  function _escapeHtml(str) {
+    if (!str) {
+ return '';
+}
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+
+  window.AuditTrailPage = AuditTrailPage;
+  console.log('✅ Audit Trail Page loaded');
+
+})();

--- a/apps/admin-panel/js/ui/Navigation.js
+++ b/apps/admin-panel/js/ui/Navigation.js
@@ -55,7 +55,8 @@ return;
                 { id: 'users', label: 'ניהול עובדים', icon: 'fa-users', href: 'index.html' },
                 { id: 'clients', label: 'ניהול לקוחות', icon: 'fa-briefcase', href: 'clients.html' },
                 { id: 'workload', label: 'ניתוח עומס', icon: 'fa-chart-line', href: 'workload.html' },
-                { id: 'announcements', label: 'הודעות מערכת', icon: 'fa-bullhorn', href: 'system-announcements.html' }
+                { id: 'announcements', label: 'הודעות מערכת', icon: 'fa-bullhorn', href: 'system-announcements.html' },
+                { id: 'audit-trail', label: 'לוג פעילות', icon: 'fa-history', href: 'audit-trail.html' }
             ];
 
             this.container.innerHTML = `

--- a/apps/admin-panel/js/ui/Navigation.js
+++ b/apps/admin-panel/js/ui/Navigation.js
@@ -55,8 +55,7 @@ return;
                 { id: 'users', label: 'ניהול עובדים', icon: 'fa-users', href: 'index.html' },
                 { id: 'clients', label: 'ניהול לקוחות', icon: 'fa-briefcase', href: 'clients.html' },
                 { id: 'workload', label: 'ניתוח עומס', icon: 'fa-chart-line', href: 'workload.html' },
-                { id: 'announcements', label: 'הודעות מערכת', icon: 'fa-bullhorn', href: 'system-announcements.html' },
-                { id: 'audit-trail', label: 'לוג פעילות', icon: 'fa-history', href: 'audit-trail.html' }
+                { id: 'announcements', label: 'הודעות מערכת', icon: 'fa-bullhorn', href: 'system-announcements.html' }
             ];
 
             this.container.innerHTML = `
@@ -83,6 +82,9 @@ return;
                             <i class="fas fa-clipboard-check"></i>
                             <span>אישורי משימות</span>
                         </button>
+                        <a href="audit-trail.html" class="btn-settings ${this.currentPage === 'audit-trail' ? 'active' : ''}" title="לוג פעילות">
+                            <i class="fas fa-history"></i>
+                        </a>
                         <a href="settings.html" class="btn-settings ${this.currentPage === 'settings' ? 'active' : ''}" title="הגדרות מערכת">
                             <i class="fas fa-cog"></i>
                         </a>


### PR DESCRIPTION
## Summary
- **Audit Trail page** — new admin page showing all activity_log + audit_log entries
  - Source tabs (All/User Activity/Admin Actions) with blue active state
  - Filters: action type, user, date range — all in single row
  - Full Hebrew translation for all action types and detail fields
  - Technical IDs hidden, values formatted (minutes→hours, dates→DD/MM, fileSize→KB)
  - Pagination (50/page), color-coded action badges
  - Clock icon in navbar utility area (next to settings gear)
- **Settings UI fixes** — admin email correction (uri→roi)
- **Navigation** — audit trail + settings moved to utility icon area

## Test plan
- [ ] Audit Trail page loads, shows entries
- [ ] Source tabs switch correctly (blue highlight)
- [ ] Filters work (action, user, dates)
- [ ] All actions in Hebrew, no raw UIDs shown
- [ ] Settings page still works
- [ ] Other admin pages unaffected
- [ ] PROD smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)