### PR TITLE
feat: daily reporting meter in sidebar

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -83,6 +83,9 @@ import * as DebugTools from './modules/debug-tools.js';
 // Sidebar Component
 import { Sidebar } from './modules/components/sidebar/sidebar.js';
 
+// Daily Meter Component (sidebar ring — daily reporting progress)
+import { DailyMeter } from './modules/components/sidebar/daily-meter.js';
+
 // Beit Midrash Component
 import { BeitMidrash } from './modules/components/beit-midrash/beit-midrash.js';
 
@@ -161,6 +164,7 @@ class LawOfficeManager {
     this.announcementTicker = new SystemAnnouncementTicker(); // System Announcement Ticker
     this.announcementPopup = new SystemAnnouncementPopup(); // System Announcement Popup
     this.breakManager = new BreakManager(); // Break Button
+    this.dailyMeter = new DailyMeter(); // Daily reporting meter (sidebar ring)
 
     // Activity Logger & Task Actions (initialized after Firebase)
     this.activityLogger = null;
@@ -908,6 +912,9 @@ return false;
         this.notificationBell.updateFromSystem(blockedClients, criticalClients, urgentTasks);
       }
 
+      // ✅ Initialize Daily Meter (sidebar ring)
+      this.initDailyMeter();
+
       // ✅ הפעלת Real-time listeners למשימות ושעות
       this.startRealTimeListeners();
 
@@ -917,6 +924,23 @@ return false;
       console.error('❌ Error loading data:', error);
       this.showNotification('שגיאה בטעינת נתונים', 'error');
       throw error;
+    }
+  }
+
+  /**
+   * Initialize Daily Meter in sidebar footer
+   */
+  initDailyMeter() {
+    try {
+      const footer = document.querySelector('.gh-sidebar-footer');
+      if (!footer) {
+        Logger.log('⚠️ Daily meter: sidebar footer not found');
+        return;
+      }
+      this.dailyMeter.init(footer);
+      Logger.log('✅ Daily Meter initialized');
+    } catch (error) {
+      console.error('❌ Daily meter init error:', error);
     }
   }
 
@@ -972,6 +996,11 @@ return false;
             // Re-filter and render
             this.filterTimesheetEntries();
             this.renderTimesheetView(); // ✅ Fixed: was renderTimesheet()
