### PR TITLE
fix: daily meter duplicate guard + popup improvements

### DIFF
--- a/SYSTEM_STATUS.md
+++ b/SYSTEM_STATUS.md
@@ -2,9 +2,9 @@
 ## law-office-system-e4801
 
 **מנוהל על ידי:** טומי — ראש צוות הפיתוח
-**עדכון אחרון:** 2026-04-09
-**סטטוס:** Employee monthly timesheet report (HTML + CSV) — PROD
-**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191, #192, #194, #195, #197, #198, #199
+**עדכון אחרון:** 2026-04-12
+**סטטוס:** Daily reporting meter (sidebar ring) — PROD
+**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191, #192, #194, #195, #197, #198, #199, #200, #201
 
 ---
 
@@ -13,8 +13,8 @@
 ### Branches
 
 ```
-main:               ae4283b — Employee monthly timesheet report
-production-stable:  merged PR #199
+main:               9941561 — Daily reporting meter + fixes
+production-stable:  merged PR #201
 אין branches פתוחים.
 ```
 
@@ -66,6 +66,8 @@ production-stable:  merged PR #199
 | #197 | 9/4 | revert: remove broken employee report from PROD (cleanup) |
 | #198 | 9/4 | feat: Employee monthly timesheet report — merge feature branch with fixes |
 | #199 | 9/4 | feat: Employee monthly timesheet report (HTML + CSV) — PROD deploy. דוח שעתון עובד חודשי: כפתור "הפק דוח" בפרטי עובד, מודאל קומפקטי לבחירת חודש/פורמט, הפקת HTML עם לוגו + פירוט פנימי/לקוחות בנפרד, CSV עם BOM לעברית. כולל: popup blocker guard, CSV escaping (RFC 4180), double-click guard |
+| #200 | 12/4 | feat: Daily reporting meter (sidebar ring) — מד דיווח יומי עגול ב-sidebar footer. מציג אחוז התקדמות יומי מול תקן העובד (dailyHoursTarget). לחיצה פותחת popup עם פירוט לפי לקוחות + זמן פנימי. real-time updates, zero DB queries נוספות, התראת חריגה חד-פעמית. קבצים: `apps/user-app/js/modules/components/sidebar/daily-meter.js`, `daily-meter.css` |
+| #201 | 12/4 | deploy: Daily reporting meter to PROD |
 
 ---
 

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -52,10 +52,15 @@ export class DailyMeter {
 return;
 }
 
-    // Prevent duplicate initialization
-    if (this._el) {
+    // Prevent duplicate — if already in DOM, just update data
+    if (this._el && this._el.isConnected) {
       this.update(window.manager?.timesheetEntries || []);
       return;
+    }
+
+    // Clean up stale reference if element was removed from DOM
+    if (this._el && !this._el.isConnected) {
+      this._el = null;
     }
 
     this._injectCSS();

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -52,6 +52,12 @@ export class DailyMeter {
 return;
 }
 
+    // Prevent duplicate initialization
+    if (this._el) {
+      this.update(window.manager?.timesheetEntries || []);
+      return;
+    }
+
     this._injectCSS();
     this._render(container);
     this._bindEvents();


### PR DESCRIPTION
## Summary
- Fix duplicate ring on repeated loadData() calls (robust isConnected guard)
- Popup anchored to bottom (no clipping on long lists)
- "New" badge for 14 days

## Test plan
- [x] Verified in DEV — no duplicate rings on refresh/save
- [x] Popup displays correctly with long client lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)