### PR TITLE
fix(admin-panel): audit trail — missing filter fixes from PR #208

### DIFF
--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css?v=20260416b">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260416c">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260416b"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260416c"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -382,6 +382,7 @@
       this.view = 'detail';
       this.selectedProfile = profile;
       this.entries = [];
+      this._allEntries = [];
       this.currentPage = 1;
       this.detailFilters = { action: '', dateFrom: '', dateTo: '' };
 
@@ -448,14 +449,15 @@
         self._applyDetailFilters();
       });
 
-      // Reset
+      // Reset — restore full list without re-fetching
       document.getElementById('btn-detail-reset').addEventListener('click', function() {
         document.getElementById('detail-filter-action').value = '';
         document.getElementById('detail-filter-from').value = '';
         document.getElementById('detail-filter-to').value = '';
         self.detailFilters = { action: '', dateFrom: '', dateTo: '' };
         self.currentPage = 1;
-        self._loadUserActivity();
+        self.entries = self._allEntries.slice();
+        self._renderActivityTable();
       });
     },
 
@@ -464,7 +466,39 @@
       this.detailFilters.dateFrom = document.getElementById('detail-filter-from').value;
       this.detailFilters.dateTo = document.getElementById('detail-filter-to').value;
       this.currentPage = 1;
-      this._loadUserActivity();
+      // Client-side filter only — no re-fetch
+      this._applyClientFilters();
+      this._renderActivityTable();
+    },
+
+    _applyClientFilters: function() {
+      const actionFilter = this.detailFilters.action;
+      const dateFrom = this.detailFilters.dateFrom;
+      const dateTo = this.detailFilters.dateTo;
+
+      let filtered = this._allEntries.slice();
+
+      if (actionFilter) {
+        filtered = filtered.filter(function(e) {
+          return e.action === actionFilter;
+        });
+      }
+
+      if (dateFrom) {
+        const fromMs = new Date(dateFrom).setHours(0, 0, 0, 0);
+        filtered = filtered.filter(function(e) {
+          return e.tsMillis >= fromMs;
+        });
+      }
+
+      if (dateTo) {
+        const toMs = new Date(dateTo).setHours(23, 59, 59, 999);
+        filtered = filtered.filter(function(e) {
+          return e.tsMillis <= toMs;
+        });
+      }
+
+      this.entries = filtered;
     },
 
     _loadUserActivity: async function() {
@@ -481,7 +515,6 @@
       const profile = this.selectedProfile;
       const uid = profile.authUID;
       const email = profile.email;
-      const actionFilter = this.detailFilters.action;
 
       try {
         // Query both collections — by userId (indexed) or email fallback
@@ -500,7 +533,7 @@
 
         // Merge and deduplicate by document id
         const seen = {};
-        let results = [];
+        const results = [];
 
         allResults.forEach(function(docs) {
           docs.forEach(function(item) {
@@ -516,18 +549,12 @@
           return b.tsMillis - a.tsMillis;
         });
 
+        // Store full dataset — filters work client-side only
+        this._allEntries = results;
         this.entries = results;
 
-        // Build action dropdown from actual data
+        // Build action dropdown from full data
         this._buildActionDropdown(results);
-
-        // Apply action filter if set
-        if (actionFilter) {
-          results = results.filter(function(e) {
-            return e.action === actionFilter;
-          });
-          this.entries = results;
-        }
 
         this._renderActivityTable();
 
@@ -542,23 +569,10 @@
     },
 
     _queryUserCollection: async function(collectionName, field, value) {
-      let query = this.db.collection(collectionName)
+      const query = this.db.collection(collectionName)
         .where(field, '==', value)
         .orderBy('timestamp', 'desc')
-        .limit(200);
-
-      // Date filters
-      if (this.detailFilters.dateFrom) {
-        const from = new Date(this.detailFilters.dateFrom);
-        from.setHours(0, 0, 0, 0);
-        query = query.where('timestamp', '>=', from);
-      }
-
-      if (this.detailFilters.dateTo) {
-        const to = new Date(this.detailFilters.dateTo);
-        to.setHours(23, 59, 59, 999);
-        query = query.where('timestamp', '<=', to);
-      }
+        .limit(500);
 
       try {
         const snapshot = await query.get();

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -480,21 +480,16 @@
 
       const profile = this.selectedProfile;
       const uid = profile.authUID;
-      const email = profile.email;
+      const actionFilter = this.detailFilters.action;
 
       try {
-        // Query both collections in parallel by userId
+        // Query both collections by userId (indexed)
         const queries = [];
 
         if (uid) {
           queries.push(this._queryUserCollection('audit_log', 'userId', uid));
           queries.push(this._queryUserCollection('activity_log', 'userId', uid));
         }
-
-        // Also query by email fields as fallback
-        queries.push(this._queryUserCollection('audit_log', 'performedBy', email));
-        queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
-        queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
 
         const allResults = await Promise.all(queries);
 
@@ -522,9 +517,9 @@
         this._buildActionDropdown(results);
 
         // Apply action filter if set
-        if (this.detailFilters.action) {
+        if (actionFilter) {
           results = results.filter(function(e) {
-            return e.action === self.detailFilters.action;
+            return e.action === actionFilter;
           });
           this.entries = results;
         }

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -480,15 +480,20 @@
 
       const profile = this.selectedProfile;
       const uid = profile.authUID;
+      const email = profile.email;
       const actionFilter = this.detailFilters.action;
 
       try {
-        // Query both collections by userId (indexed)
+        // Query both collections — by userId (indexed) or email fallback
         const queries = [];
 
         if (uid) {
           queries.push(this._queryUserCollection('audit_log', 'userId', uid));
           queries.push(this._queryUserCollection('activity_log', 'userId', uid));
+        } else {
+          // No authUID — fallback to email-based queries
+          queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
+          queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
         }
 
         const allResults = await Promise.all(queries);

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -427,6 +427,34 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "adminEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "activity_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
PR #208 was merged before these follow-up fixes landed on main. Bringing them in now:

- **Remove fallback queries** needing missing indexes (`performedBy`, `adminEmail`, `userEmail` with timestamp)
- **Email fallback** for users without `authUID`
- **Client-side filtering** instead of re-querying Firestore on filter
- **Cache-bust bump** to `v=20260416c` to force fresh asset load

## Why this is needed
After PR #208 merged, DEV showed these errors:
- `TypeError: Cannot read properties of undefined (reading 'action')` when clicking "סנן"
- `Query failed for audit_log.performedBy: The query requires an index`

These fixes resolve both.

## Test plan
- [ ] Open Admin Panel DEV → Audit Trail
- [ ] Click a user profile
- [ ] Select an action from dropdown → click "סנן" → results filter correctly
- [ ] Select a date range → click "סנן" → results filter correctly
- [ ] Click "נקה" → full list restored
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)