+
+            // ✅ Update Daily Meter with new entries
+            if (this.dailyMeter) {
+              this.dailyMeter.update(entries);
+            }
           },
           (error) => {
             console.error('❌ Timesheet listener error:', error);

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.css
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.css
@@ -1,0 +1,336 @@
+/* ═══════════════════════════════════════
+   Daily Meter Component
+   prefix: gh-daily-meter-*
+   Location: Sidebar footer, above break button
+   ═══════════════════════════════════════ */
+
+/* ─── Container ─── */
+.gh-daily-meter {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px 0 6px;
+  border-top: 1px solid #1e293b;
+}
+
+/* ─── Ring Wrapper ─── */
+.gh-daily-meter-ring {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.gh-daily-meter-ring:hover {
+  transform: scale(1.06);
+}
+
+.gh-daily-meter-ring svg {
+  transform: rotate(-90deg);
+  transition: filter 0.5s ease;
+}
+
+/* ─── Ring Track & Fill ─── */
+.gh-daily-meter-track {
+  fill: none;
+  stroke: #1e293b;
+  stroke-width: 5;
+}
+
+.gh-daily-meter-fill {
+  fill: none;
+  stroke-width: 5;
+  stroke-linecap: round;
+  transition:
+    stroke-dashoffset 1s cubic-bezier(0.4, 0, 0.2, 1),
+    stroke 0.5s ease;
+}
+
+/* Color states */
+.gh-daily-meter-fill.state-blue { stroke: #3b82f6; }
+
+.gh-daily-meter-fill.state-orange { stroke: #f59e0b; }
+
+.gh-daily-meter-fill.state-green { stroke: #22c55e; }
+
+.gh-daily-meter-fill.state-red { stroke: #ef4444; }
+
+/* Glow per state */
+.gh-daily-meter-ring.glow-blue svg { filter: drop-shadow(0 0 5px rgb(59 130 246 / 35%)); }
+
+.gh-daily-meter-ring.glow-orange svg { filter: drop-shadow(0 0 5px rgb(245 158 11 / 35%)); }
+
+.gh-daily-meter-ring.glow-green svg { filter: drop-shadow(0 0 6px rgb(34 197 94 / 40%)); }
+
+.gh-daily-meter-ring.glow-red svg { filter: drop-shadow(0 0 6px rgb(239 68 68 / 40%)); }
+
+/* Gentle pulse for green (target reached) */
+@keyframes gh-meter-pulse-green {
+  0%, 100% { filter: drop-shadow(0 0 6px rgb(34 197 94 / 35%)); }
+
+  50% { filter: drop-shadow(0 0 10px rgb(34 197 94 / 55%)); }
+}
+
+.gh-daily-meter-ring.pulse-green svg {
+  animation: gh-meter-pulse-green 2.5s ease infinite;
+}
+
+/* Gentle pulse for red (over target) */
+@keyframes gh-meter-pulse-red {
+  0%, 100% { filter: drop-shadow(0 0 6px rgb(239 68 68 / 35%)); }
+
+  50% { filter: drop-shadow(0 0 10px rgb(239 68 68 / 55%)); }
+}
+
+.gh-daily-meter-ring.pulse-red svg {
+  animation: gh-meter-pulse-red 2.5s ease infinite;
+}
+
+/* ─── Center Text ─── */
+.gh-daily-meter-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  line-height: 1;
+  pointer-events: none;
+}
+
+.gh-daily-meter-pct {
+  font-size: 12px;
+  font-weight: 800;
+  color: #f1f5f9;
+}
+
+.gh-daily-meter-hours {
+  font-size: 8px;
+  color: #64748b;
+  font-weight: 600;
+  margin-top: 2px;
+}
+
+/* ─── Label below ring ─── */
+.gh-daily-meter-label {
+  font-size: 7.5px;
+  color: #64748b;
+  font-weight: 700;
+  margin-top: 3px;
+  letter-spacing: 0.06em;
+}
+
+/* ═══════════════════════════════════════
+   Popup (click to open)
+   ═══════════════════════════════════════ */
+
+.gh-daily-meter-popup {
+  position: absolute;
+  left: calc(-230px - 14px);
+  top: 50%;
+  transform: translateY(-50%) translateX(10px);
+  width: 230px;
+  background: #1e293b;
+  border-radius: 12px;
+  padding: 16px 18px;
+  box-shadow:
+    -8px 4px 24px rgb(0 0 0 / 40%),
+    0 0 0 1px rgb(255 255 255 / 5%);
+  opacity: 0;
+  visibility: hidden;
+  transition: all 0.25s ease;
+  z-index: 2000;
+  pointer-events: none;
+  color: #e2e8f0;
+  font-size: 13px;
+  direction: rtl;
+}
+
+/* Bridge to prevent close when moving to popup */
+.gh-daily-meter-popup::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: -16px;
+  width: 20px;
+  height: 100%;
+}
+
+.gh-daily-meter-popup.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(-50%) translateX(0);
+  pointer-events: auto;
+}
+
+/* ─── Popup Header ─── */
+.gh-daily-meter-popup-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.gh-daily-meter-popup-title {
+  font-weight: 700;
+  font-size: 14px;
+  color: #f1f5f9;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.gh-daily-meter-popup-title i {
+  font-size: 12px;
+  color: #3b82f6;
+}
+
+.gh-daily-meter-popup-close {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px;
+  border-radius: 6px;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.gh-daily-meter-popup-close:hover {
+  background: rgb(255 255 255 / 8%);
+  color: #94a3b8;
+}
+
+/* ─── Popup Client List ─── */
+.gh-daily-meter-popup-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.gh-daily-meter-popup-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  transition: background 0.15s;
+}
+
+.gh-daily-meter-popup-row:hover {
+  background: rgb(255 255 255 / 4%);
+}
+
+.gh-daily-meter-popup-row-name {
+  color: #cbd5e1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 150px;
+}
+
+.gh-daily-meter-popup-row-name .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.gh-daily-meter-popup-row-hours {
+  font-weight: 600;
+  color: #e2e8f0;
+  white-space: nowrap;
+}
+
+.gh-daily-meter-popup-row.internal .gh-daily-meter-popup-row-name {
+  color: #f59e0b;
+}
+
+/* ─── Popup Divider ─── */
+.gh-daily-meter-popup-divider {
+  height: 1px;
+  background: #334155;
+  margin: 8px 0;
+}
+
+/* ─── Popup Total ─── */
+.gh-daily-meter-popup-total {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 700;
+  font-size: 13px;
+  color: #f1f5f9;
+  padding: 4px 8px;
+}
+
+/* ─── Popup Status ─── */
+.gh-daily-meter-popup-status {
+  margin-top: 8px;
+  font-size: 11px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.gh-daily-meter-popup-status.status-normal {
+  background: rgb(59 130 246 / 12%);
+  color: #93c5fd;
+}
+
+.gh-daily-meter-popup-status.status-almost {
+  background: rgb(245 158 11 / 12%);
+  color: #fcd34d;
+}
+
+.gh-daily-meter-popup-status.status-done {
+  background: rgb(34 197 94 / 12%);
+  color: #86efac;
+}
+
+.gh-daily-meter-popup-status.status-over {
+  background: rgb(239 68 68 / 12%);
+  color: #fca5a5;
+}
+
+/* ─── Empty state ─── */
+.gh-daily-meter-popup-empty {
+  text-align: center;
+  color: #64748b;
+  font-size: 12px;
+  padding: 12px 0;
+}
+
+/* ─── Scrollbar in popup ─── */
+.gh-daily-meter-popup-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.gh-daily-meter-popup-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.gh-daily-meter-popup-list::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-radius: 4px;
+}
+
+/* ─── Mobile ─── */
+@media (width <= 768px) {
+  .gh-daily-meter-popup {
+    display: none;
+  }
+}
+
+/* ─── Print ─── */
+@media print {
+  .gh-daily-meter { display: none; }
+}

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -1,0 +1,434 @@
+/**
+ * Daily Meter Component
+ * GH Law Office System
+ *
+ * Shows a circular ring in the sidebar footer indicating
+ * how many hours the user has reported today vs. their daily target.
+ * Click to see per-client breakdown.
+ *
+ * Dependencies:
+ *   - window.manager.timesheetEntries
+ *   - window.manager.currentEmployee.dailyHoursTarget
+ *   - window.manager.showNotification (for overage alert)
+ */
+
+const RADIUS = 21;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const DEFAULT_DAILY_TARGET = 8.45;
+
+export class DailyMeter {
+  constructor() {
+    this._el = null;
+    this._ringEl = null;
+    this._circleEl = null;
+    this._pctEl = null;
+    this._hoursEl = null;
+    this._popupEl = null;
+    this._cssElement = null;
+
+    this._dailyTarget = DEFAULT_DAILY_TARGET;
+    this._todayEntries = [];
+    this._isPopupOpen = false;
+    this._overageAlertedToday = false;
+
+    // Store date string for "today" — recalculated on update
+    this._todayStr = this._getTodayStr();
+
+    // Bound handler for outside clicks
+    this._onOutsideClick = this._handleOutsideClick.bind(this);
+  }
+
+  // ════════════════════════════════════
+  // Lifecycle
+  // ════════════════════════════════════
+
+  /**
+   * Initialize the meter.
+   * Call after sidebar is rendered and data is loaded.
+   * @param {HTMLElement} container - the .gh-sidebar-footer element
+   */
+  init(container) {
+    if (!container) {
+return;
+}
+
+    this._injectCSS();
+    this._render(container);
+    this._bindEvents();
+
+    // Read target from employee data
+    this._dailyTarget =
+      window.manager?.currentEmployee?.dailyHoursTarget || DEFAULT_DAILY_TARGET;
+
+    // Initial update
+    this.update(window.manager?.timesheetEntries || []);
+  }
+
+  destroy() {
+    this._closePopup();
+    if (this._el) {
+      this._el.remove();
+      this._el = null;
+    }
+    this._removeCSS();
+  }
+
+  // ════════════════════════════════════
+  // Public API
+  // ════════════════════════════════════
+
+  /**
+   * Update the meter with current entries.
+   * Called whenever timesheetEntries change (real-time listener).
+   * @param {Array} allEntries - all timesheet entries for current user
+   */
+  update(allEntries) {
+    this._todayStr = this._getTodayStr();
+    this._todayEntries = this._filterToday(allEntries);
+
+    const totalMinutes = this._todayEntries.reduce(
+      (sum, e) => sum + (e.minutes || 0), 0
+    );
+    const totalHours = totalMinutes / 60;
+    const pct = this._dailyTarget > 0
+      ? (totalHours / this._dailyTarget) * 100
+      : 0;
+
+    this._updateRing(pct, totalHours);
+    this._checkOverage(totalHours);
+
+    // If popup is open, refresh its content
+    if (this._isPopupOpen) {
+      this._renderPopupContent();
+    }
+  }
+
+  // ════════════════════════════════════
+  // Rendering
+  // ════════════════════════════════════
+
+  _render(container) {
+    this._el = document.createElement('div');
+    this._el.className = 'gh-daily-meter';
+    this._el.innerHTML = `
+      <div class="gh-daily-meter-ring" title="מד דיווח יומי">
+        <svg width="52" height="52" viewBox="0 0 46 46">
+          <circle class="gh-daily-meter-track" cx="23" cy="23" r="${RADIUS}" />
+          <circle class="gh-daily-meter-fill state-blue" cx="23" cy="23" r="${RADIUS}"
+            stroke-dasharray="${CIRCUMFERENCE}"
+            stroke-dashoffset="${CIRCUMFERENCE}" />
+        </svg>
+        <div class="gh-daily-meter-center">
+          <div class="gh-daily-meter-pct">0%</div>
+          <div class="gh-daily-meter-hours">0:00</div>
+        </div>
+        <div class="gh-daily-meter-popup"></div>
+      </div>
+      <span class="gh-daily-meter-label">דיווח יומי</span>
+    `;
+
+    // Insert as first child of footer (above break button)
+    container.insertBefore(this._el, container.firstChild);
+
+    // Cache DOM references
+    this._ringEl = this._el.querySelector('.gh-daily-meter-ring');
+    this._circleEl = this._el.querySelector('.gh-daily-meter-fill');
+    this._pctEl = this._el.querySelector('.gh-daily-meter-pct');
+    this._hoursEl = this._el.querySelector('.gh-daily-meter-hours');
+    this._popupEl = this._el.querySelector('.gh-daily-meter-popup');
+  }
+
+  _bindEvents() {
+    if (!this._ringEl) {
+return;
+}
+
+    this._ringEl.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (this._isPopupOpen) {
+        this._closePopup();
+      } else {
+        this._openPopup();
+      }
+    });
+  }
+
+  // ════════════════════════════════════
+  // Ring Update
+  // ════════════════════════════════════
+
+  _updateRing(pct, totalHours) {
+    if (!this._circleEl) {
+return;
+}
+
+    const cappedPct = Math.min(pct, 100);
+    const offset = CIRCUMFERENCE - (cappedPct / 100) * CIRCUMFERENCE;
+    const state = this._getState(pct);
+
+    // Ring fill
+    this._circleEl.style.strokeDashoffset = offset;
+    this._circleEl.className = `gh-daily-meter-fill state-${state}`;
+
+    // Center text — always white
+    this._pctEl.textContent = Math.round(pct) + '%';
+    this._hoursEl.textContent = this._fmt(totalHours);
+
+    // Glow & pulse
+    this._ringEl.className = 'gh-daily-meter-ring';
+    if (totalHours > 0) {
+      this._ringEl.classList.add(`glow-${state}`);
+      if (state === 'green') {
+this._ringEl.classList.add('pulse-green');
+}
+      if (state === 'red') {
+this._ringEl.classList.add('pulse-red');
+}
+    }
+  }
+
+  _getState(pct) {
+    if (pct > 100) {
+return 'red';
+}
+    if (pct >= 95) {
+return 'green';
+}
+    if (pct >= 70) {
+return 'orange';
+}
+    return 'blue';
+  }
+
+  // ════════════════════════════════════
+  // Popup
+  // ════════════════════════════════════
+
+  _openPopup() {
+    this._isPopupOpen = true;
+    this._renderPopupContent();
+    this._popupEl.classList.add('open');
+
+    // Listen for outside clicks to close
+    setTimeout(() => {
+      document.addEventListener('click', this._onOutsideClick);
+    }, 0);
+  }
+
+  _closePopup() {
+    this._isPopupOpen = false;
+    if (this._popupEl) {
+      this._popupEl.classList.remove('open');
+    }
+    document.removeEventListener('click', this._onOutsideClick);
+  }
+
+  _handleOutsideClick(e) {
+    if (this._el && !this._el.contains(e.target)) {
+      this._closePopup();
+    }
+  }
+
+  _renderPopupContent() {
+    if (!this._popupEl) {
+return;
+}
+
+    const grouped = this._groupByClient(this._todayEntries);
+    const totalMinutes = this._todayEntries.reduce(
+      (sum, e) => sum + (e.minutes || 0), 0
+    );
+    const totalHours = totalMinutes / 60;
+    const remaining = Math.max(this._dailyTarget - totalHours, 0);
+    const isOver = totalHours > this._dailyTarget;
+
+    // Build client rows
+    let listHtml = '';
+    if (grouped.length === 0) {
+      listHtml = '<div class="gh-daily-meter-popup-empty">אין דיווחים להיום</div>';
+    } else {
+      listHtml = '<div class="gh-daily-meter-popup-list">';
+      for (const item of grouped) {
+        const isInternal = item.isInternal;
+        const dotColor = isInternal ? '#f59e0b' : '#3b82f6';
+        const rowClass = isInternal ? ' internal' : '';
+        listHtml += `
+          <div class="gh-daily-meter-popup-row${rowClass}">
+            <span class="gh-daily-meter-popup-row-name">
+              <span class="dot" style="background:${dotColor}"></span>
+              ${this._escapeHtml(item.name)}
+            </span>
+            <span class="gh-daily-meter-popup-row-hours">${this._fmt(item.hours)}</span>
+          </div>
+        `;
+      }
+      listHtml += '</div>';
+    }
+
+    // Status line
+    let statusHtml = '';
+    let statusClass = '';
+    if (isOver) {
+      const overBy = totalHours - this._dailyTarget;
+      statusHtml = `<i class="fas fa-exclamation-triangle" style="margin-left:4px"></i> חריגה של ${this._fmt(overBy)}`;
+      statusClass = 'status-over';
+    } else if (remaining <= 1 && remaining > 0) {
+      statusHtml = `<i class="fas fa-flag-checkered" style="margin-left:4px"></i> נותרו ${this._fmt(remaining)} — כמעט שם!`;
+      statusClass = 'status-almost';
+    } else if (remaining === 0) {
+      statusHtml = '<i class="fas fa-check-circle" style="margin-left:4px"></i> הגעת לתקן היומי!';
+      statusClass = 'status-done';
+    } else {
+      statusHtml = `<i class="fas fa-clock" style="margin-left:4px"></i> נותרו ${this._fmt(remaining)} שעות`;
+      statusClass = 'status-normal';
+    }
+
+    this._popupEl.innerHTML = `
+      <div class="gh-daily-meter-popup-header">
+        <span class="gh-daily-meter-popup-title">
+          <i class="fas fa-chart-pie"></i>
+          דיווח יומי
+        </span>
+        <button class="gh-daily-meter-popup-close" title="סגור">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+      ${listHtml}
+      <div class="gh-daily-meter-popup-divider"></div>
+      <div class="gh-daily-meter-popup-total">
+        <span>סה"כ</span>
+        <span>${this._fmt(totalHours)} / ${this._fmt(this._dailyTarget)}</span>
+      </div>
+      <div class="gh-daily-meter-popup-status ${statusClass}">
+        ${statusHtml}
+      </div>
+    `;
+
+    // Close button handler
+    const closeBtn = this._popupEl.querySelector('.gh-daily-meter-popup-close');
+    if (closeBtn) {
+      closeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._closePopup();
+      });
+    }
+  }
+
+  // ════════════════════════════════════
+  // Data Processing
+  // ════════════════════════════════════
+
+  _filterToday(entries) {
+    if (!entries || !entries.length) {
+return [];
+}
+    const todayStr = this._todayStr;
+
+    return entries.filter(e => {
+      if (!e.date) {
+return false;
+}
+      // entries store date as YYYY-MM-DD string
+      const entryDate = typeof e.date === 'string'
+        ? e.date.slice(0, 10)
+        : new Date(e.date).toISOString().slice(0, 10);
+      return entryDate === todayStr;
+    });
+  }
+
+  _groupByClient(entries) {
+    const map = new Map();
+
+    for (const entry of entries) {
+      const isInternal = !!entry.isInternal;
+      const key = isInternal ? '__internal__' : (entry.clientName || entry.caseNumber || 'לא ידוע');
+      const name = isInternal ? 'זמן פנימי' : key;
+
+      if (!map.has(key)) {
+        map.set(key, { name, isInternal, minutes: 0 });
+      }
+      map.get(key).minutes += (entry.minutes || 0);
+    }
+
+    // Convert to array with hours, sort: clients first, then internal
+    const result = [];
+    for (const item of map.values()) {
+      result.push({
+        name: item.name,
+        isInternal: item.isInternal,
+        hours: item.minutes / 60
+      });
+    }
+
+    result.sort((a, b) => {
+      if (a.isInternal !== b.isInternal) {
+return a.isInternal ? 1 : -1;
+}
+      return b.hours - a.hours;
+    });
+
+    return result;
+  }
+
+  // ════════════════════════════════════
+  // Overage Check
+  // ════════════════════════════════════
+
+  _checkOverage(totalHours) {
+    if (totalHours > this._dailyTarget && !this._overageAlertedToday) {
+      this._overageAlertedToday = true;
+      const msg = `עברת את התקן היומי! דווחו ${this._fmt(totalHours)} מתוך ${this._fmt(this._dailyTarget)} שעות`;
+      if (window.manager?.showNotification) {
+        window.manager.showNotification(msg, 'warning');
+      }
+    }
+  }
+
+  // ════════════════════════════════════
+  // Helpers
+  // ════════════════════════════════════
+
+  _fmt(h) {
+    const hrs = Math.floor(Math.abs(h));
+    const mins = Math.round((Math.abs(h) - hrs) * 60);
+    return `${hrs}:${String(mins).padStart(2, '0')}`;
+  }
+
+  _getTodayStr() {
+    const d = new Date();
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+
+  _escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str || '';
+    return div.innerHTML;
+  }
+
+  // ════════════════════════════════════
+  // CSS Injection (same pattern as sidebar)
+  // ════════════════════════════════════
+
+  _injectCSS() {
+    if (document.getElementById('gh-daily-meter-css')) {
+return;
+}
+
+    const link = document.createElement('link');
+    link.id = 'gh-daily-meter-css';
+    link.rel = 'stylesheet';
+    link.href = 'js/modules/components/sidebar/daily-meter.css';
+    document.head.appendChild(link);
+    this._cssElement = link;
+  }
+
+  _removeCSS() {
+    if (this._cssElement) {
+      this._cssElement.remove();
+      this._cssElement = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a circular progress ring to the sidebar footer showing daily reported hours vs. daily target
- Click to see per-client breakdown popup
- Real-time updates via existing Firestore listener
- Overage warning notification (once per day, non-blocking)

## Details
- **New files:** `daily-meter.js`, `daily-meter.css` (sidebar component)
- **Modified:** `main.js` (import, init, real-time hook)
- **Zero DB writes** — read-only UI component
- **Zero new queries** — uses data already in memory (`timesheetEntries`)
- **Target source:** `employee.dailyHoursTarget` (default 8.45)

## Visual states
| State | Range | Ring color |
|-------|-------|-----------|
| Working | 0-69% | Blue |
| Almost there | 70-94% | Orange |
| Target reached | 95-100% | Green (gentle pulse) |
| Over target | >100% | Red (gentle pulse + toast) |

## Test plan
- [ ] Login and verify ring appears in sidebar
- [ ] Report time entries — ring fills automatically
- [ ] Click ring — popup shows per-client breakdown
- [ ] Exceed daily target — warning toast appears once
- [ ] Delete entry — ring updates in real-time
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)