### PR TITLE
fix(admin-panel): audit trail filter dropdown — match actual DB values

### DIFF
--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260415a">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260415a"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -97,6 +97,13 @@
   box-shadow: 0 0 0 2px rgb(59 130 246 / 10%);
 }
 
+.audit-filter-select optgroup {
+  font-weight: 600;
+  font-style: normal;
+  color: var(--gray-700);
+  background: #f3f4f6;
+}
+
 .audit-filter-btn {
   padding: 6px 14px;
   background: #2563eb;

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -88,7 +88,16 @@
     'RESOLVE_SERVICE_OVERDRAFT': 'פתרון חריגת שירות',
     'UNRESOLVE_SERVICE_OVERDRAFT': 'ביטול פתרון חריגה',
     'CREATE_TIMESHEET_ENTRY_V2': 'רישום שעות',
+    'CREATE_TIMESHEET_ENTRY': 'רישום שעות (גרסה קודמת)',
     'CREATE_USER': 'יצירת משתמש',
+    'delete_user_data_selective': 'מחיקת נתוני משתמש (חלקית)',
+    'ADD_SERVICE_TO_CASE': 'הוספת שירות לתיק',
+    'UPDATE_TASK_BY_ADMIN': 'עדכון משימה ע"י מנהל',
+    'TASK_UPDATED_BY_ADMIN': 'עדכון משימה ע"י מנהל',
+    'CREATE_CASE': 'יצירת תיק',
+    'MIGRATE_CLIENTS_TO_CASES': 'העברת לקוחות לתיקים',
+    'MIGRATE_CASES_TO_CLIENTS': 'העברת תיקים ללקוחות',
+    'ADD_PACKAGE_TO_STAGE': 'הוספת חבילה לשלב',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
   };
@@ -191,34 +200,70 @@
               <label>פעולה:</label>
               <select class="audit-filter-select" id="filter-action">
                 <option value="">הכל</option>
+
                 <optgroup label="כניסה/יציאה">
-                  <option value="login">כניסה</option>
-                  <option value="logout">יציאה</option>
+                  <option value="login">כניסה (~2,400)</option>
+                  <option value="logout">יציאה (8)</option>
                 </optgroup>
-                <optgroup label="משימות">
-                  <option value="create_task">יצירת משימה</option>
-                  <option value="edit_task">עריכת משימה</option>
-                  <option value="delete_task">מחיקת משימה</option>
-                  <option value="complete_task">השלמת משימה</option>
+
+                <optgroup label="משימות — פעילות משתמשים">
+                  <option value="create_task">יצירת משימה (משתמש) (~20)</option>
+                  <option value="complete_task">השלמת משימה (משתמש) (10)</option>
                 </optgroup>
+
+                <optgroup label="משימות — פעולות מנהל">
+                  <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
+                  <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
+                  <option value="CANCEL_TASK">ביטול משימה (~45)</option>
+                  <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
+                  <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
+                  <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
+                  <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
+                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
+                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
+                </optgroup>
+
                 <optgroup label="שעתון">
-                  <option value="create_timesheet">רישום שעות</option>
-                  <option value="edit_timesheet">עריכת שעות</option>
-                  <option value="delete_timesheet">מחיקת שעות</option>
+                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
+                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
+                  <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
-                <optgroup label="לקוחות">
-                  <option value="create_client">יצירת לקוח</option>
-                  <option value="edit_client">עריכת לקוח</option>
-                  <option value="delete_client">מחיקת לקוח</option>
+
+                <optgroup label="לקוחות ותיקים">
+                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
+                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
+                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
+
+                <optgroup label="שירותים וחבילות">
+                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
+                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                  <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
+                  <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
+                  <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
+                  <option value="REMOVE_SERVICE_OVERRIDE">הסרת ביטול חסימה (3)</option>
+                  <option value="RESOLVE_SERVICE_OVERDRAFT">פתרון חריגת שירות (1)</option>
+                  <option value="UNRESOLVE_SERVICE_OVERDRAFT">ביטול פתרון חריגה (1)</option>
+                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
+                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
+                </optgroup>
+
+                <optgroup label="הסכמי שכ״ט">
+                  <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
+                  <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
+                </optgroup>
+
                 <optgroup label="ניהול משתמשים">
-                  <option value="USER_CREATED">יצירת משתמש</option>
-                  <option value="USER_UPDATED">עדכון משתמש</option>
-                  <option value="USER_DELETED">מחיקת משתמש</option>
-                  <option value="USER_BLOCKED">חסימת משתמש</option>
+                  <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
+                  <option value="CREATE_USER">יצירת משתמש (7)</option>
+                  <option value="UPDATE_USER">עדכון משתמש (~30)</option>
+                  <option value="DELETE_USER">מחיקת משתמש (7)</option>
+                  <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
                 </optgroup>
+
                 <optgroup label="מערכת">
-                  <option value="system_config_updated">עדכון הגדרות</option>
+                  <option value="system_config_updated">עדכון הגדרות (6)</option>
                 </optgroup>
               </select>
             </div>


### PR DESCRIPTION
## Summary
- **Bug:** Audit trail filter dropdown returned 0 results for all options except "login" — dropdown values (lowercase) didn't match DB values (UPPER_SNAKE_CASE)
- **Fix:** Rebuilt dropdown with 38 values verified via empirical scan of 6,648 records across `activity_log` + `audit_log`, grouped into 9 Hebrew optgroups with approximate counts
- **Added** 9 missing Hebrew translations to `ACTION_LABELS` for DB values that had no translation (e.g. `CREATE_TIMESHEET_ENTRY` with 486 records)
- **CSS** styling for optgroup headers + cache-bust on JS/CSS references

## Files changed (3)
- `apps/admin-panel/js/ui/AuditTrailPage.js` — ACTION_LABELS additions + dropdown rebuild
- `apps/admin-panel/css/audit-trail.css` — optgroup styling
- `apps/admin-panel/audit-trail.html` — cache-bust `?v=20260415a`

## What does NOT change
- Filter logic (`_queryCollection`) — zero changes
- Firestore queries, writers, rules
- Existing ACTION_LABELS keys (only additions)
- Any other file

## Test plan
- [ ] Gate 1: Firestore verification script — 5 sample values exist in DB
- [ ] Gate 2: Dropdown loads with 38 options + 9 optgroups in Hebrew
- [ ] Gate 3: Filter returns >0 for VIEW_USER_DETAILS, CREATE_TIMESHEET_ENTRY, login, DELETE_FEE_AGREEMENT(=1)
- [ ] Gate 4: Hebrew display in action column for new translations
- [ ] Gate 5: No console errors, tabs + user/date filters still work
- [ ] Gate 6: optgroup styling correct in Edge (Chrome/Firefox not tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)