### PR TITLE
feat: employee monthly timesheet report (HTML + CSV)

### DIFF
--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -229,6 +229,7 @@
     <script src="js/ui/Notifications.js?v=2ba1e81"></script>
     <script src="js/ui/UserForm.js?v=2ba1e81"></script>
     <script src="js/ui/UserDetailsModal.js?v=2ba1e81"></script>
+    <script src="js/managers/ReportGenerator.js?v=2ba1e81"></script>
     <script src="js/ui/DeleteDataSidePanel.js?v=2ba1e81"></script>
     <script src="js/managers/UsersActions.js?v=2ba1e81"></script>
 

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -1359,6 +1359,12 @@ return '0:00';
             const html = this.buildEmployeeHTML(reportData);
 
             const newWindow = window.open('', '_blank');
+            if (!newWindow) {
+                if (window.notify) {
+                    window.notify.error('הדפדפן חסם את החלון. אנא אפשר חלונות קופצים ונסה שוב.', 'שגיאה');
+                }
+                return;
+            }
             newWindow.document.write(html);
             newWindow.document.close();
             newWindow.focus();
@@ -1670,11 +1676,14 @@ return '0.00';
 
             const { employee, period, summary, clientBreakdown, entries } = reportData;
 
+            // RFC 4180: escape double quotes by doubling them
+            const csvEscape = (val) => String(val || '').replace(/"/g, '""');
+
             let csv = '\uFEFF'; // BOM for Hebrew/Excel support
 
             // Header
             csv += 'דוח שעתון עובד\n';
-            csv += `שם,${employee.name}\n`;
+            csv += `שם,"${csvEscape(employee.name)}"\n`;
             csv += `תקופה,${period.label}\n`;
             csv += `תקן יומי,${employee.dailyTarget}\n`;
             csv += '\n';
@@ -1694,7 +1703,7 @@ return '0.00';
                 csv += 'פילוח לפי לקוחות\n';
                 csv += 'לקוח,שעות,רשומות,%\n';
                 clientBreakdown.forEach(c => {
-                    csv += `"${c.name}",${c.hours.toFixed(2)},${c.count},${c.percent}%\n`;
+                    csv += `"${csvEscape(c.name)}",${c.hours.toFixed(2)},${c.count},${c.percent}%\n`;
                 });
                 csv += '\n';
             }
@@ -1706,7 +1715,7 @@ return '0.00';
                 const sortedInternal = [...entries.internal].sort((a, b) => (a.date || '').localeCompare(b.date || ''));
                 sortedInternal.forEach(e => {
                     const desc = e.action || e.taskDescription || e.description || '';
-                    csv += `"${(e.date || '').substring(0, 10)}","${desc}",${e.minutes || 0},${((e.minutes || 0) / 60).toFixed(2)}\n`;
+                    csv += `"${(e.date || '').substring(0, 10)}","${csvEscape(desc)}",${e.minutes || 0},${((e.minutes || 0) / 60).toFixed(2)}\n`;
                 });
                 csv += '\n';
             }
@@ -1718,7 +1727,7 @@ return '0.00';
                 const sortedClient = [...entries.client].sort((a, b) => (a.date || '').localeCompare(b.date || ''));
                 sortedClient.forEach(e => {
                     const desc = e.action || e.taskDescription || e.description || '';
-                    csv += `"${(e.date || '').substring(0, 10)}","${e.clientName || ''}","${desc}",${e.minutes || 0},${((e.minutes || 0) / 60).toFixed(2)}\n`;
+                    csv += `"${(e.date || '').substring(0, 10)}","${csvEscape(e.clientName || '')}","${csvEscape(desc)}",${e.minutes || 0},${((e.minutes || 0) / 60).toFixed(2)}\n`;
                 });
             }
 

--- a/apps/admin-panel/js/ui/UserDetailsModal.js
+++ b/apps/admin-panel/js/ui/UserDetailsModal.js
@@ -6113,6 +6113,10 @@ return true;
          * פתיחת פאנל בחירת פרמטרים לדוח
          */
         openReportPanel() {
+            if (document.getElementById('reportSlideInPanel')) {
+                return; // Already open
+            }
+
             const user = this.userData || this.currentUser;
             if (!user) {
                 return;


### PR DESCRIPTION
## Summary
- "הפק דוח" button in employee details modal footer
- Slide-in panel for month/format selection
- HTML report: office logo, employee info, monthly summary, client breakdown, separate internal/client detail tables
- CSV report: downloadable with Hebrew BOM support
- Fresh Firestore query (independent from modal data)

## Fixes from Gatekeeper review
- window.open() null check (popup blocker safe)
- CSV quote escaping per RFC 4180 (handles בע"מ etc.)
- Duplicate panel guard (double-click safe)
- ReportGenerator.js script tag added to index.html

## Files changed
- `apps/admin-panel/js/ui/UserDetailsModal.js` — button, panel, query, stats
- `apps/admin-panel/js/managers/ReportGenerator.js` — HTML/CSV generation
- `apps/admin-panel/index.html` — script tag

## Test plan
- [ ] Open employee details → click "הפק דוח"
- [ ] Select month with data (e.g. March for מרווה) → HTML → report opens in new window
- [ ] Select CSV → file downloads with correct Hebrew
- [ ] Select month with no data → shows "אין רשומות שעתון"
- [ ] Double-click "הפק דוח" → only one panel opens
- [ ] Verify hours tab still works (userData.hours not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)