### PR TITLE
fix: override bypasses -10h guard + report serviceId

### DIFF
--- a/SYSTEM_STATUS.md
+++ b/SYSTEM_STATUS.md
@@ -2,9 +2,9 @@
 ## law-office-system-e4801
 
 **מנוהל על ידי:** טומי — ראש צוות הפיתוח
-**עדכון אחרון:** 2026-04-05
-**סטטוס:** System Settings centralization + Audit Trail — PROD
-**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191
+**עדכון אחרון:** 2026-04-06
+**סטטוס:** Configurable description char limits — PROD
+**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191, #192
 
 ---
 
@@ -13,8 +13,8 @@
 ### Branches
 
 ```
-main:               deb8dc2 — System Settings + Audit Trail + UI fixes
-production-stable:  merged PR #191
+main:               a693cf0 — Configurable description char limits
+production-stable:  merged PR #192
 אין branches פתוחים.
 ```
 
@@ -60,6 +60,7 @@ production-stable:  merged PR #191
 | #189 | 5/4 | refactor+feat: System Settings Phase 1+2 — ריכוז 170+ constants ב-42 קבצים + Firestore system_config + Settings page |
 | #190 | 5/4 | fix: admin email uri@ → roi@ |
 | #191 | 5/4 | feat: Audit Trail page — לוג פעילות עם סינון, תרגום עברית, badges צבעוניים |
+| #192 | 6/4 | feat: Configurable description char limits — מגבלות תווים ניהוליות לתיאור משימה ורישום שעות, אכיפה ב-3 שכבות (Admin UI + Frontend + Backend) |
 
 ---
 

--- a/apps/admin-panel/js/ui/ClientReportModal.js
+++ b/apps/admin-panel/js/ui/ClientReportModal.js
@@ -532,6 +532,7 @@ return;
                         usedHours: usedHours,
                         type: serviceType,
                         stage: stage,
+                        serviceId: service.id,
                         status: service.status || 'active',
                         pricingType: service.pricingType || (serviceType === 'legal_procedure' && totalHours > 0 ? 'hourly' : service.pricingType || null)
                     });
@@ -764,7 +765,7 @@ card.classList.add('resolved');
 
             // Data attributes for selection
             card.dataset.serviceName = serviceInfo.displayName;
-            card.dataset.serviceId = serviceInfo.stage || serviceInfo.serviceKey;
+            card.dataset.serviceId = serviceInfo.serviceId || serviceInfo.stage || '';
             card.dataset.serviceIndex = index;
             card.dataset.serviceType = serviceInfo.type;
 

