### PR TITLE
fix: auto-select ignores fixed services in task creation

### DIFF
--- a/apps/user-app/js/modules/client-case-selector.js
+++ b/apps/user-app/js/modules/client-case-selector.js
@@ -1123,6 +1123,7 @@ return;
 
       // בחירה אוטומטית אם יש שירות/שלב אחד בלבד
       const activeServices = services.filter(s => s.status === 'active' && s.type === 'hours');
+      const activeFixedServices = services.filter(s => s.status === 'active' && s.type === 'fixed');
 
       // ספירת שלבים פעילים (הן במבנה חדש והן בישן)
       const allActiveStages = [];
@@ -1135,15 +1136,21 @@ return;
         allActiveStages.push(...stages.filter(s => s.status === 'active'));
       }
 
+      // סה"כ שירותים/שלבים פעילים (כולל fixed)
+      const totalActive = activeServices.length + allActiveStages.length + activeFixedServices.length;
+
       if (isLegacyCase) {
         // תיק ישן - בחירה אוטומטית
         this.selectService(caseItem.id, 'hours');
-      } else if (activeServices.length === 1 && allActiveStages.length === 0) {
-        // שירות שעות אחד בלבד - בחירה אוטומטית
-        this.selectService(activeServices[0].id, 'hours');
-      } else if (allActiveStages.length === 1 && activeServices.length === 0) {
-        // שלב אחד בלבד - בחירה אוטומטית
-        this.selectService(allActiveStages[0].id, 'legal_procedure');
+      } else if (totalActive === 1) {
+        // בדיוק שירות/שלב פעיל אחד - בחירה אוטומטית
+        if (activeServices.length === 1) {
+          this.selectService(activeServices[0].id, 'hours');
+        } else if (allActiveStages.length === 1) {
+          this.selectService(allActiveStages[0].id, 'legal_procedure');
+        } else if (activeFixedServices.length === 1) {
+          this.selectService(activeFixedServices[0].id, 'fixed');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Auto-select logic in User App task creation only counted `hours` and `legal_procedure` services, ignoring `fixed` type
- When a client had 1 active legal stage + fixed services, it auto-selected the stage and hid all other cards
- Fix: count all service types (hours + legal_procedure stages + fixed) in `totalActive`, only auto-select when exactly 1 is active

## Verified on
- Client: זיאת שמוליק (2026043) — 1 legal_procedure + 2 fixed services
- DEV: confirmed all 3 service cards now visible

## Files changed
- `apps/user-app/js/modules/client-case-selector.js` — 1 file, auto-select logic only

## Test plan
- [ ] Cache bust PROD
- [ ] Login → הוספת משימה → בחר זיאת שמוליק → verify 3 service cards appear
- [ ] Verify auto-select still works for single-service clients
- [ ] Console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)