--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -421,11 +421,12 @@ async function addTimeToTaskWithTransaction(db, data, user) {
             const serviceType = targetService.type || clientData.procedureType;
 
             if (serviceType === ST.HOURS) {
+              const hasOverride = !!targetService.overrideActive;
               let resolvedPackageId = serviceIds.packageId;
               if (!resolvedPackageId) {
                 const fallbackPkg = (targetService.packages || []).find(pkg => {
                   const status = pkg.status || 'active';
-                  return ['active', 'pending', 'overdraft', 'depleted'].includes(status) && (pkg.hoursRemaining || 0) > -10;
+                  return ['active', 'pending', 'overdraft', 'depleted'].includes(status) && (hasOverride || (pkg.hoursRemaining || 0) > -10);
                 });
                 if (fallbackPkg) resolvedPackageId = fallbackPkg.id;
               }
@@ -436,7 +437,7 @@ async function addTimeToTaskWithTransaction(db, data, user) {
                 if (targetPkg) {
                   const currentRemaining = targetPkg.hoursRemaining || 0;
                   const afterDeduction = currentRemaining - (minutesDelta / 60);
-                  if (afterDeduction < -10) {
+                  if (afterDeduction < -10 && !hasOverride) {
                     throw new functions.https.HttpsError('resource-exhausted',
                       'הלקוח בחריגה נא לעדכן בהקדם את גיא',
                       { clientId: taskData.clientId, currentRemaining, requestedHours: minutesDelta / 60, wouldBe: afterDeduction });

--- a/functions/tests/update-guard.test.js
+++ b/functions/tests/update-guard.test.js
@@ -243,12 +243,12 @@ describe('updateTimesheetEntry — -10h overdraft guard (hours)', () => {
     expect(result.success).toBe(true);
   });
 
-  test('increase blocked when afterDeduction < -10', async () => {
-    // Package at -8h, delta = +3h → afterDeduction = -11 → blocked
+  test('increase blocked when afterDeduction < -10 (no override)', async () => {
+    // Package at -8h, delta = +3h → afterDeduction = -11 → blocked (no override)
     mockTransaction.get
       .mockResolvedValueOnce(makeEntryDoc())
       .mockResolvedValueOnce(makeTaskDoc())
-      .mockResolvedValueOnce(makeHoursClientDoc(-8, { overrideActive: true }));
+      .mockResolvedValueOnce(makeHoursClientDoc(-8));
 
     await expect(
       updateTimesheetEntry(
@@ -259,6 +259,20 @@ describe('updateTimesheetEntry — -10h overdraft guard (hours)', () => {
       code: 'resource-exhausted',
       message: expect.stringContaining('חריגה')
     });
+  });
+
+  test('increase allowed when afterDeduction < -10 WITH overrideActive', async () => {
+    // Package at -8h, delta = +3h → afterDeduction = -11 → allowed with override
+    mockTransaction.get
+      .mockResolvedValueOnce(makeEntryDoc())
+      .mockResolvedValueOnce(makeTaskDoc())
+      .mockResolvedValueOnce(makeHoursClientDoc(-8, { overrideActive: true }));
+
+    const result = await updateTimesheetEntry(
+      { ...defaultData, minutes: 240 },  // 60→240 = +3h
+      defaultContext
+    );
+    expect(result.success).toBe(true);
   });
 
   test('boundary: afterDeduction exactly -10 → passes', async () => {
@@ -304,12 +318,26 @@ describe('updateTimesheetEntry — -10h overdraft guard (hours)', () => {
     expect(result.success).toBe(true);
   });
 
-  test('error details include currentRemaining, requestedHoursDelta, wouldBe', async () => {
-    // Package at -8h, delta = +3h → blocked
+  test('overrideActive bypasses -10 guard — update allowed even past -10', async () => {
+    // Package at -8h, delta = +3h → -11 → normally blocked, but overrideActive bypasses
     mockTransaction.get
       .mockResolvedValueOnce(makeEntryDoc())
       .mockResolvedValueOnce(makeTaskDoc())
       .mockResolvedValueOnce(makeHoursClientDoc(-8, { overrideActive: true }));
+
+    const result = await updateTimesheetEntry(
+      { ...defaultData, minutes: 240 },  // +3h
+      defaultContext
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test('without overrideActive — error details include currentRemaining, requestedHoursDelta, wouldBe', async () => {
+    // Package at -8h, delta = +3h → blocked (no override)
+    mockTransaction.get
+      .mockResolvedValueOnce(makeEntryDoc())
+      .mockResolvedValueOnce(makeTaskDoc())
+      .mockResolvedValueOnce(makeHoursClientDoc(-8));
 
     try {
       await updateTimesheetEntry(
@@ -328,23 +356,18 @@ describe('updateTimesheetEntry — -10h overdraft guard (hours)', () => {
     }
   });
 
-  test('no packageId on entry → falls back to DeductionSystem.getActivePackage', async () => {
-    // Entry has no packageId. DeductionSystem.getActivePackage will find the
-    // package with status=active/overdraft and hoursRemaining > -10.
-    // Package at -8h, delta = +3h → -11 → blocked
+  test('no packageId on entry + overrideActive → falls back and succeeds past -10', async () => {
+    // Entry has no packageId. overrideActive bypasses -10 guard.
     mockTransaction.get
       .mockResolvedValueOnce(makeEntryDoc({ packageId: null }))
       .mockResolvedValueOnce(makeTaskDoc())
       .mockResolvedValueOnce(makeHoursClientDoc(-8, { overrideActive: true }));
 
-    await expect(
-      updateTimesheetEntry(
-        { ...defaultData, minutes: 240 },  // +3h, after = -8-3 = -11
-        defaultContext
-      )
-    ).rejects.toMatchObject({
-      code: 'resource-exhausted'
-    });
+    const result = await updateTimesheetEntry(
+      { ...defaultData, minutes: 240 },  // +3h, after = -8-3 = -11
+      defaultContext
+    );
+    expect(result.success).toBe(true);
   });
 
   test('no client doc → guard skipped, update succeeds', async () => {

--- a/functions/timesheet/index.js
+++ b/functions/timesheet/index.js
@@ -278,11 +278,12 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
 
             if (serviceType === ST.HOURS) {
               // Find active package + overdraft check
-              const activePackage = DeductionSystem.getActivePackage(targetService);
+              const hasOverride = !!targetService.overrideActive;
+              const activePackage = DeductionSystem.getActivePackage(targetService, true, hasOverride);
               if (activePackage) {
                 const currentRemaining = activePackage.hoursRemaining || 0;
                 const afterDeduction = currentRemaining - hoursWorked;
-                if (afterDeduction < -10) {
+                if (afterDeduction < -10 && !hasOverride) {
                   throw new functions.https.HttpsError(
                     'resource-exhausted',
                     'הלקוח בחריגה נא לעדכן בהקדם את גיא',
@@ -295,7 +296,7 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
                 const fallbackPkg = (targetService.packages || []).find(pkg => {
                   const status = pkg.status || 'active';
                   return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
-                    && (pkg.hoursRemaining || 0) > -10;
+                    && (hasOverride || (pkg.hoursRemaining || 0) > -10);
                 });
                 if (fallbackPkg) {
                   updatedPackageId = fallbackPkg.id;
@@ -305,7 +306,7 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
                   if (lastPkg && lastPkg.id) {
                     const currentRemaining = lastPkg.hoursRemaining || 0;
                     const afterDeduction = currentRemaining - hoursWorked;
-                    if (afterDeduction < -10) {
+                    if (afterDeduction < -10 && !hasOverride) {
                       throw new functions.https.HttpsError('resource-exhausted',
                         'הלקוח בחריגה חמורה — כל החבילות מוצו מעבר למגבלה',
                         { clientId: clientData.caseNumber, currentRemaining, requestedHours: hoursWorked, wouldBe: afterDeduction });
@@ -745,11 +746,12 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
             const serviceType = targetService.type || clientData.procedureType;
 
             if (serviceType === ST.HOURS) {
-              const activePackage = DeductionSystem.getActivePackage(targetService);
+              const hasOverride = !!targetService.overrideActive;
+              const activePackage = DeductionSystem.getActivePackage(targetService, true, hasOverride);
               if (activePackage) {
                 const currentRemaining = activePackage.hoursRemaining || 0;
                 const afterDeduction = currentRemaining - hoursWorked;
-                if (afterDeduction < -10) {
+                if (afterDeduction < -10 && !hasOverride) {
                   throw new functions.https.HttpsError('resource-exhausted', 'הלקוח בחריגה נא לעדכן בהקדם את גיא',
                     { clientId: clientData.caseNumber, currentRemaining, requestedHours: hoursWorked, wouldBe: afterDeduction });
                 }
@@ -757,7 +759,7 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
               } else {
                 const fallbackPkg = (targetService.packages || []).find(pkg => {
                   const status = pkg.status || 'active';
-                  return ['active', 'pending', 'overdraft', 'depleted'].includes(status) && (pkg.hoursRemaining || 0) > -10;
+                  return ['active', 'pending', 'overdraft', 'depleted'].includes(status) && (hasOverride || (pkg.hoursRemaining || 0) > -10);
                 });
                 if (fallbackPkg) {
                   updatedPackageId = fallbackPkg.id;
@@ -767,7 +769,7 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
                   if (lastPkg && lastPkg.id) {
                     const currentRemaining = lastPkg.hoursRemaining || 0;
                     const afterDeduction = currentRemaining - hoursWorked;
-                    if (afterDeduction < -10) {
+                    if (afterDeduction < -10 && !hasOverride) {
                       throw new functions.https.HttpsError('resource-exhausted',
                         'הלקוח בחריגה חמורה — כל החבילות מוצו מעבר למגבלה',
                         { clientId: clientData.caseNumber, currentRemaining, requestedHours: hoursWorked, wouldBe: afterDeduction });
@@ -1211,15 +1213,16 @@ exports.updateTimesheetEntry = functions.https.onCall(async (data, context) => {
 
             if (serviceType === ST.HOURS) {
               // Find the package — prefer entry's packageId, fallback to active package
+              const hasOverride = !!targetService.overrideActive;
               const entryPackageId = entryData.packageId;
               const targetPackage = entryPackageId
                 ? (targetService.packages || []).find(p => p.id === entryPackageId)
-                : DeductionSystem.getActivePackage(targetService);
+                : DeductionSystem.getActivePackage(targetService, true, hasOverride);
 
               if (targetPackage) {
                 const currentRemaining = targetPackage.hoursRemaining || 0;
                 const afterDeduction = currentRemaining - hoursDiff;
-                if (afterDeduction < -10) {
+                if (afterDeduction < -10 && !hasOverride) {
                   console.error(`🛡️ [UPDATE GUARD] Blocked: package ${targetPackage.id} would drop to ${afterDeduction}h (limit: -10h)`);
                   throw new functions.https.HttpsError('resource-exhausted',
                     'הלקוח בחריגה — העריכה תגרום לחריגה מעבר למגבלת -10 שעות',

--- a/functions/triggers/timesheet-trigger.js
+++ b/functions/triggers/timesheet-trigger.js
@@ -324,6 +324,7 @@ const onTimesheetEntryChanged = onDocumentWritten({
 
         if (serviceType === ST.HOURS) {
           // ── hours: resolve packageId if missing ──
+          const hasOverride = !!targetService.overrideActive;
           let resolvedPackageId = packageId;
 
           if (!resolvedPackageId) {
@@ -331,7 +332,7 @@ const onTimesheetEntryChanged = onDocumentWritten({
             const fallbackPkg = (targetService.packages || []).find((pkg) => {
               const status = pkg.status || 'active';
               return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
-                && (pkg.hoursRemaining || 0) > -10;
+                && (hasOverride || (pkg.hoursRemaining || 0) > -10);
             });
             if (fallbackPkg) {
               resolvedPackageId = fallbackPkg.id;


### PR DESCRIPTION
## Summary
- **Override bypass bug**: When admin approved overdraft (overrideActive=true), the -10h hard limit still blocked entry creation once hoursRemaining dropped below -10. Fixed in all 5 locations: createQuickLogEntry, createTimesheetEntry_v2, updateTimesheetEntry, addTimeToTask_v2, timesheet trigger.
- **Report bug**: Admin Panel report showed "no records" for hours-type services because card.dataset.serviceId was set to undefined. Now passes real service.id.

## Test plan
- [x] Unit tests: 17/17 update-guard, 33/33 timesheet-trigger, 87/87 guard-related
- [x] DEV: רישום שעות לרבקה דרמר עם override פעיל — עובד
- [x] DEV: דוח Admin Panel לרבקה דרמר — מציג רשומות
- [ ] PROD smoke test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)