### PR TITLE
Deploy to PROD: audit trail — user profiles + security hardening

### DIFF
--- a/SYSTEM_STATUS.md
+++ b/SYSTEM_STATUS.md
@@ -2,9 +2,9 @@
 ## law-office-system-e4801
 
 **מנוהל על ידי:** טומי — ראש צוות הפיתוח
-**עדכון אחרון:** 2026-04-12
-**סטטוס:** Daily reporting meter (sidebar ring) — PROD
-**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191, #192, #194, #195, #197, #198, #199, #200, #201
+**עדכון אחרון:** 2026-04-14
+**סטטוס:** UI performance fixes — popup interaction lag eliminated — PROD
+**PRs:** #144, #145, #146, #166, #168, #169, #170, #171, #172, #173, #176, #177, #178, #183, #188, #189, #190, #191, #192, #194, #195, #197, #198, #199, #200, #201, #204
 
 ---
 
@@ -13,8 +13,8 @@
 ### Branches
 
 ```
-main:               9941561 — Daily reporting meter + fixes
-production-stable:  merged PR #201
+main:               9d1c989 — UI performance fixes
+production-stable:  merged PR #204
 אין branches פתוחים.
 ```
 
@@ -68,6 +68,7 @@ production-stable:  merged PR #201
 | #199 | 9/4 | feat: Employee monthly timesheet report (HTML + CSV) — PROD deploy. דוח שעתון עובד חודשי: כפתור "הפק דוח" בפרטי עובד, מודאל קומפקטי לבחירת חודש/פורמט, הפקת HTML עם לוגו + פירוט פנימי/לקוחות בנפרד, CSV עם BOM לעברית. כולל: popup blocker guard, CSV escaping (RFC 4180), double-click guard |
 | #200 | 12/4 | feat: Daily reporting meter (sidebar ring) — מד דיווח יומי עגול ב-sidebar footer. מציג אחוז התקדמות יומי מול תקן העובד (dailyHoursTarget). לחיצה פותחת popup עם פירוט לפי לקוחות + זמן פנימי. real-time updates, zero DB queries נוספות, התראת חריגה חד-פעמית. קבצים: `apps/user-app/js/modules/components/sidebar/daily-meter.js`, `daily-meter.css` |
 | #201 | 12/4 | deploy: Daily reporting meter to PROD |
+| #204 | 14/4 | perf: eliminate popup interaction lag — root cause היה backdrop-filter: blur(12px) על כל popups שגרם ל-GPU recomposite בכל keystroke/DOM change. הסרה מלאה של backdrop-filter, transition: all → ממוקד, animation 0.35s→0.15s, setTimeout(10)→requestAnimationFrame (11 מופעים). כולל: ActionFlowManager דילייים מלאכותיים (minLoadingDuration 200→0, closeDelay 500→150), GuidedTextInput DOM caching, _realTimeListenersStarted guard, 50 unit tests |
 
 ---
 

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css?v=20260416a">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260416b">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260416a"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260416b"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260415a">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260415a"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css?v=20260416c">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260417a">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260416c"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260417a"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css?v=20260416b">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260416c">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260416b"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260416c"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/audit-trail.css?v=20260415a">
+    <link rel="stylesheet" href="css/audit-trail.css?v=20260416a">
 </head>
 
 <body class="admin-page">
@@ -64,7 +64,7 @@
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260415a"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260416a"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -365,25 +365,3 @@
   color: var(--gray-400);
   font-size: 14px;
 }
-
-/* ═══════════════════════════════════════════
-   Responsive — Large Screens
-   ═══════════════════════════════════════════ */
-
-@media (width <= 1200px) {
-  .audit-filters {
-    flex-wrap: wrap;
-  }
-}
-
-@media (width >= 1600px) {
-  .audit-page {
-    max-width: 1400px;
-  }
-}
-
-@media (width >= 2400px) {
-  .audit-page {
-    max-width: 1900px;
-  }
-}

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -1,5 +1,5 @@
 /* ═══════════════════════════════════════════
-   Audit Trail Page Styles
+   Audit Trail — User Profiles View
    ═══════════════════════════════════════════ */
 
 .audit-page {
@@ -27,38 +27,309 @@
   color: var(--gray-400);
 }
 
-.audit-stats {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.audit-stat {
-  padding: 4px 12px;
-  background: var(--gray-100);
-  border-radius: 20px;
-  font-size: 12px;
-  color: var(--gray-600);
-  font-weight: 500;
-}
-
-.audit-stat strong {
-  color: var(--gray-900);
-}
-
 /* ═══════════════════════════════════════════
-   Filters Bar
-   ═══════════════════���═══════════════════════ */
+   Profile List — Search & Filters
+   ═══════════════════════════════════════════ */
 
-.audit-filters {
+.audit-profiles-toolbar {
   display: flex;
   gap: var(--space-3);
   align-items: center;
-  flex-wrap: nowrap;
   padding: var(--space-3) var(--space-4);
   background: white;
   border: 1px solid var(--gray-200);
   border-radius: var(--radius-lg);
   margin-bottom: var(--space-4);
+}
+
+.audit-search-box {
+  position: relative;
+  flex: 1;
+  max-width: 320px;
+}
+
+.audit-search-box input {
+  width: 100%;
+  padding: 8px 12px 8px 36px;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--gray-800);
+  background: white;
+}
+
+.audit-search-box input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgb(59 130 246 / 10%);
+}
+
+.audit-search-box i {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--gray-400);
+  font-size: 13px;
+}
+
+.audit-role-filter {
+  display: flex;
+  gap: 4px;
+  background: var(--gray-100);
+  padding: 3px;
+  border-radius: var(--radius-sm);
+}
+
+.audit-role-btn {
+  padding: 5px 12px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-600);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.audit-role-btn.active {
+  background: #2563eb;
+  color: white;
+  box-shadow: 0 1px 3px rgb(37 99 235 / 30%);
+}
+
+.audit-profiles-count {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-right: auto;
+}
+
+/* ═══════════════════════════════════════════
+   Profile Cards Grid
+   ═══════════════════════════════════════════ */
+
+.audit-profiles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.audit-profile-card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  cursor: pointer;
+  transition: all var(--transition-smooth);
+  position: relative;
+}
+
+.audit-profile-card:hover {
+  border-color: #3b82f6;
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.audit-profile-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.audit-profile-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
+}
+
+.audit-profile-avatar.admin { background: linear-gradient(135deg, #7c3aed, #9333ea); }
+
+.audit-profile-avatar.lawyer { background: linear-gradient(135deg, #2563eb, #3b82f6); }
+
+.audit-profile-avatar.employee { background: linear-gradient(135deg, #059669, #10b981); }
+
+.audit-profile-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.audit-profile-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--gray-900);
+  margin: 0 0 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-profile-email {
+  font-size: 12px;
+  color: var(--gray-500);
+  direction: ltr;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-profile-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.audit-profile-badges {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.audit-role-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.audit-role-badge.admin { background: #f3e8ff; color: #7c3aed; }
+
+.audit-role-badge.lawyer { background: #dbeafe; color: #2563eb; }
+
+.audit-role-badge.employee { background: #dcfce7; color: #059669; }
+
+.audit-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.audit-status-dot.active { background: #10b981; }
+
+.audit-status-dot.blocked { background: #ef4444; }
+
+.audit-profile-last-login {
+  font-size: 11px;
+  color: var(--gray-400);
+}
+
+.audit-profile-arrow {
+  position: absolute;
+  left: var(--space-4);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--gray-300);
+  font-size: 14px;
+  transition: all 0.15s;
+}
+
+.audit-profile-card:hover .audit-profile-arrow {
+  color: #3b82f6;
+  left: var(--space-3);
+}
+
+/* ═══════════════════════════════════════════
+   Profile Detail — Back Button & Header
+   ═══════════════════════════════════════════ */
+
+.audit-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--gray-100);
+  color: var(--gray-700);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  margin-bottom: var(--space-4);
+}
+
+.audit-back-btn:hover {
+  background: var(--gray-200);
+}
+
+.audit-profile-detail-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-4);
+}
+
+.audit-detail-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  font-weight: 600;
+  color: white;
+  flex-shrink: 0;
+}
+
+.audit-detail-avatar.admin { background: linear-gradient(135deg, #7c3aed, #9333ea); }
+
+.audit-detail-avatar.lawyer { background: linear-gradient(135deg, #2563eb, #3b82f6); }
+
+.audit-detail-avatar.employee { background: linear-gradient(135deg, #059669, #10b981); }
+
+.audit-detail-info h2 {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin: 0 0 4px;
+}
+
+.audit-detail-info .audit-detail-email {
+  font-size: 13px;
+  color: var(--gray-500);
+  direction: ltr;
+  text-align: right;
+}
+
+.audit-detail-badges {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-top: 6px;
+}
+
+/* ═══════════════════════════════════════════
+   Profile Detail — Filters
+   ═══════════════════════════════════════════ */
+
+.audit-detail-filters {
+  display: flex;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  margin-bottom: var(--space-4);
+  flex-wrap: nowrap;
   overflow-x: auto;
 }
 
@@ -132,37 +403,7 @@
 }
 
 /* ═══════════════════════════════════════════
-   Source Tabs
-   ═══════════════════════════════════════════ */
-
-.audit-source-tabs {
-  display: flex;
-  gap: 4px;
-  background: var(--gray-100);
-  padding: 3px;
-  border-radius: var(--radius-sm);
-}
-
-.audit-source-tab {
-  padding: 5px 12px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--gray-600);
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.audit-source-tab.active {
-  background: #2563eb;
-  color: white;
-  box-shadow: 0 1px 3px rgb(37 99 235 / 30%);
-}
-
-/* ═══════════════════════════════════════════
-   Log Table
+   Activity Log Table
    ═══════════════════════════════════════════ */
 
 .audit-table-wrapper {
@@ -239,23 +480,8 @@
 
 .audit-action-badge.other { background: var(--gray-100); color: var(--gray-600); }
 
-/* Severity indicators */
-.audit-severity {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  margin-left: 6px;
-}
-
-.audit-severity.info { background: #3b82f6; }
-
-.audit-severity.warning { background: #f59e0b; }
-
-.audit-severity.critical { background: #ef4444; }
-
 /* ═══════════════════════════════════════════
-   Details Cell
+   Detail Cells
    ═══════════════════════════════════════════ */
 
 .audit-details {
@@ -266,29 +492,28 @@
   text-overflow: ellipsis;
 }
 
-.audit-user-cell {
-  font-size: 13px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-/* Email addresses need LTR inside RTL context */
-.audit-user-cell.email-cell {
-  direction: ltr;
-  text-align: left;
-  font-size: 12px;
-}
-
 .audit-time-cell {
   font-size: 12px;
   color: var(--gray-500);
   white-space: nowrap;
 }
 
+.audit-target-cell {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.audit-target-cell.email-cell {
+  direction: ltr;
+  text-align: left;
+  font-size: 12px;
+}
+
 /* ═══════════════════════════════════════════
    Pagination
-   ════════════���══════════════════════════════ */
+   ═══════════════════════════════════════════ */
 
 .audit-pagination {
   display: flex;
@@ -335,7 +560,7 @@
 }
 
 /* ═══════════════════════════════════════════
-   Empty State
+   Empty & Loading States
    ═══════════════════════════════════════════ */
 
 .audit-empty {
@@ -355,10 +580,6 @@
   margin: 0;
 }
 
-/* ═══════════════════════════════════════════
-   Loading
-   ═══════════════════���═══════════════════════ */
-
 .audit-loading {
   text-align: center;
   padding: var(--space-8);
@@ -371,8 +592,23 @@
    ═══════════════════════════════════════════ */
 
 @media (width <= 1200px) {
-  .audit-filters {
+  .audit-profiles-toolbar {
     flex-wrap: wrap;
+  }
+
+  .audit-detail-filters {
+    flex-wrap: wrap;
+  }
+}
+
+@media (width <= 768px) {
+  .audit-profiles-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .audit-profile-detail-header {
+    flex-direction: column;
+    text-align: center;
   }
 }
 

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -365,3 +365,25 @@
   color: var(--gray-400);
   font-size: 14px;
 }
+
+/* ═══════════════════════════════════════════
+   Responsive
+   ═══════════════════════════════════════════ */
+
+@media (width <= 1200px) {
+  .audit-filters {
+    flex-wrap: wrap;
+  }
+}
+
+@media (width >= 1600px) {
+  .audit-page {
+    max-width: 1400px;
+  }
+}
+
+@media (width >= 2400px) {
+  .audit-page {
+    max-width: 1900px;
+  }
+}

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -365,3 +365,25 @@
   color: var(--gray-400);
   font-size: 14px;
 }
+
+/* ═══════════════════════════════════════════
+   Responsive — Large Screens
+   ═══════════════════════════════════════════ */
+
+@media (width <= 1200px) {
+  .audit-filters {
+    flex-wrap: wrap;
+  }
+}
+
+@media (width >= 1600px) {
+  .audit-page {
+    max-width: 1400px;
+  }
+}
+
+@media (width >= 2400px) {
+  .audit-page {
+    max-width: 1900px;
+  }
+}

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -97,6 +97,13 @@
   box-shadow: 0 0 0 2px rgb(59 130 246 / 10%);
 }
 
+.audit-filter-select optgroup {
+  font-weight: 600;
+  font-style: normal;
+  color: var(--gray-700);
+  background: #f3f4f6;
+}
+
 .audit-filter-btn {
   padding: 6px 14px;
   background: #2563eb;

--- a/apps/admin-panel/css/audit-trail.css
+++ b/apps/admin-panel/css/audit-trail.css
@@ -560,6 +560,28 @@
 }
 
 /* ═══════════════════════════════════════════
+   Warning Banner
+   ═══════════════════════════════════════════ */
+
+.audit-warning-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: #fef3c7;
+  color: #92400e;
+  border: 1px solid #fcd34d;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  margin: 0 0 var(--space-3);
+}
+
+.audit-warning-banner i {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+/* ═══════════════════════════════════════════
    Empty & Loading States
    ═══════════════════════════════════════════ */
 

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -382,6 +382,7 @@
       this.view = 'detail';
       this.selectedProfile = profile;
       this.entries = [];
+      this._allEntries = [];
       this.currentPage = 1;
       this.detailFilters = { action: '', dateFrom: '', dateTo: '' };
 
@@ -448,14 +449,15 @@
         self._applyDetailFilters();
       });
 
-      // Reset
+      // Reset — restore full list without re-fetching
       document.getElementById('btn-detail-reset').addEventListener('click', function() {
         document.getElementById('detail-filter-action').value = '';
         document.getElementById('detail-filter-from').value = '';
         document.getElementById('detail-filter-to').value = '';
         self.detailFilters = { action: '', dateFrom: '', dateTo: '' };
         self.currentPage = 1;
-        self._loadUserActivity();
+        self.entries = self._allEntries.slice();
+        self._renderActivityTable();
       });
     },
 
@@ -464,7 +466,39 @@
       this.detailFilters.dateFrom = document.getElementById('detail-filter-from').value;
       this.detailFilters.dateTo = document.getElementById('detail-filter-to').value;
       this.currentPage = 1;
-      this._loadUserActivity();
+      // Client-side filter only — no re-fetch
+      this._applyClientFilters();
+      this._renderActivityTable();
+    },
+
+    _applyClientFilters: function() {
+      const actionFilter = this.detailFilters.action;
+      const dateFrom = this.detailFilters.dateFrom;
+      const dateTo = this.detailFilters.dateTo;
+
+      let filtered = this._allEntries.slice();
+
+      if (actionFilter) {
+        filtered = filtered.filter(function(e) {
+          return e.action === actionFilter;
+        });
+      }
+
+      if (dateFrom) {
+        const fromMs = new Date(dateFrom).setHours(0, 0, 0, 0);
+        filtered = filtered.filter(function(e) {
+          return e.tsMillis >= fromMs;
+        });
+      }
+
+      if (dateTo) {
+        const toMs = new Date(dateTo).setHours(23, 59, 59, 999);
+        filtered = filtered.filter(function(e) {
+          return e.tsMillis <= toMs;
+        });
+      }
+
+      this.entries = filtered;
     },
 
     _loadUserActivity: async function() {
@@ -481,7 +515,6 @@
       const profile = this.selectedProfile;
       const uid = profile.authUID;
       const email = profile.email;
-      const actionFilter = this.detailFilters.action;
 
       try {
         // Query both collections — by userId (indexed) or email fallback
@@ -500,7 +533,7 @@
 
         // Merge and deduplicate by document id
         const seen = {};
-        let results = [];
+        const results = [];
 
         allResults.forEach(function(docs) {
           docs.forEach(function(item) {
@@ -516,18 +549,12 @@
           return b.tsMillis - a.tsMillis;
         });
 
+        // Store full dataset — filters work client-side only
+        this._allEntries = results;
         this.entries = results;
 
-        // Build action dropdown from actual data
+        // Build action dropdown from full data
         this._buildActionDropdown(results);
-
-        // Apply action filter if set
-        if (actionFilter) {
-          results = results.filter(function(e) {
-            return e.action === actionFilter;
-          });
-          this.entries = results;
-        }
 
         this._renderActivityTable();
 
@@ -542,23 +569,10 @@
     },
 
     _queryUserCollection: async function(collectionName, field, value) {
-      let query = this.db.collection(collectionName)
+      const query = this.db.collection(collectionName)
         .where(field, '==', value)
         .orderBy('timestamp', 'desc')
-        .limit(200);
-
-      // Date filters
-      if (this.detailFilters.dateFrom) {
-        const from = new Date(this.detailFilters.dateFrom);
-        from.setHours(0, 0, 0, 0);
-        query = query.where('timestamp', '>=', from);
-      }
-
-      if (this.detailFilters.dateTo) {
-        const to = new Date(this.detailFilters.dateTo);
-        to.setHours(23, 59, 59, 999);
-        query = query.where('timestamp', '<=', to);
-      }
+        .limit(500);
 
       try {
         const snapshot = await query.get();

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -201,61 +201,60 @@
               <select class="audit-filter-select" id="filter-action">
                 <option value="">הכל</option>
 
-                <optgroup label="כניסה/יציאה" data-source="activity">
+                <optgroup label="כניסה/יציאה">
                   <option value="login">כניסה (~2,400)</option>
                   <option value="logout">יציאה (8)</option>
                 </optgroup>
 
-                <optgroup label="משימות — משתמש" data-source="activity">
-                  <option value="create_task">יצירת משימה — activity (~20)</option>
-                  <option value="complete_task">השלמת משימה — activity (10)</option>
-                  <option value="CREATE_TASK">יצירת משימה (~700)</option>
-                  <option value="COMPLETE_TASK">השלמת משימה (~300)</option>
+                <optgroup label="משימות — פעילות משתמשים">
+                  <option value="create_task">יצירת משימה (משתמש) (~20)</option>
+                  <option value="complete_task">השלמת משימה (משתמש) (10)</option>
+                </optgroup>
+
+                <optgroup label="משימות — פעולות מנהל">
+                  <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
+                  <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
                   <option value="CANCEL_TASK">ביטול משימה (~45)</option>
                   <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
                   <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
                   <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
-                </optgroup>
-
-                <optgroup label="שעתון — משתמש" data-source="activity">
-                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
-                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
-                </optgroup>
-
-                <optgroup label="לקוחות ותיקים — משתמש" data-source="activity">
-                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
-                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
-                  <option value="CREATE_CASE">יצירת תיק (6)</option>
-                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
-                </optgroup>
-
-                <optgroup label="משימות — מנהל" data-source="audit">
                   <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
                   <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
+                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
                 </optgroup>
 
-                <optgroup label="שעתון — מנהל" data-source="audit">
+                <optgroup label="שעתון">
+                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
+                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
                   <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
 
-                <optgroup label="לקוחות ושירותים — מנהל" data-source="audit">
-                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
-                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
-                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
+                <optgroup label="לקוחות ותיקים">
+                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
+                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
+                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
+                </optgroup>
+
+                <optgroup label="שירותים וחבילות">
+                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
+                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
                   <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
                   <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
                   <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
                   <option value="REMOVE_SERVICE_OVERRIDE">הסרת ביטול חסימה (3)</option>
                   <option value="RESOLVE_SERVICE_OVERDRAFT">פתרון חריגת שירות (1)</option>
                   <option value="UNRESOLVE_SERVICE_OVERDRAFT">ביטול פתרון חריגה (1)</option>
+                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
+                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
                 </optgroup>
 
-                <optgroup label="הסכמי שכ״ט — מנהל" data-source="audit">
+                <optgroup label="הסכמי שכ״ט">
                   <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
                   <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
                 </optgroup>
 
-                <optgroup label="ניהול משתמשים — מנהל" data-source="audit">
+                <optgroup label="ניהול משתמשים">
                   <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
                   <option value="CREATE_USER">יצירת משתמש (7)</option>
                   <option value="UPDATE_USER">עדכון משתמש (~30)</option>
@@ -263,13 +262,8 @@
                   <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
                 </optgroup>
 
-                <optgroup label="מערכת — מנהל" data-source="audit">
+                <optgroup label="מערכת">
                   <option value="system_config_updated">עדכון הגדרות (6)</option>
-                </optgroup>
-
-                <optgroup label="פעולות מערכת (legacy)">
-                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
-                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
               </select>
             </div>
@@ -314,7 +308,6 @@
 });
           tab.classList.add('active');
           self.source = tab.dataset.source;
-          self._updateDropdownBySource();
           self.currentPage = 1;
           self.loadData();
         });
@@ -332,7 +325,6 @@
         document.getElementById('filter-date-from').value = '';
         document.getElementById('filter-date-to').value = '';
         self.filters = { action: '', user: '', dateFrom: '', dateTo: '' };
-        self._updateDropdownBySource();
         self.currentPage = 1;
         self.loadData();
       });
@@ -352,32 +344,6 @@
       this.filters.dateTo = document.getElementById('filter-date-to').value;
       this.currentPage = 1;
       this.loadData();
-    },
-
-    _updateDropdownBySource: function() {
-      const select = document.getElementById('filter-action');
-      if (!select) {
-return;
-}
-      const source = this.source;
-
-      const optgroups = select.querySelectorAll('optgroup[data-source]');
-      optgroups.forEach(function(og) {
-        const ogSource = og.getAttribute('data-source');
-        if (source === 'all') {
-          og.style.display = '';
-        } else {
-          og.style.display = (ogSource === source) ? '' : 'none';
-        }
-      });
-
-      // If selected option is inside a hidden optgroup — reset to "הכל"
-      const selectedOption = select.options[select.selectedIndex];
-      if (selectedOption && selectedOption.parentElement.tagName === 'OPTGROUP') {
-        if (selectedOption.parentElement.style.display === 'none') {
-          select.value = '';
-        }
-      }
     },
 
     // ═══════════════════════════════════════════

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -201,17 +201,17 @@
               <select class="audit-filter-select" id="filter-action">
                 <option value="">הכל</option>
 
-                <optgroup label="כניסה/יציאה">
+                <optgroup label="כניסה/יציאה" data-source="activity">
                   <option value="login">כניסה (~2,400)</option>
                   <option value="logout">יציאה (8)</option>
                 </optgroup>
 
-                <optgroup label="משימות — פעילות משתמשים">
+                <optgroup label="משימות — פעילות משתמשים" data-source="activity">
                   <option value="create_task">יצירת משימה (משתמש) (~20)</option>
                   <option value="complete_task">השלמת משימה (משתמש) (10)</option>
                 </optgroup>
 
-                <optgroup label="משימות — פעולות מנהל">
+                <optgroup label="משימות — פעולות מנהל" data-source="audit">
                   <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
                   <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
                   <option value="CANCEL_TASK">ביטול משימה (~45)</option>
@@ -223,20 +223,20 @@
                   <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
                 </optgroup>
 
-                <optgroup label="שעתון">
+                <optgroup label="שעתון" data-source="audit">
                   <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
                   <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
                   <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
 
-                <optgroup label="לקוחות ותיקים">
+                <optgroup label="לקוחות ותיקים" data-source="audit">
                   <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
                   <option value="CREATE_CASE">יצירת תיק (6)</option>
                   <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
                   <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
 
-                <optgroup label="שירותים וחבילות">
+                <optgroup label="שירותים וחבילות" data-source="audit">
                   <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
                   <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
                   <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
@@ -249,12 +249,12 @@
                   <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
                 </optgroup>
 
-                <optgroup label="הסכמי שכ״ט">
+                <optgroup label="הסכמי שכ״ט" data-source="audit">
                   <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
                   <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
                 </optgroup>
 
-                <optgroup label="ניהול משתמשים">
+                <optgroup label="ניהול משתמשים" data-source="audit">
                   <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
                   <option value="CREATE_USER">יצירת משתמש (7)</option>
                   <option value="UPDATE_USER">עדכון משתמש (~30)</option>
@@ -262,7 +262,7 @@
                   <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
                 </optgroup>
 
-                <optgroup label="מערכת">
+                <optgroup label="מערכת" data-source="audit">
                   <option value="system_config_updated">עדכון הגדרות (6)</option>
                 </optgroup>
               </select>
@@ -308,6 +308,7 @@
 });
           tab.classList.add('active');
           self.source = tab.dataset.source;
+          self._updateDropdownBySource();
           self.currentPage = 1;
           self.loadData();
         });
@@ -325,6 +326,7 @@
         document.getElementById('filter-date-from').value = '';
         document.getElementById('filter-date-to').value = '';
         self.filters = { action: '', user: '', dateFrom: '', dateTo: '' };
+        self._updateDropdownBySource();
         self.currentPage = 1;
         self.loadData();
       });
@@ -344,6 +346,32 @@
       this.filters.dateTo = document.getElementById('filter-date-to').value;
       this.currentPage = 1;
       this.loadData();
+    },
+
+    _updateDropdownBySource: function() {
+      const select = document.getElementById('filter-action');
+      if (!select) {
+return;
+}
+      const source = this.source;
+
+      const optgroups = select.querySelectorAll('optgroup[data-source]');
+      optgroups.forEach(function(og) {
+        const ogSource = og.getAttribute('data-source');
+        if (source === 'all') {
+          og.style.display = '';
+        } else {
+          og.style.display = (ogSource === source) ? '' : 'none';
+        }
+      });
+
+      // If selected option is inside a hidden optgroup — reset to "הכל"
+      const selectedOption = select.options[select.selectedIndex];
+      if (selectedOption && selectedOption.parentElement.tagName === 'OPTGROUP') {
+        if (selectedOption.parentElement.style.display === 'none') {
+          select.value = '';
+        }
+      }
     },
 
     // ═══════════════════════════════════════════

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -1,8 +1,13 @@
 /**
- * Audit Trail Page
- * =================
- * Displays activity_log and audit_log entries in a filterable table.
- * Reads directly from Firestore collections.
+ * Audit Trail Page — User Profiles
+ * ==================================
+ * Two views:
+ *   1. Profile list — all employees from Firestore
+ *   2. Profile detail — activity log for a single user
+ *
+ * Data sources:
+ *   - employees collection (profile list)
+ *   - audit_log + activity_log (user activity)
  */
 
 (function() {
@@ -10,176 +15,137 @@
 
   const PAGE_SIZE = 50;
 
-  // Action categories for badge colors
+  // ═══════════════════════════════════════════
+  // Action Categories & Labels (kept from original)
+  // ═══════════════════════════════════════════
+
   const ACTION_CATEGORIES = {
-    create: ['USER_CREATED', 'create_task', 'create_timesheet', 'create_client', 'CREATE_USER'],
-    update: ['USER_UPDATED', 'edit_task', 'edit_timesheet', 'edit_client', 'UPDATE_USER', 'extend_deadline', 'update_progress'],
-    delete: ['USER_DELETED', 'delete_task', 'delete_timesheet', 'delete_client', 'DELETE_USER', 'delete_user_data_selective'],
+    create: ['USER_CREATED', 'create_task', 'create_timesheet', 'create_client', 'CREATE_USER',
+      'CREATE_TASK', 'CREATE_CLIENT', 'CREATE_CASE', 'CREATE_TIMESHEET_ENTRY', 'CREATE_TIMESHEET_ENTRY_V2',
+      'ADD_SERVICE_TO_CLIENT', 'ADD_SERVICE_TO_CASE', 'ADD_SERVICE', 'ADD_PACKAGE',
+      'ADD_PACKAGE_TO_SERVICE', 'ADD_PACKAGE_TO_STAGE', 'CREATE_QUICK_LOG_ENTRY',
+      'UPLOAD_FEE_AGREEMENT', 'ADD_TIME_TO_TASK'],
+    update: ['USER_UPDATED', 'edit_task', 'edit_timesheet', 'edit_client', 'UPDATE_USER',
+      'extend_deadline', 'update_progress', 'COMPLETE_TASK', 'EXTEND_TASK_DEADLINE',
+      'ADJUST_BUDGET', 'UPDATE_CLIENT', 'CHANGE_CLIENT_STATUS', 'CLOSE_CASE',
+      'UPDATE_TASK_BY_ADMIN', 'TASK_UPDATED_BY_ADMIN', 'MOVE_TO_NEXT_STAGE',
+      'CHANGE_SERVICE_STATUS', 'COMPLETE_SERVICE', 'SET_SERVICE_OVERRIDE',
+      'REMOVE_SERVICE_OVERRIDE', 'RESOLVE_SERVICE_OVERDRAFT', 'UNRESOLVE_SERVICE_OVERDRAFT',
+      'complete_task', 'CANCEL_TASK',
+      'MIGRATE_CLIENTS_TO_CASES', 'MIGRATE_CASES_TO_CLIENTS'],
+    delete: ['USER_DELETED', 'delete_task', 'delete_timesheet', 'delete_client',
+      'DELETE_USER', 'delete_user_data_selective', 'DELETE_CLIENT', 'DELETE_SERVICE',
+      'DELETE_FEE_AGREEMENT'],
     block: ['USER_BLOCKED', 'USER_UNBLOCKED', 'block_client', 'unblock_client'],
     login: ['login', 'logout'],
     config: ['system_config_updated', 'system_config_rollback']
   };
 
-  // Role-based action classification
-  const USER_ACTIONS = [
-    // activity_log (lowercase)
-    'login', 'logout', 'create_task', 'edit_task', 'delete_task',
-    'complete_task', 'extend_deadline', 'update_progress',
-    'create_timesheet', 'edit_timesheet', 'delete_timesheet',
-    'create_client', 'edit_client', 'delete_client', 'block_client', 'unblock_client',
-    'generate_report', 'export_data',
-    // audit_log (UPPERCASE — user-initiated via Functions)
-    'CREATE_TASK', 'COMPLETE_TASK', 'CANCEL_TASK', 'EXTEND_TASK_DEADLINE',
-    'ADJUST_BUDGET', 'ADD_TIME_TO_TASK', 'CREATE_TIMESHEET_ENTRY_V2',
-    'CREATE_TIMESHEET_ENTRY', 'CREATE_CLIENT', 'ADD_SERVICE_TO_CLIENT',
-    'CREATE_CASE', 'ADD_SERVICE_TO_CASE'
-  ];
-
-  const ADMIN_ACTIONS = [
-    // User management
-    'VIEW_USER_DETAILS', 'CREATE_USER', 'UPDATE_USER', 'DELETE_USER',
-    'USER_CREATED', 'USER_UPDATED', 'USER_DELETED', 'USER_BLOCKED', 'USER_UNBLOCKED',
-    'delete_user_data_selective',
-    // Tasks — admin
-    'UPDATE_TASK_BY_ADMIN', 'TASK_UPDATED_BY_ADMIN', 'MOVE_TO_NEXT_STAGE',
-    // Timesheet — admin
-    'CREATE_QUICK_LOG_ENTRY',
-    // Clients & cases — admin
-    'UPDATE_CLIENT', 'DELETE_CLIENT', 'CHANGE_CLIENT_STATUS', 'CLOSE_CASE',
-    // Services & packages — admin
-    'ADD_SERVICE', 'ADD_PACKAGE', 'DELETE_SERVICE',
-    'CHANGE_SERVICE_STATUS', 'COMPLETE_SERVICE',
-    'SET_SERVICE_OVERRIDE', 'REMOVE_SERVICE_OVERRIDE',
-    'RESOLVE_SERVICE_OVERDRAFT', 'UNRESOLVE_SERVICE_OVERDRAFT',
-    'ADD_PACKAGE_TO_SERVICE', 'ADD_PACKAGE_TO_STAGE',
-    // Fee agreements
-    'UPLOAD_FEE_AGREEMENT', 'DELETE_FEE_AGREEMENT',
-    // System config
-    'system_config_updated', 'system_config_rollback',
-    // Migration (admin-initiated)
-    'MIGRATE_CLIENTS_TO_CASES', 'MIGRATE_CASES_TO_CLIENTS'
-  ];
-
-  function getActionCategory(action) {
-    for (const [cat, actions] of Object.entries(ACTION_CATEGORIES)) {
-      if (actions.includes(action)) {
- return cat;
-}
-    }
-    return 'other';
-  }
-
-  // Hebrew action labels
   const ACTION_LABELS = {
-    // User activity (lowercase)
-    'login': 'כניסה',
-    'logout': 'יציאה',
-    'create_task': 'יצירת משימה',
-    'edit_task': 'עריכת משימה',
-    'delete_task': 'מחיקת משימה',
-    'complete_task': 'השלמת משימה',
-    'extend_deadline': 'הארכת דדליין',
-    'update_progress': 'עדכון התקדמות',
-    'create_timesheet': 'רישום שעות',
-    'edit_timesheet': 'עריכת שעות',
-    'delete_timesheet': 'מחיקת שעות',
-    'create_client': 'יצירת לקוח',
-    'edit_client': 'עריכת לקוח',
-    'delete_client': 'מחיקת לקוח',
-    'block_client': 'חסימת לקוח',
-    'unblock_client': 'ביטול חסימת לקוח',
-    'generate_report': 'הפקת דוח',
-    'export_data': 'ייצוא נתונים',
-    // Admin actions (UPPERCASE — from audit_log)
-    'USER_CREATED': 'יצירת משתמש',
-    'USER_UPDATED': 'עדכון משתמש',
-    'USER_DELETED': 'מחיקת משתמש',
-    'USER_BLOCKED': 'חסימת משתמש',
-    'USER_UNBLOCKED': 'ביטול חסימה',
-    'CREATE_USER': 'יצירת משתמש',
-    'UPDATE_USER': 'עדכון משתמש',
-    'DELETE_USER': 'מחיקת משתמש',
-    'VIEW_USER_DETAILS': 'צפייה בפרטי משתמש',
-    'CREATE_TASK': 'יצירת משימה',
-    'COMPLETE_TASK': 'השלמת משימה',
-    'ADJUST_BUDGET': 'התאמת תקציב',
-    'EXTEND_TASK_DEADLINE': 'הארכת דדליין',
-    'CREATE_CLIENT': 'יצירת לקוח',
-    'UPDATE_CLIENT': 'עדכון לקוח',
-    'DELETE_CLIENT': 'מחיקת לקוח',
-    'CHANGE_CLIENT_STATUS': 'שינוי סטטוס לקוח',
-    'CLOSE_CASE': 'סגירת תיק',
-    'ADD_SERVICE': 'הוספת שירות',
-    'ADD_PACKAGE': 'הוספת חבילה',
-    'delete_user_data_selective': 'מחיקת נתוני משתמש',
-    'UPLOAD_FEE_AGREEMENT': 'העלאת הסכם שכ"ט',
-    'DELETE_FEE_AGREEMENT': 'מחיקת הסכם שכ"ט',
-    'ADD_TIME_TO_TASK': 'הוספת שעות למשימה',
-    'ADD_SERVICE_TO_CLIENT': 'הוספת שירות ללקוח',
-    'CREATE_QUICK_LOG_ENTRY': 'רישום שעות מהיר',
-    'CANCEL_TASK': 'ביטול משימה',
-    'MOVE_TO_NEXT_STAGE': 'מעבר לשלב הבא',
-    'ADD_PACKAGE_TO_SERVICE': 'הוספת חבילה לשירות',
-    'CHANGE_SERVICE_STATUS': 'שינוי סטטוס שירות',
-    'COMPLETE_SERVICE': 'השלמת שירות',
-    'DELETE_SERVICE': 'מחיקת שירות',
-    'SET_SERVICE_OVERRIDE': 'ביטול חסימת שירות',
-    'REMOVE_SERVICE_OVERRIDE': 'הסרת ביטול חסימה',
-    'RESOLVE_SERVICE_OVERDRAFT': 'פתרון חריגת שירות',
-    'UNRESOLVE_SERVICE_OVERDRAFT': 'ביטול פתרון חריגה',
-    'CREATE_TIMESHEET_ENTRY_V2': 'רישום שעות',
-    'CREATE_TIMESHEET_ENTRY': 'רישום שעות (גרסה קודמת)',
-    'CREATE_USER': 'יצירת משתמש',
-    'delete_user_data_selective': 'מחיקת נתוני משתמש (חלקית)',
-    'ADD_SERVICE_TO_CASE': 'הוספת שירות לתיק',
-    'UPDATE_TASK_BY_ADMIN': 'עדכון משימה ע"י מנהל',
-    'TASK_UPDATED_BY_ADMIN': 'עדכון משימה ע"י מנהל',
-    'CREATE_CASE': 'יצירת תיק',
-    'MIGRATE_CLIENTS_TO_CASES': 'העברת לקוחות לתיקים',
-    'MIGRATE_CASES_TO_CLIENTS': 'העברת תיקים ללקוחות',
-    'ADD_PACKAGE_TO_STAGE': 'הוספת חבילה לשלב',
-    'system_config_updated': 'עדכון הגדרות',
-    'system_config_rollback': 'שחזור הגדרות'
+    'login': '\u05db\u05e0\u05d9\u05e1\u05d4',
+    'logout': '\u05d9\u05e6\u05d9\u05d0\u05d4',
+    'create_task': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'edit_task': '\u05e2\u05e8\u05d9\u05db\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'delete_task': '\u05de\u05d7\u05d9\u05e7\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'complete_task': '\u05d4\u05e9\u05dc\u05de\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'extend_deadline': '\u05d4\u05d0\u05e8\u05db\u05ea \u05d3\u05d3\u05dc\u05d9\u05d9\u05df',
+    'update_progress': '\u05e2\u05d3\u05db\u05d5\u05df \u05d4\u05ea\u05e7\u05d3\u05de\u05d5\u05ea',
+    'create_timesheet': '\u05e8\u05d9\u05e9\u05d5\u05dd \u05e9\u05e2\u05d5\u05ea',
+    'edit_timesheet': '\u05e2\u05e8\u05d9\u05db\u05ea \u05e9\u05e2\u05d5\u05ea',
+    'delete_timesheet': '\u05de\u05d7\u05d9\u05e7\u05ea \u05e9\u05e2\u05d5\u05ea',
+    'create_client': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'edit_client': '\u05e2\u05e8\u05d9\u05db\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'delete_client': '\u05de\u05d7\u05d9\u05e7\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'block_client': '\u05d7\u05e1\u05d9\u05de\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'unblock_client': '\u05d1\u05d9\u05d8\u05d5\u05dc \u05d7\u05e1\u05d9\u05de\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'generate_report': '\u05d4\u05e4\u05e7\u05ea \u05d3\u05d5\u05d7',
+    'export_data': '\u05d9\u05d9\u05e6\u05d5\u05d0 \u05e0\u05ea\u05d5\u05e0\u05d9\u05dd',
+    'USER_CREATED': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05de\u05e9\u05ea\u05de\u05e9',
+    'USER_UPDATED': '\u05e2\u05d3\u05db\u05d5\u05df \u05de\u05e9\u05ea\u05de\u05e9',
+    'USER_DELETED': '\u05de\u05d7\u05d9\u05e7\u05ea \u05de\u05e9\u05ea\u05de\u05e9',
+    'USER_BLOCKED': '\u05d7\u05e1\u05d9\u05de\u05ea \u05de\u05e9\u05ea\u05de\u05e9',
+    'USER_UNBLOCKED': '\u05d1\u05d9\u05d8\u05d5\u05dc \u05d7\u05e1\u05d9\u05de\u05d4',
+    'CREATE_USER': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05de\u05e9\u05ea\u05de\u05e9',
+    'UPDATE_USER': '\u05e2\u05d3\u05db\u05d5\u05df \u05de\u05e9\u05ea\u05de\u05e9',
+    'DELETE_USER': '\u05de\u05d7\u05d9\u05e7\u05ea \u05de\u05e9\u05ea\u05de\u05e9',
+    'VIEW_USER_DETAILS': '\u05e6\u05e4\u05d9\u05d9\u05d4 \u05d1\u05e4\u05e8\u05d8\u05d9 \u05de\u05e9\u05ea\u05de\u05e9',
+    'CREATE_TASK': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'COMPLETE_TASK': '\u05d4\u05e9\u05dc\u05de\u05ea \u05de\u05e9\u05d9\u05de\u05d4',
+    'ADJUST_BUDGET': '\u05d4\u05ea\u05d0\u05de\u05ea \u05ea\u05e7\u05e6\u05d9\u05d1',
+    'EXTEND_TASK_DEADLINE': '\u05d4\u05d0\u05e8\u05db\u05ea \u05d3\u05d3\u05dc\u05d9\u05d9\u05df',
+    'CREATE_CLIENT': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'UPDATE_CLIENT': '\u05e2\u05d3\u05db\u05d5\u05df \u05dc\u05e7\u05d5\u05d7',
+    'DELETE_CLIENT': '\u05de\u05d7\u05d9\u05e7\u05ea \u05dc\u05e7\u05d5\u05d7',
+    'CHANGE_CLIENT_STATUS': '\u05e9\u05d9\u05e0\u05d5\u05d9 \u05e1\u05d8\u05d8\u05d5\u05e1 \u05dc\u05e7\u05d5\u05d7',
+    'CLOSE_CASE': '\u05e1\u05d2\u05d9\u05e8\u05ea \u05ea\u05d9\u05e7',
+    'ADD_SERVICE': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'ADD_PACKAGE': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05d7\u05d1\u05d9\u05dc\u05d4',
+    'delete_user_data_selective': '\u05de\u05d7\u05d9\u05e7\u05ea \u05e0\u05ea\u05d5\u05e0\u05d9 \u05de\u05e9\u05ea\u05de\u05e9',
+    'UPLOAD_FEE_AGREEMENT': '\u05d4\u05e2\u05dc\u05d0\u05ea \u05d4\u05e1\u05db\u05dd \u05e9\u05db"\u05d8',
+    'DELETE_FEE_AGREEMENT': '\u05de\u05d7\u05d9\u05e7\u05ea \u05d4\u05e1\u05db\u05dd \u05e9\u05db"\u05d8',
+    'ADD_TIME_TO_TASK': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05e9\u05e2\u05d5\u05ea \u05dc\u05de\u05e9\u05d9\u05de\u05d4',
+    'ADD_SERVICE_TO_CLIENT': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea \u05dc\u05dc\u05e7\u05d5\u05d7',
+    'CREATE_QUICK_LOG_ENTRY': '\u05e8\u05d9\u05e9\u05d5\u05dd \u05e9\u05e2\u05d5\u05ea \u05de\u05d4\u05d9\u05e8',
+    'CANCEL_TASK': '\u05d1\u05d9\u05d8\u05d5\u05dc \u05de\u05e9\u05d9\u05de\u05d4',
+    'MOVE_TO_NEXT_STAGE': '\u05de\u05e2\u05d1\u05e8 \u05dc\u05e9\u05dc\u05d1 \u05d4\u05d1\u05d0',
+    'ADD_PACKAGE_TO_SERVICE': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05d7\u05d1\u05d9\u05dc\u05d4 \u05dc\u05e9\u05d9\u05e8\u05d5\u05ea',
+    'CHANGE_SERVICE_STATUS': '\u05e9\u05d9\u05e0\u05d5\u05d9 \u05e1\u05d8\u05d8\u05d5\u05e1 \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'COMPLETE_SERVICE': '\u05d4\u05e9\u05dc\u05de\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'DELETE_SERVICE': '\u05de\u05d7\u05d9\u05e7\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'SET_SERVICE_OVERRIDE': '\u05d1\u05d9\u05d8\u05d5\u05dc \u05d7\u05e1\u05d9\u05de\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'REMOVE_SERVICE_OVERRIDE': '\u05d4\u05e1\u05e8\u05ea \u05d1\u05d9\u05d8\u05d5\u05dc \u05d7\u05e1\u05d9\u05de\u05d4',
+    'RESOLVE_SERVICE_OVERDRAFT': '\u05e4\u05ea\u05e8\u05d5\u05df \u05d7\u05e8\u05d9\u05d2\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'UNRESOLVE_SERVICE_OVERDRAFT': '\u05d1\u05d9\u05d8\u05d5\u05dc \u05e4\u05ea\u05e8\u05d5\u05df \u05d7\u05e8\u05d9\u05d2\u05d4',
+    'CREATE_TIMESHEET_ENTRY_V2': '\u05e8\u05d9\u05e9\u05d5\u05dd \u05e9\u05e2\u05d5\u05ea',
+    'CREATE_TIMESHEET_ENTRY': '\u05e8\u05d9\u05e9\u05d5\u05dd \u05e9\u05e2\u05d5\u05ea (\u05d2\u05e8\u05e1\u05d4 \u05e7\u05d5\u05d3\u05de\u05ea)',
+    'ADD_SERVICE_TO_CASE': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05e9\u05d9\u05e8\u05d5\u05ea \u05dc\u05ea\u05d9\u05e7',
+    'UPDATE_TASK_BY_ADMIN': '\u05e2\u05d3\u05db\u05d5\u05df \u05de\u05e9\u05d9\u05de\u05d4 \u05e2"\u05d9 \u05de\u05e0\u05d4\u05dc',
+    'TASK_UPDATED_BY_ADMIN': '\u05e2\u05d3\u05db\u05d5\u05df \u05de\u05e9\u05d9\u05de\u05d4 \u05e2"\u05d9 \u05de\u05e0\u05d4\u05dc',
+    'CREATE_CASE': '\u05d9\u05e6\u05d9\u05e8\u05ea \u05ea\u05d9\u05e7',
+    'MIGRATE_CLIENTS_TO_CASES': '\u05d4\u05e2\u05d1\u05e8\u05ea \u05dc\u05e7\u05d5\u05d7\u05d5\u05ea \u05dc\u05ea\u05d9\u05e7\u05d9\u05dd',
+    'MIGRATE_CASES_TO_CLIENTS': '\u05d4\u05e2\u05d1\u05e8\u05ea \u05ea\u05d9\u05e7\u05d9\u05dd \u05dc\u05dc\u05e7\u05d5\u05d7\u05d5\u05ea',
+    'ADD_PACKAGE_TO_STAGE': '\u05d4\u05d5\u05e1\u05e4\u05ea \u05d7\u05d1\u05d9\u05dc\u05d4 \u05dc\u05e9\u05dc\u05d1',
+    'system_config_updated': '\u05e2\u05d3\u05db\u05d5\u05df \u05d4\u05d2\u05d3\u05e8\u05d5\u05ea',
+    'system_config_rollback': '\u05e9\u05d7\u05d6\u05d5\u05e8 \u05d4\u05d2\u05d3\u05e8\u05d5\u05ea',
+    'VIEW_USER_ACTIVITY': '\u05e6\u05e4\u05d9\u05d9\u05d4 \u05d1\u05e4\u05e2\u05d9\u05dc\u05d5\u05ea \u05de\u05e9\u05ea\u05de\u05e9'
   };
 
-  // Hebrew labels for detail keys
   const DETAIL_KEY_LABELS = {
-    'targetEmail': 'משתמש',
-    'targetName': 'שם',
-    'targetRole': 'תפקיד',
-    'clientId': 'לקוח',
-    'clientName': 'לקוח',
-    'caseNumber': 'תיק',
-    'estimatedHours': 'שעות מוערכות',
-    'actualMinutes': 'דקות בפועל',
-    'minutes': 'זמן',
-    'gapPercent': 'חריגה',
-    'oldEstimate': 'הערכה קודמת',
-    'newEstimate': 'הערכה חדשה',
-    'addedMinutes': 'דקות שנוספו',
-    'reason': 'סיבה',
-    'note': 'הערה',
-    'role': 'תפקיד',
-    'status': 'סטטוס',
-    'message': 'הודעה',
-    'username': 'שם',
-    'changes': 'שינויים',
-    'fileName': 'קובץ',
-    'fileSize': 'גודל',
-    'serviceName': 'שירות',
-    'serviceType': 'סוג שירות',
-    'procedureType': 'סוג הליך',
-    'newDeadline': 'דדליין חדש',
-    'oldDeadline': 'דדליין קודם',
-    'date': 'תאריך',
-    'isInternal': 'פנימי',
-    'fromStageName': 'משלב',
-    'toStageName': 'לשלב',
-    'overrideActive': 'חסימה מבוטלת',
-    'resolved': 'נפתר'
+    'targetEmail': '\u05de\u05e9\u05ea\u05de\u05e9',
+    'targetName': '\u05e9\u05dd',
+    'targetRole': '\u05ea\u05e4\u05e7\u05d9\u05d3',
+    'clientId': '\u05dc\u05e7\u05d5\u05d7',
+    'clientName': '\u05dc\u05e7\u05d5\u05d7',
+    'caseNumber': '\u05ea\u05d9\u05e7',
+    'estimatedHours': '\u05e9\u05e2\u05d5\u05ea \u05de\u05d5\u05e2\u05e8\u05db\u05d5\u05ea',
+    'actualMinutes': '\u05d3\u05e7\u05d5\u05ea \u05d1\u05e4\u05d5\u05e2\u05dc',
+    'minutes': '\u05d6\u05de\u05df',
+    'gapPercent': '\u05d7\u05e8\u05d9\u05d2\u05d4',
+    'oldEstimate': '\u05d4\u05e2\u05e8\u05db\u05d4 \u05e7\u05d5\u05d3\u05de\u05ea',
+    'newEstimate': '\u05d4\u05e2\u05e8\u05db\u05d4 \u05d7\u05d3\u05e9\u05d4',
+    'addedMinutes': '\u05d3\u05e7\u05d5\u05ea \u05e9\u05e0\u05d5\u05e1\u05e4\u05d5',
+    'reason': '\u05e1\u05d9\u05d1\u05d4',
+    'note': '\u05d4\u05e2\u05e8\u05d4',
+    'role': '\u05ea\u05e4\u05e7\u05d9\u05d3',
+    'status': '\u05e1\u05d8\u05d8\u05d5\u05e1',
+    'message': '\u05d4\u05d5\u05d3\u05e2\u05d4',
+    'username': '\u05e9\u05dd',
+    'changes': '\u05e9\u05d9\u05e0\u05d5\u05d9\u05d9\u05dd',
+    'fileName': '\u05e7\u05d5\u05d1\u05e5',
+    'fileSize': '\u05d2\u05d5\u05d3\u05dc',
+    'serviceName': '\u05e9\u05d9\u05e8\u05d5\u05ea',
+    'serviceType': '\u05e1\u05d5\u05d2 \u05e9\u05d9\u05e8\u05d5\u05ea',
+    'procedureType': '\u05e1\u05d5\u05d2 \u05d4\u05dc\u05d9\u05da',
+    'newDeadline': '\u05d3\u05d3\u05dc\u05d9\u05d9\u05df \u05d7\u05d3\u05e9',
+    'oldDeadline': '\u05d3\u05d3\u05dc\u05d9\u05d9\u05df \u05e7\u05d5\u05d3\u05dd',
+    'date': '\u05ea\u05d0\u05e8\u05d9\u05da',
+    'isInternal': '\u05e4\u05e0\u05d9\u05de\u05d9',
+    'fromStageName': '\u05de\u05e9\u05dc\u05d1',
+    'toStageName': '\u05dc\u05e9\u05dc\u05d1',
+    'overrideActive': '\u05d7\u05e1\u05d9\u05de\u05d4 \u05de\u05d1\u05d5\u05d8\u05dc\u05ea',
+    'resolved': '\u05e0\u05e4\u05ea\u05e8'
   };
 
-  // Keys to skip in details (shown elsewhere or internal/technical)
   const DETAIL_SKIP_KEYS = [
     'entityId', 'loginTime', 'isCritical', '_seconds', '_nanoseconds',
     'targetEmail', 'targetUser', 'clientName', 'agreementId',
@@ -189,18 +155,30 @@
     'serviceId', 'fromStageId', 'toStageId'
   ];
 
+  const ROLE_LABELS = {
+    'admin': '\u05de\u05e0\u05d4\u05dc',
+    'lawyer': '\u05e2\u05d5"\u05d3',
+    'employee': '\u05e2\u05d5\u05d1\u05d3'
+  };
+
+  // ═══════════════════════════════════════════
+  // Main Page Object
+  // ═══════════════════════════════════════════
+
   const AuditTrailPage = {
     container: null,
     db: null,
+    view: 'profiles', // 'profiles' | 'detail'
+    profiles: [],
+    filteredProfiles: [],
+    selectedProfile: null,
     entries: [],
-    filteredEntries: [],
     currentPage: 1,
-    totalLoaded: 0,
     loading: false,
-    source: 'all', // 'all', 'user', 'admin'
-    filters: {
+    roleFilter: 'all',
+    searchQuery: '',
+    detailFilters: {
       action: '',
-      user: '',
       dateFrom: '',
       dateTo: ''
     },
@@ -213,423 +191,447 @@
 
       this.db = window.firebaseDB;
       if (!this.db) {
-        this.container.innerHTML = '<p>שגיאה: Firestore לא מאותחל</p>';
+        this.container.innerHTML = '<p>\u05e9\u05d2\u05d9\u05d0\u05d4: Firestore \u05dc\u05d0 \u05de\u05d0\u05d5\u05ea\u05d7\u05dc</p>';
         return;
       }
 
-      this.render();
-      this.loadData();
-    },
-
-    render: function() {
-      this.container.innerHTML = `
-        <div class="audit-page">
-          <div class="audit-header">
-            <h1><i class="fas fa-history"></i> לוג פעילות</h1>
-            <div class="audit-stats" id="audit-stats"></div>
-          </div>
-
-          <div class="audit-filters">
-            <div class="audit-source-tabs" id="source-tabs">
-              <button class="audit-source-tab active" data-source="all">הכל</button>
-              <button class="audit-source-tab" data-source="user">פעילות משתמשים</button>
-              <button class="audit-source-tab" data-source="admin">פעולות מנהל</button>
-            </div>
-
-            <div class="audit-filter-group">
-              <label>פעולה:</label>
-              <select class="audit-filter-select" id="filter-action">
-                <option value="">הכל</option>
-
-                <!-- ═══ User Actions ═══ -->
-                <optgroup label="כניסה/יציאה" data-source="user">
-                  <option value="login">כניסה (~2,400)</option>
-                  <option value="logout">יציאה (8)</option>
-                </optgroup>
-
-                <optgroup label="משימות (משתמש)" data-source="user">
-                  <option value="create_task">יצירת משימה — activity (20)</option>
-                  <option value="edit_task">עריכת משימה</option>
-                  <option value="delete_task">מחיקת משימה</option>
-                  <option value="complete_task">השלמת משימה — activity (10)</option>
-                  <option value="extend_deadline">הארכת דדליין — activity</option>
-                  <option value="update_progress">עדכון התקדמות</option>
-                  <option value="CREATE_TASK">יצירת משימה (~700)</option>
-                  <option value="COMPLETE_TASK">השלמת משימה (~300)</option>
-                  <option value="CANCEL_TASK">ביטול משימה (~45)</option>
-                  <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
-                  <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
-                  <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
-                </optgroup>
-
-                <optgroup label="שעתון (משתמש)" data-source="user">
-                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
-                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות — גרסה קודמת (~490)</option>
-                  <option value="create_timesheet">רישום שעות — activity</option>
-                  <option value="edit_timesheet">עריכת שעות</option>
-                  <option value="delete_timesheet">מחיקת שעות</option>
-                </optgroup>
-
-                <optgroup label="לקוחות ותיקים (משתמש)" data-source="user">
-                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
-                  <option value="CREATE_CASE">יצירת תיק (6)</option>
-                  <option value="create_client">יצירת לקוח — activity</option>
-                  <option value="edit_client">עריכת לקוח</option>
-                  <option value="delete_client">מחיקת לקוח</option>
-                  <option value="block_client">חסימת לקוח</option>
-                  <option value="unblock_client">ביטול חסימת לקוח</option>
-                </optgroup>
-
-                <optgroup label="שירותים (משתמש)" data-source="user">
-                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
-                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
-                </optgroup>
-
-                <optgroup label="דוחות (משתמש)" data-source="user">
-                  <option value="generate_report">הפקת דוח</option>
-                  <option value="export_data">ייצוא נתונים</option>
-                </optgroup>
-
-                <!-- ═══ Admin Actions ═══ -->
-                <optgroup label="ניהול משתמשים" data-source="admin">
-                  <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
-                  <option value="CREATE_USER">יצירת משתמש (7)</option>
-                  <option value="UPDATE_USER">עדכון משתמש (~30)</option>
-                  <option value="DELETE_USER">מחיקת משתמש (7)</option>
-                  <option value="USER_CREATED">יצירת משתמש — legacy</option>
-                  <option value="USER_UPDATED">עדכון משתמש — legacy</option>
-                  <option value="USER_DELETED">מחיקת משתמש — legacy</option>
-                  <option value="USER_BLOCKED">חסימת משתמש</option>
-                  <option value="USER_UNBLOCKED">ביטול חסימת משתמש</option>
-                  <option value="delete_user_data_selective">מחיקת נתוני משתמש — חלקית (~25)</option>
-                </optgroup>
-
-                <optgroup label="משימות (ניהול)" data-source="admin">
-                  <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
-                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה — legacy (3)</option>
-                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
-                </optgroup>
-
-                <optgroup label="שעתון (ניהול)" data-source="admin">
-                  <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
-                </optgroup>
-
-                <optgroup label="לקוחות ותיקים (ניהול)" data-source="admin">
-                  <option value="UPDATE_CLIENT">עדכון לקוח</option>
-                  <option value="DELETE_CLIENT">מחיקת לקוח</option>
-                  <option value="CHANGE_CLIENT_STATUS">שינוי סטטוס לקוח</option>
-                  <option value="CLOSE_CASE">סגירת תיק</option>
-                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
-                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
-                </optgroup>
-
-                <optgroup label="שירותים (ניהול)" data-source="admin">
-                  <option value="ADD_SERVICE">הוספת שירות</option>
-                  <option value="ADD_PACKAGE">הוספת חבילה</option>
-                  <option value="DELETE_SERVICE">מחיקת שירות</option>
-                  <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
-                  <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
-                  <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
-                  <option value="REMOVE_SERVICE_OVERRIDE">הסרת ביטול חסימה (3)</option>
-                  <option value="RESOLVE_SERVICE_OVERDRAFT">פתרון חריגת שירות (1)</option>
-                  <option value="UNRESOLVE_SERVICE_OVERDRAFT">ביטול פתרון חריגה (1)</option>
-                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
-                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
-                </optgroup>
-
-                <optgroup label="הסכמי שכ״ט" data-source="admin">
-                  <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
-                  <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
-                </optgroup>
-
-                <optgroup label="מערכת" data-source="admin">
-                  <option value="system_config_updated">עדכון הגדרות (6)</option>
-                  <option value="system_config_rollback">שחזור הגדרות</option>
-                </optgroup>
-              </select>
-            </div>
-
-            <div class="audit-filter-group">
-              <label>משתמש:</label>
-              <input type="text" class="audit-filter-input" id="filter-user" placeholder="מייל או שם..." dir="rtl">
-            </div>
-
-            <div class="audit-filter-group">
-              <label>מ:</label>
-              <input type="date" class="audit-filter-input" id="filter-date-from" lang="en">
-            </div>
-            <div class="audit-filter-group">
-              <label>עד:</label>
-              <input type="date" class="audit-filter-input" id="filter-date-to" lang="en">
-            </div>
-
-            <button class="audit-filter-btn" id="btn-apply-filters"><i class="fas fa-search"></i> סנן</button>
-            <button class="audit-filter-btn secondary" id="btn-reset-filters"><i class="fas fa-undo"></i> נקה</button>
-          </div>
-
-          <div class="audit-table-wrapper">
-            <div id="audit-table-content">
-              <div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> טוען נתונים...</div>
-            </div>
-          </div>
-        </div>
-      `;
-
-      this._bindEvents();
-    },
-
-    _bindEvents: function() {
-      const self = this;
-
-      // Source tabs
-      document.querySelectorAll('.audit-source-tab').forEach(function(tab) {
-        tab.addEventListener('click', function() {
-          document.querySelectorAll('.audit-source-tab').forEach(function(t) {
- t.classList.remove('active');
-});
-          tab.classList.add('active');
-          self.source = tab.dataset.source;
-          self._updateDropdownBySource();
-          self.currentPage = 1;
-          self.loadData();
-        });
-      });
-
-      // Apply filters
-      document.getElementById('btn-apply-filters').addEventListener('click', function() {
-        self._applyFilters();
-      });
-
-      // Reset filters
-      document.getElementById('btn-reset-filters').addEventListener('click', function() {
-        document.getElementById('filter-action').value = '';
-        document.getElementById('filter-user').value = '';
-        document.getElementById('filter-date-from').value = '';
-        document.getElementById('filter-date-to').value = '';
-        self.filters = { action: '', user: '', dateFrom: '', dateTo: '' };
-        self.currentPage = 1;
-        self.loadData();
-        self._updateDropdownBySource();
-      });
-
-      // Enter key on user filter
-      document.getElementById('filter-user').addEventListener('keypress', function(e) {
-        if (e.key === 'Enter') {
- self._applyFilters();
-}
-      });
-    },
-
-    _applyFilters: function() {
-      this.filters.action = document.getElementById('filter-action').value;
-      this.filters.user = document.getElementById('filter-user').value.trim().toLowerCase();
-      this.filters.dateFrom = document.getElementById('filter-date-from').value;
-      this.filters.dateTo = document.getElementById('filter-date-to').value;
-      this.currentPage = 1;
-      this.loadData();
-    },
-
-    _updateDropdownBySource: function() {
-      const select = document.getElementById('filter-action');
-      if (!select) {
-return;
-}
-      const source = this.source;
-
-      select.querySelectorAll('optgroup[data-source]').forEach(function(og) {
-        const ds = og.getAttribute('data-source');
-        if (source === 'all') {
-          og.style.display = '';
-        } else {
-          og.style.display = (ds === source) ? '' : 'none';
-        }
-      });
-
-      // If selected option is in a hidden optgroup — reset to "all"
-      const sel = select.options[select.selectedIndex];
-      if (sel && sel.parentElement.tagName === 'OPTGROUP' && sel.parentElement.style.display === 'none') {
-        select.value = '';
-      }
+      this._renderProfilesView();
+      this._loadProfiles();
     },
 
     // ═══════════════════════════════════════════
-    // Data Loading
-    // ═══════════��═══════════════════════════════
+    // View: Profile List
+    // ═══════════════════════════════════════════
 
-    loadData: async function() {
+    _renderProfilesView: function() {
+      this.view = 'profiles';
+      this.container.innerHTML =
+        '<div class="audit-page">' +
+          '<div class="audit-header">' +
+            '<h1><i class="fas fa-users"></i> \u05dc\u05d5\u05d2 \u05e4\u05e2\u05d9\u05dc\u05d5\u05ea</h1>' +
+          '</div>' +
+          '<div class="audit-profiles-toolbar">' +
+            '<div class="audit-search-box">' +
+              '<i class="fas fa-search"></i>' +
+              '<input type="text" id="profile-search" placeholder="\u05d7\u05d9\u05e4\u05d5\u05e9 \u05dc\u05e4\u05d9 \u05e9\u05dd \u05d0\u05d5 \u05de\u05d9\u05d9\u05dc..." dir="rtl">' +
+            '</div>' +
+            '<div class="audit-role-filter" id="role-filter">' +
+              '<button class="audit-role-btn active" data-role="all">\u05d4\u05db\u05dc</button>' +
+              '<button class="audit-role-btn" data-role="admin">\u05de\u05e0\u05d4\u05dc\u05d9\u05dd</button>' +
+              '<button class="audit-role-btn" data-role="lawyer">\u05e2\u05d5"\u05d3</button>' +
+              '<button class="audit-role-btn" data-role="employee">\u05e2\u05d5\u05d1\u05d3\u05d9\u05dd</button>' +
+            '</div>' +
+            '<span class="audit-profiles-count" id="profiles-count"></span>' +
+          '</div>' +
+          '<div id="profiles-grid" class="audit-profiles-grid">' +
+            '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> \u05d8\u05d5\u05e2\u05df \u05de\u05e9\u05ea\u05de\u05e9\u05d9\u05dd...</div>' +
+          '</div>' +
+        '</div>';
+
+      this._bindProfilesEvents();
+    },
+
+    _bindProfilesEvents: function() {
+      const self = this;
+
+      // Search
+      const searchInput = document.getElementById('profile-search');
+      if (searchInput) {
+        searchInput.addEventListener('input', function() {
+          self.searchQuery = searchInput.value.trim().toLowerCase();
+          self._filterAndRenderProfiles();
+        });
+      }
+
+      // Role filter buttons
+      document.querySelectorAll('.audit-role-btn').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          document.querySelectorAll('.audit-role-btn').forEach(function(b) {
+ b.classList.remove('active');
+});
+          btn.classList.add('active');
+          self.roleFilter = btn.dataset.role;
+          self._filterAndRenderProfiles();
+        });
+      });
+    },
+
+    _loadProfiles: async function() {
+      try {
+        const snapshot = await this.db.collection('employees').get();
+        this.profiles = [];
+        const self = this;
+
+        snapshot.forEach(function(doc) {
+          const data = doc.data();
+          self.profiles.push({
+            id: doc.id,
+            email: data.email || doc.id,
+            displayName: data.displayName || data.name || data.username || doc.id,
+            username: data.username || '',
+            role: data.role || 'employee',
+            isActive: data.isActive !== false && !data.disabled,
+            lastLogin: data.lastLogin || null,
+            authUID: data.authUID || ''
+          });
+        });
+
+        // Sort alphabetically by displayName
+        this.profiles.sort(function(a, b) {
+          return a.displayName.localeCompare(b.displayName, 'he');
+        });
+
+        this._filterAndRenderProfiles();
+      } catch (error) {
+        console.error('Error loading profiles:', error);
+        const grid = document.getElementById('profiles-grid');
+        if (grid) {
+          grid.innerHTML = '<div class="audit-empty"><i class="fas fa-exclamation-triangle"></i><p>\u05e9\u05d2\u05d9\u05d0\u05d4 \u05d1\u05d8\u05e2\u05d9\u05e0\u05ea \u05de\u05e9\u05ea\u05de\u05e9\u05d9\u05dd</p></div>';
+        }
+      }
+    },
+
+    _filterAndRenderProfiles: function() {
+      const self = this;
+      this.filteredProfiles = this.profiles.filter(function(p) {
+        // Role filter
+        if (self.roleFilter !== 'all' && p.role !== self.roleFilter) {
+ return false;
+}
+        // Search filter
+        if (self.searchQuery) {
+          const searchable = (p.displayName + ' ' + p.email + ' ' + p.username).toLowerCase();
+          if (!searchable.includes(self.searchQuery)) {
+ return false;
+}
+        }
+        return true;
+      });
+
+      this._renderProfileCards();
+    },
+
+    _renderProfileCards: function() {
+      const grid = document.getElementById('profiles-grid');
+      const countEl = document.getElementById('profiles-count');
+      if (!grid) {
+ return;
+}
+
+      if (countEl) {
+        countEl.textContent = this.filteredProfiles.length + ' \u05de\u05e9\u05ea\u05de\u05e9\u05d9\u05dd';
+      }
+
+      if (this.filteredProfiles.length === 0) {
+        grid.innerHTML = '<div class="audit-empty"><i class="fas fa-users"></i><p>\u05dc\u05d0 \u05e0\u05de\u05e6\u05d0\u05d5 \u05de\u05e9\u05ea\u05de\u05e9\u05d9\u05dd</p></div>';
+        return;
+      }
+
+      const self = this;
+      let html = '';
+
+      this.filteredProfiles.forEach(function(profile) {
+        const initial = _getInitial(profile.displayName);
+        const roleClass = profile.role;
+        const roleLabel = ROLE_LABELS[profile.role] || profile.role;
+        const statusClass = profile.isActive ? 'active' : 'blocked';
+        const statusTitle = profile.isActive ? '\u05e4\u05e2\u05d9\u05dc' : '\u05d7\u05e1\u05d5\u05dd';
+        const lastLoginStr = _formatLastLogin(profile.lastLogin);
+
+        html +=
+          '<div class="audit-profile-card" data-email="' + _escapeHtml(profile.email) + '">' +
+            '<div class="audit-profile-card-header">' +
+              '<div class="audit-profile-avatar ' + roleClass + '">' + _escapeHtml(initial) + '</div>' +
+              '<div class="audit-profile-info">' +
+                '<div class="audit-profile-name">' + _escapeHtml(profile.displayName) + '</div>' +
+                '<div class="audit-profile-email">' + _escapeHtml(profile.email) + '</div>' +
+              '</div>' +
+            '</div>' +
+            '<div class="audit-profile-meta">' +
+              '<div class="audit-profile-badges">' +
+                '<span class="audit-role-badge ' + roleClass + '">' + _escapeHtml(roleLabel) + '</span>' +
+                '<span class="audit-status-dot ' + statusClass + '" title="' + statusTitle + '"></span>' +
+              '</div>' +
+              '<span class="audit-profile-last-login">' + lastLoginStr + '</span>' +
+            '</div>' +
+            '<i class="fas fa-chevron-left audit-profile-arrow"></i>' +
+          '</div>';
+      });
+
+      grid.innerHTML = html;
+
+      // Bind click events on cards
+      grid.querySelectorAll('.audit-profile-card').forEach(function(card) {
+        card.addEventListener('click', function() {
+          const email = card.dataset.email;
+          const profile = self.profiles.find(function(p) {
+ return p.email === email;
+});
+          if (profile) {
+            self._openProfile(profile);
+          }
+        });
+      });
+    },
+
+    // ═══════════════════════════════════════════
+    // View: Profile Detail (Activity Log)
+    // ═══════════════════════════════════════════
+
+    _openProfile: function(profile) {
+      this.view = 'detail';
+      this.selectedProfile = profile;
+      this.entries = [];
+      this.currentPage = 1;
+      this.detailFilters = { action: '', dateFrom: '', dateTo: '' };
+
+      const roleClass = profile.role;
+      const roleLabel = ROLE_LABELS[profile.role] || profile.role;
+      const statusClass = profile.isActive ? 'active' : 'blocked';
+      const statusLabel = profile.isActive ? '\u05e4\u05e2\u05d9\u05dc' : '\u05d7\u05e1\u05d5\u05dd';
+      const initial = _getInitial(profile.displayName);
+
+      this.container.innerHTML =
+        '<div class="audit-page">' +
+          '<button class="audit-back-btn" id="btn-back"><i class="fas fa-arrow-right"></i> \u05d7\u05d6\u05e8\u05d4 \u05dc\u05e8\u05e9\u05d9\u05de\u05d4</button>' +
+          '<div class="audit-profile-detail-header">' +
+            '<div class="audit-detail-avatar ' + roleClass + '">' + _escapeHtml(initial) + '</div>' +
+            '<div class="audit-detail-info">' +
+              '<h2>' + _escapeHtml(profile.displayName) + '</h2>' +
+              '<div class="audit-detail-email">' + _escapeHtml(profile.email) + '</div>' +
+              '<div class="audit-detail-badges">' +
+                '<span class="audit-role-badge ' + roleClass + '">' + _escapeHtml(roleLabel) + '</span>' +
+                '<span class="audit-status-dot ' + statusClass + '" title="' + statusLabel + '"></span>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="audit-detail-filters">' +
+            '<div class="audit-filter-group">' +
+              '<label>\u05e4\u05e2\u05d5\u05dc\u05d4:</label>' +
+              '<select class="audit-filter-select" id="detail-filter-action">' +
+                '<option value="">\u05d4\u05db\u05dc</option>' +
+              '</select>' +
+            '</div>' +
+            '<div class="audit-filter-group">' +
+              '<label>\u05de:</label>' +
+              '<input type="date" class="audit-filter-input" id="detail-filter-from" lang="en">' +
+            '</div>' +
+            '<div class="audit-filter-group">' +
+              '<label>\u05e2\u05d3:</label>' +
+              '<input type="date" class="audit-filter-input" id="detail-filter-to" lang="en">' +
+            '</div>' +
+            '<button class="audit-filter-btn" id="btn-detail-filter"><i class="fas fa-search"></i> \u05e1\u05e0\u05df</button>' +
+            '<button class="audit-filter-btn secondary" id="btn-detail-reset"><i class="fas fa-undo"></i> \u05e0\u05e7\u05d4</button>' +
+          '</div>' +
+          '<div class="audit-table-wrapper">' +
+            '<div id="detail-table-content">' +
+              '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> \u05d8\u05d5\u05e2\u05df \u05e4\u05e2\u05d9\u05dc\u05d5\u05ea...</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+
+      this._bindDetailEvents();
+      this._loadUserActivity();
+    },
+
+    _bindDetailEvents: function() {
+      const self = this;
+
+      // Back button
+      document.getElementById('btn-back').addEventListener('click', function() {
+        self._renderProfilesView();
+        self._filterAndRenderProfiles();
+      });
+
+      // Filter
+      document.getElementById('btn-detail-filter').addEventListener('click', function() {
+        self._applyDetailFilters();
+      });
+
+      // Reset
+      document.getElementById('btn-detail-reset').addEventListener('click', function() {
+        document.getElementById('detail-filter-action').value = '';
+        document.getElementById('detail-filter-from').value = '';
+        document.getElementById('detail-filter-to').value = '';
+        self.detailFilters = { action: '', dateFrom: '', dateTo: '' };
+        self.currentPage = 1;
+        self._loadUserActivity();
+      });
+    },
+
+    _applyDetailFilters: function() {
+      this.detailFilters.action = document.getElementById('detail-filter-action').value;
+      this.detailFilters.dateFrom = document.getElementById('detail-filter-from').value;
+      this.detailFilters.dateTo = document.getElementById('detail-filter-to').value;
+      this.currentPage = 1;
+      this._loadUserActivity();
+    },
+
+    _loadUserActivity: async function() {
       if (this.loading) {
  return;
 }
       this.loading = true;
 
-      const content = document.getElementById('audit-table-content');
-      content.innerHTML = '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> טוען נתונים...</div>';
+      const content = document.getElementById('detail-table-content');
+      if (content) {
+        content.innerHTML = '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> \u05d8\u05d5\u05e2\u05df \u05e4\u05e2\u05d9\u05dc\u05d5\u05ea...</div>';
+      }
+
+      const profile = this.selectedProfile;
+      const uid = profile.authUID;
+      const email = profile.email;
 
       try {
+        // Query both collections in parallel by userId
+        const queries = [];
+
+        if (uid) {
+          queries.push(this._queryUserCollection('audit_log', 'userId', uid));
+          queries.push(this._queryUserCollection('activity_log', 'userId', uid));
+        }
+
+        // Also query by email fields as fallback
+        queries.push(this._queryUserCollection('audit_log', 'performedBy', email));
+        queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
+        queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
+
+        const allResults = await Promise.all(queries);
+
+        // Merge and deduplicate by document id
+        const seen = {};
         let results = [];
 
-        // Always query both collections in parallel
-        const [activityDocs, auditDocs] = await Promise.all([
-          this._queryCollection('activity_log'),
-          this._queryCollection('audit_log')
-        ]);
-
-        // Map activity_log docs
-        activityDocs.forEach(function(doc) {
-          const data = doc.data();
-          const displayUser = data.username || data.userEmail || _emailFromUid(data.userId) || '';
-          results.push({
-            id: doc.id,
-            source: 'activity',
-            action: data.action || data.type || '',
-            user: displayUser,
-            username: data.username || '',
-            target: data.targetUser || '',
-            details: data.details || '',
-            severity: data.severity || 'info',
-            timestamp: data.timestamp,
-            timestampLocal: data.timestampLocal || null
+        allResults.forEach(function(docs) {
+          docs.forEach(function(item) {
+            if (!seen[item.id]) {
+              seen[item.id] = true;
+              results.push(item);
+            }
           });
         });
-
-        // Map audit_log docs
-        auditDocs.forEach(function(doc) {
-          const data = doc.data();
-          const displayUser = data.performedByName || data.username || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
-          const det = _parseDetails(data.details);
-          let target = data.targetUser || data.targetUserEmail || '';
-          if (!target) {
-            target = det.targetEmail || det.targetUser || det.clientName || '';
-          }
-          results.push({
-            id: doc.id,
-            source: 'audit',
-            action: data.action || '',
-            user: displayUser,
-            username: data.performedByName || data.username || '',
-            target: target,
-            details: data.details || '',
-            severity: data.severity || 'info',
-            timestamp: data.timestamp,
-            timestampLocal: data.timestampLocal || null
-          });
-        });
-
-        // Filter by role
-        if (this.source === 'user') {
-          results = results.filter(function(e) {
- return USER_ACTIONS.includes(e.action);
-});
-        } else if (this.source === 'admin') {
-          results = results.filter(function(e) {
- return ADMIN_ACTIONS.includes(e.action);
-});
-        }
 
         // Sort by timestamp desc
         results.sort(function(a, b) {
-          const ta = a.timestamp?.toMillis?.() || 0;
-          const tb = b.timestamp?.toMillis?.() || 0;
-          return tb - ta;
+          return b.tsMillis - a.tsMillis;
         });
 
         this.entries = results;
-        this.totalLoaded = results.length;
-        this._renderTable();
-        this._renderStats();
+
+        // Build action dropdown from actual data
+        this._buildActionDropdown(results);
+
+        // Apply action filter if set
+        if (this.detailFilters.action) {
+          results = results.filter(function(e) {
+            return e.action === self.detailFilters.action;
+          });
+          this.entries = results;
+        }
+
+        this._renderActivityTable();
 
       } catch (error) {
-        console.error('Error loading audit data:', error);
-        content.innerHTML = '<div class="audit-empty"><i class="fas fa-exclamation-triangle"></i><p>שגיאה בטעינת נתונים</p></div>';
+        console.error('Error loading user activity:', error);
+        if (content) {
+          content.innerHTML = '<div class="audit-empty"><i class="fas fa-exclamation-triangle"></i><p>\u05e9\u05d2\u05d9\u05d0\u05d4 \u05d1\u05d8\u05e2\u05d9\u05e0\u05ea \u05e4\u05e2\u05d9\u05dc\u05d5\u05ea</p></div>';
+        }
       }
 
       this.loading = false;
     },
 
-    _queryCollection: async function(collectionName) {
+    _queryUserCollection: async function(collectionName, field, value) {
       let query = this.db.collection(collectionName)
+        .where(field, '==', value)
         .orderBy('timestamp', 'desc')
-        .limit(500);
+        .limit(200);
 
       // Date filters
-      if (this.filters.dateFrom) {
-        const from = new Date(this.filters.dateFrom);
+      if (this.detailFilters.dateFrom) {
+        const from = new Date(this.detailFilters.dateFrom);
         from.setHours(0, 0, 0, 0);
         query = query.where('timestamp', '>=', from);
       }
 
-      if (this.filters.dateTo) {
-        const to = new Date(this.filters.dateTo);
+      if (this.detailFilters.dateTo) {
+        const to = new Date(this.detailFilters.dateTo);
         to.setHours(23, 59, 59, 999);
         query = query.where('timestamp', '<=', to);
       }
 
-      const snapshot = await query.get();
-      const docs = [];
+      try {
+        const snapshot = await query.get();
+        const results = [];
 
-      snapshot.forEach(function(doc) {
- docs.push(doc);
-});
+        snapshot.forEach(function(doc) {
+          const data = doc.data();
+          const det = _parseDetails(data.details);
+          const target = data.targetUser || data.targetUserEmail || det.targetEmail || det.targetUser || det.clientName || '';
 
-      // Client-side filtering (action and user)
-      return docs.filter(function(doc) {
-        const data = doc.data();
+          results.push({
+            id: doc.id,
+            source: collectionName === 'audit_log' ? 'audit' : 'activity',
+            action: data.action || data.type || '',
+            target: target,
+            details: data.details || '',
+            severity: data.severity || 'info',
+            timestamp: data.timestamp,
+            timestampLocal: data.timestampLocal || null,
+            tsMillis: data.timestamp?.toMillis?.() || 0
+          });
+        });
 
-        if (this.filters.action) {
-          const docAction = data.action || data.type || '';
-          if (docAction !== this.filters.action) {
- return false;
-}
-        }
-
-        if (this.filters.user) {
-          const searchTerm = this.filters.user;
-          const userFields = [
-            data.userEmail, data.userId, data.username,
-            data.performedBy, data.adminEmail, data.performedByName,
-            data.targetUser, data.targetUserEmail
-          ].filter(Boolean).join(' ').toLowerCase();
-
-          if (!userFields.includes(searchTerm)) {
- return false;
-}
-        }
-
-        return true;
-      }.bind(this));
+        return results;
+      } catch (e) {
+        // Index might not exist for some field combinations — return empty
+        console.warn('Query failed for ' + collectionName + '.' + field + ':', e.message);
+        return [];
+      }
     },
 
-    // ═══════════════════════════════════════════
-    // Rendering
-    // ═══════════════════════════════════════════
+    _buildActionDropdown: function(entries) {
+      const actionCounts = {};
+      entries.forEach(function(e) {
+        if (e.action) {
+          actionCounts[e.action] = (actionCounts[e.action] || 0) + 1;
+        }
+      });
 
-    _renderStats: function() {
-      const statsEl = document.getElementById('audit-stats');
-      if (!statsEl) {
+      const select = document.getElementById('detail-filter-action');
+      if (!select) {
  return;
 }
 
-      const userCount = this.entries.filter(function(e) {
- return USER_ACTIONS.includes(e.action);
-}).length;
-      const adminCount = this.entries.filter(function(e) {
- return ADMIN_ACTIONS.includes(e.action);
-}).length;
+      // Keep the "all" option
+      let html = '<option value="">\u05d4\u05db\u05dc (' + entries.length + ')</option>';
 
-      statsEl.innerHTML =
-        '<span class="audit-stat"><strong>' + this.entries.length + '</strong> רשומות</span>' +
-        '<span class="audit-stat"><strong>' + userCount + '</strong> משתמשים</span>' +
-        '<span class="audit-stat"><strong>' + adminCount + '</strong> ניהול</span>';
+      // Sort by count desc
+      const actions = Object.keys(actionCounts).sort(function(a, b) {
+        return actionCounts[b] - actionCounts[a];
+      });
+
+      actions.forEach(function(action) {
+        const label = ACTION_LABELS[action] || action;
+        html += '<option value="' + _escapeHtml(action) + '">' + _escapeHtml(label) + ' (' + actionCounts[action] + ')</option>';
+      });
+
+      select.innerHTML = html;
+
+      // Restore filter selection if set
+      if (this.detailFilters.action) {
+        select.value = this.detailFilters.action;
+      }
     },
 
-    _renderTable: function() {
-      const content = document.getElementById('audit-table-content');
+    _renderActivityTable: function() {
+      const content = document.getElementById('detail-table-content');
       if (!content) {
  return;
 }
 
       if (this.entries.length === 0) {
-        content.innerHTML = '<div class="audit-empty"><i class="fas fa-clipboard-list"></i><p>לא נמצאו רשומות</p></div>';
+        content.innerHTML = '<div class="audit-empty"><i class="fas fa-clipboard-list"></i><p>\u05dc\u05d0 \u05e0\u05de\u05e6\u05d0\u05d5 \u05e8\u05e9\u05d5\u05de\u05d5\u05ea</p></div>';
         return;
       }
 
@@ -640,45 +642,40 @@ return;
 
       let rows = '';
       pageEntries.forEach(function(entry) {
-        const cat = getActionCategory(entry.action);
+        const cat = _getActionCategory(entry.action);
         const actionLabel = ACTION_LABELS[entry.action] || entry.action;
         const timeStr = _formatTimestamp(entry.timestamp, entry.timestampLocal);
         const detailsStr = _formatDetails(entry.details);
         const sourceIcon = entry.source === 'audit'
-          ? '<i class="fas fa-shield-alt" style="color:#9333ea;font-size:11px" title="פעולת מנהל"></i>'
-          : '<i class="fas fa-user" style="color:#6b7280;font-size:11px" title="פעילות משתמש"></i>';
+          ? '<i class="fas fa-shield-alt" style="color:#9333ea;font-size:11px" title="\u05e4\u05e2\u05d5\u05dc\u05ea \u05de\u05e0\u05d4\u05dc"></i>'
+          : '<i class="fas fa-user" style="color:#6b7280;font-size:11px" title="\u05e4\u05e2\u05d9\u05dc\u05d5\u05ea \u05de\u05e9\u05ea\u05de\u05e9"></i>';
 
-        const userCls = entry.user && entry.user.includes('@') ? 'audit-user-cell email-cell' : 'audit-user-cell';
-        const targetCls = entry.target && entry.target.includes('@') ? 'audit-user-cell email-cell' : 'audit-user-cell';
+        const targetCls = entry.target && entry.target.includes('@') ? 'audit-target-cell email-cell' : 'audit-target-cell';
 
         rows += '<tr>' +
           '<td style="text-align:center">' + sourceIcon + '</td>' +
           '<td class="audit-time-cell">' + timeStr + '</td>' +
           '<td><span class="audit-action-badge ' + cat + '">' + _escapeHtml(actionLabel) + '</span></td>' +
-          '<td class="' + userCls + '" title="' + _escapeHtml(entry.user) + '">' + _escapeHtml(entry.user) + '</td>' +
           '<td class="' + targetCls + '" title="' + _escapeHtml(entry.target || '') + '">' + _escapeHtml(entry.target || '') + '</td>' +
           '<td class="audit-details" title="' + _escapeHtml(detailsStr) + '">' + detailsStr + '</td>' +
           '</tr>';
       });
 
-      content.innerHTML = `
-        <table class="audit-table">
-          <thead>
-            <tr>
-              <th style="width:3%">סוג</th>
-              <th style="width:8%">זמן</th>
-              <th style="width:14%">פעולה</th>
-              <th style="width:10%">בוצע ע"י</th>
-              <th style="width:15%">נוגע ל</th>
-              <th style="width:50%">פרטים</th>
-            </tr>
-          </thead>
-          <tbody>${rows}</tbody>
-        </table>
-        ${this._renderPagination(totalPages)}
-      `;
+      content.innerHTML =
+        '<table class="audit-table">' +
+          '<thead>' +
+            '<tr>' +
+              '<th style="width:4%">\u05e1\u05d5\u05d2</th>' +
+              '<th style="width:10%">\u05d6\u05de\u05df</th>' +
+              '<th style="width:16%">\u05e4\u05e2\u05d5\u05dc\u05d4</th>' +
+              '<th style="width:18%">\u05e0\u05d5\u05d2\u05e2 \u05dc</th>' +
+              '<th style="width:52%">\u05e4\u05e8\u05d8\u05d9\u05dd</th>' +
+            '</tr>' +
+          '</thead>' +
+          '<tbody>' + rows + '</tbody>' +
+        '</table>' +
+        this._renderPagination(totalPages);
 
-      // Bind pagination
       this._bindPagination();
     },
 
@@ -701,11 +698,11 @@ return;
 
       btns += '<button class="audit-page-btn" data-page="next" ' + (self.currentPage >= totalPages ? 'disabled' : '') + '><i class="fas fa-chevron-left"></i></button>';
 
-      const start = (self.currentPage - 1) * PAGE_SIZE + 1;
-      const end = Math.min(self.currentPage * PAGE_SIZE, self.entries.length);
+      const rangeStart = (self.currentPage - 1) * PAGE_SIZE + 1;
+      const rangeEnd = Math.min(self.currentPage * PAGE_SIZE, self.entries.length);
 
       return '<div class="audit-pagination">' +
-        '<span class="audit-pagination-info">' + start + '-' + end + ' מתוך ' + self.entries.length + '</span>' +
+        '<span class="audit-pagination-info">' + rangeStart + '-' + rangeEnd + ' \u05de\u05ea\u05d5\u05da ' + self.entries.length + '</span>' +
         '<div class="audit-pagination-btns">' + btns + '</div>' +
         '</div>';
     },
@@ -724,9 +721,11 @@ return;
           } else if (page !== 'prev' && page !== 'next') {
             self.currentPage = parseInt(page);
           }
-          self._renderTable();
-          // Scroll to top of table
-          document.querySelector('.audit-table-wrapper')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          self._renderActivityTable();
+          const wrapper = document.querySelector('.audit-table-wrapper');
+          if (wrapper) {
+ wrapper.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
         });
       });
     }
@@ -736,25 +735,52 @@ return;
   // Utility Functions
   // ═══════════════════════════════════════════
 
-  /**
-   * If a field contains a raw Firebase UID (no @ sign, long alphanumeric),
-   * return empty string so we don't show it to the user.
-   */
-  function _emailFromUid(val) {
-    if (!val) {
- return '';
+  function _getInitial(name) {
+    if (!name) {
+ return '?';
 }
-    // If it looks like an email, return it
-    if (val.includes('@')) {
- return val;
-}
-    // Raw UID — don't display it
-    return '';
+    const parts = name.trim().split(/\s+/);
+    if (parts.length >= 2) {
+      return parts[0].charAt(0) + parts[1].charAt(0);
+    }
+    return parts[0].charAt(0);
   }
 
-  /**
-   * Parse details field — can be string (JSON) or object
-   */
+  function _formatLastLogin(ts) {
+    if (!ts) {
+ return '';
+}
+    try {
+      const date = ts.toDate ? ts.toDate() : new Date(ts);
+      const now = new Date();
+      const diff = now - date;
+      const days = Math.floor(diff / 86400000);
+      if (days === 0) {
+ return '\u05d4\u05d9\u05d5\u05dd';
+}
+      if (days === 1) {
+ return '\u05d0\u05ea\u05de\u05d5\u05dc';
+}
+      if (days < 7) {
+ return '\u05dc\u05e4\u05e0\u05d9 ' + days + ' \u05d9\u05de\u05d9\u05dd';
+}
+      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, '0');
+      return day + '/' + month + '/' + date.getFullYear();
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function _getActionCategory(action) {
+    for (const cat in ACTION_CATEGORIES) {
+      if (ACTION_CATEGORIES[cat].indexOf(action) !== -1) {
+ return cat;
+}
+    }
+    return 'other';
+  }
+
   function _parseDetails(details) {
     if (!details) {
  return {};
@@ -776,9 +802,8 @@ return;
     if (!ts && !localStr) {
  return '-';
 }
-
     try {
-      const date = ts?.toDate?.() || new Date(localStr);
+      const date = ts && ts.toDate ? ts.toDate() : new Date(localStr);
       const day = String(date.getDate()).padStart(2, '0');
       const month = String(date.getMonth() + 1).padStart(2, '0');
       const hours = String(date.getHours()).padStart(2, '0');
@@ -816,7 +841,7 @@ return;
 }
     const parts = [];
     keys.forEach(function(key) {
-      if (DETAIL_SKIP_KEYS.includes(key)) {
+      if (DETAIL_SKIP_KEYS.indexOf(key) !== -1) {
  return;
 }
       if (parts.length >= 3) {
@@ -844,12 +869,12 @@ return;
       if (val >= 60) {
         const h = Math.floor(val / 60);
         const m = val % 60;
-        return m > 0 ? h + ' שעות ' + m + ' דקות' : h + ' שעות';
+        return m > 0 ? h + ' \u05e9\u05e2\u05d5\u05ea ' + m + ' \u05d3\u05e7\u05d5\u05ea' : h + ' \u05e9\u05e2\u05d5\u05ea';
       }
-      return val + ' דקות';
+      return val + ' \u05d3\u05e7\u05d5\u05ea';
     }
     if (key === 'estimatedHours' && typeof val === 'number') {
-      return Math.round(val * 10) / 10 + ' שעות';
+      return Math.round(val * 10) / 10 + ' \u05e9\u05e2\u05d5\u05ea';
     }
     if (key === 'gapPercent' && typeof val === 'number') {
       return val + '%';
@@ -871,7 +896,7 @@ return;
       }
     }
     if (typeof val === 'boolean') {
-      return val ? 'כן' : 'לא';
+      return val ? '\u05db\u05df' : '\u05dc\u05d0';
     }
     return val;
   }
@@ -884,6 +909,6 @@ return;
   }
 
   window.AuditTrailPage = AuditTrailPage;
-  console.log('✅ Audit Trail Page loaded');
+  console.warn('AuditTrailPage loaded (user profiles)');
 
 })();

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -88,7 +88,16 @@
     'RESOLVE_SERVICE_OVERDRAFT': 'פתרון חריגת שירות',
     'UNRESOLVE_SERVICE_OVERDRAFT': 'ביטול פתרון חריגה',
     'CREATE_TIMESHEET_ENTRY_V2': 'רישום שעות',
+    'CREATE_TIMESHEET_ENTRY': 'רישום שעות (גרסה קודמת)',
     'CREATE_USER': 'יצירת משתמש',
+    'delete_user_data_selective': 'מחיקת נתוני משתמש (חלקית)',
+    'ADD_SERVICE_TO_CASE': 'הוספת שירות לתיק',
+    'UPDATE_TASK_BY_ADMIN': 'עדכון משימה ע"י מנהל',
+    'TASK_UPDATED_BY_ADMIN': 'עדכון משימה ע"י מנהל',
+    'CREATE_CASE': 'יצירת תיק',
+    'MIGRATE_CLIENTS_TO_CASES': 'העברת לקוחות לתיקים',
+    'MIGRATE_CASES_TO_CLIENTS': 'העברת תיקים ללקוחות',
+    'ADD_PACKAGE_TO_STAGE': 'הוספת חבילה לשלב',
     'system_config_updated': 'עדכון הגדרות',
     'system_config_rollback': 'שחזור הגדרות'
   };
@@ -191,34 +200,70 @@
               <label>פעולה:</label>
               <select class="audit-filter-select" id="filter-action">
                 <option value="">הכל</option>
+
                 <optgroup label="כניסה/יציאה">
-                  <option value="login">כניסה</option>
-                  <option value="logout">יציאה</option>
+                  <option value="login">כניסה (~2,400)</option>
+                  <option value="logout">יציאה (8)</option>
                 </optgroup>
-                <optgroup label="משימות">
-                  <option value="create_task">יצירת משימה</option>
-                  <option value="edit_task">עריכת משימה</option>
-                  <option value="delete_task">מחיקת משימה</option>
-                  <option value="complete_task">השלמת משימה</option>
+
+                <optgroup label="משימות — פעילות משתמשים">
+                  <option value="create_task">יצירת משימה (משתמש) (~20)</option>
+                  <option value="complete_task">השלמת משימה (משתמש) (10)</option>
                 </optgroup>
+
+                <optgroup label="משימות — פעולות מנהל">
+                  <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
+                  <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
+                  <option value="CANCEL_TASK">ביטול משימה (~45)</option>
+                  <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
+                  <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
+                  <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
+                  <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
+                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
+                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
+                </optgroup>
+
                 <optgroup label="שעתון">
-                  <option value="create_timesheet">רישום שעות</option>
-                  <option value="edit_timesheet">עריכת שעות</option>
-                  <option value="delete_timesheet">מחיקת שעות</option>
+                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
+                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
+                  <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
-                <optgroup label="לקוחות">
-                  <option value="create_client">יצירת לקוח</option>
-                  <option value="edit_client">עריכת לקוח</option>
-                  <option value="delete_client">מחיקת לקוח</option>
+
+                <optgroup label="לקוחות ותיקים">
+                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
+                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
+                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
+
+                <optgroup label="שירותים וחבילות">
+                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
+                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                  <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
+                  <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
+                  <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
+                  <option value="REMOVE_SERVICE_OVERRIDE">הסרת ביטול חסימה (3)</option>
+                  <option value="RESOLVE_SERVICE_OVERDRAFT">פתרון חריגת שירות (1)</option>
+                  <option value="UNRESOLVE_SERVICE_OVERDRAFT">ביטול פתרון חריגה (1)</option>
+                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
+                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
+                </optgroup>
+
+                <optgroup label="הסכמי שכ״ט">
+                  <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
+                  <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
+                </optgroup>
+
                 <optgroup label="ניהול משתמשים">
-                  <option value="USER_CREATED">יצירת משתמש</option>
-                  <option value="USER_UPDATED">עדכון משתמש</option>
-                  <option value="USER_DELETED">מחיקת משתמש</option>
-                  <option value="USER_BLOCKED">חסימת משתמש</option>
+                  <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
+                  <option value="CREATE_USER">יצירת משתמש (7)</option>
+                  <option value="UPDATE_USER">עדכון משתמש (~30)</option>
+                  <option value="DELETE_USER">מחיקת משתמש (7)</option>
+                  <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
                 </optgroup>
+
                 <optgroup label="מערכת">
-                  <option value="system_config_updated">עדכון הגדרות</option>
+                  <option value="system_config_updated">עדכון הגדרות (6)</option>
                 </optgroup>
               </select>
             </div>

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -173,6 +173,9 @@
     filteredProfiles: [],
     selectedProfile: null,
     entries: [],
+    _allEntries: [],
+    _loadToken: 0,
+    _truncated: false,
     currentPage: 1,
     loading: false,
     roleFilter: 'all',
@@ -502,9 +505,9 @@
     },
 
     _loadUserActivity: async function() {
-      if (this.loading) {
- return;
-}
+      // Increment token on every load — stale results are discarded
+      this._loadToken++;
+      const myToken = this._loadToken;
       this.loading = true;
 
       const content = document.getElementById('detail-table-content');
@@ -517,26 +520,41 @@
       const email = profile.email;
 
       try {
-        // Query both collections — by userId (indexed) or email fallback
+        // Primary: query by userId (indexed). activity_log writer always sets userId.
+        // Fallback: query by email fields — union with primary to catch admin actions
+        // logged with adminEmail but without userId, or legacy records missing userId.
         const queries = [];
 
         if (uid) {
           queries.push(this._queryUserCollection('audit_log', 'userId', uid));
           queries.push(this._queryUserCollection('activity_log', 'userId', uid));
-        } else {
-          // No authUID — fallback to email-based queries
+        }
+
+        // Always also query by email to catch edge cases:
+        //  - admin actions in audit_log that use adminEmail/performedBy (may lack userId)
+        //  - legacy activity_log records before userId was standardized
+        if (email) {
           queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
           queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
         }
 
         const allResults = await Promise.all(queries);
 
+        // Stale-result guard: if another profile was clicked, discard
+        if (myToken !== this._loadToken) {
+          return;
+        }
+
         // Merge and deduplicate by document id
         const seen = {};
         const results = [];
+        let anyTruncated = false;
 
-        allResults.forEach(function(docs) {
-          docs.forEach(function(item) {
+        allResults.forEach(function(queryResult) {
+          if (queryResult.truncated) {
+            anyTruncated = true;
+          }
+          queryResult.docs.forEach(function(item) {
             if (!seen[item.id]) {
               seen[item.id] = true;
               results.push(item);
@@ -544,13 +562,14 @@
           });
         });
 
-        // Sort by timestamp desc
+        // Sort by timestamp desc (stable across timestamp formats)
         results.sort(function(a, b) {
           return b.tsMillis - a.tsMillis;
         });
 
         // Store full dataset — filters work client-side only
         this._allEntries = results;
+        this._truncated = anyTruncated;
         this.entries = results;
 
         // Build action dropdown from full data
@@ -559,31 +578,38 @@
         this._renderActivityTable();
 
       } catch (error) {
+        // Still check token before rendering error — avoid overwriting newer view
+        if (myToken !== this._loadToken) {
+          return;
+        }
         console.error('Error loading user activity:', error);
         if (content) {
           content.innerHTML = '<div class="audit-empty"><i class="fas fa-exclamation-triangle"></i><p>\u05e9\u05d2\u05d9\u05d0\u05d4 \u05d1\u05d8\u05e2\u05d9\u05e0\u05ea \u05e4\u05e2\u05d9\u05dc\u05d5\u05ea</p></div>';
         }
       }
 
-      this.loading = false;
+      if (myToken === this._loadToken) {
+        this.loading = false;
+      }
     },
 
     _queryUserCollection: async function(collectionName, field, value) {
+      const LIMIT = 500;
       const query = this.db.collection(collectionName)
         .where(field, '==', value)
         .orderBy('timestamp', 'desc')
-        .limit(500);
+        .limit(LIMIT);
 
       try {
         const snapshot = await query.get();
-        const results = [];
+        const docs = [];
 
         snapshot.forEach(function(doc) {
           const data = doc.data();
           const det = _parseDetails(data.details);
           const target = data.targetUser || data.targetUserEmail || det.targetEmail || det.targetUser || det.clientName || '';
 
-          results.push({
+          docs.push({
             id: doc.id,
             source: collectionName === 'audit_log' ? 'audit' : 'activity',
             action: data.action || data.type || '',
@@ -592,15 +618,15 @@
             severity: data.severity || 'info',
             timestamp: data.timestamp,
             timestampLocal: data.timestampLocal || null,
-            tsMillis: data.timestamp?.toMillis?.() || 0
+            tsMillis: _timestampToMillis(data.timestamp, data.timestampLocal)
           });
         });
 
-        return results;
+        return { docs: docs, truncated: snapshot.size >= LIMIT };
       } catch (e) {
         // Index might not exist for some field combinations — return empty
         console.warn('Query failed for ' + collectionName + '.' + field + ':', e.message);
-        return [];
+        return { docs: [], truncated: false };
       }
     },
 
@@ -641,11 +667,32 @@
     _renderActivityTable: function() {
       const content = document.getElementById('detail-table-content');
       if (!content) {
- return;
-}
+        return;
+      }
+
+      // Count entries with missing/zero timestamp (excluded from ordering)
+      const missingTimestampCount = this._allEntries
+        ? this._allEntries.filter(function(e) {
+ return !e.tsMillis;
+}).length
+        : 0;
+
+      let banner = '';
+      if (this._truncated) {
+        banner += '<div class="audit-warning-banner">' +
+          '<i class="fas fa-exclamation-triangle"></i> ' +
+          '\u05d4\u05d9\u05e1\u05d8\u05d5\u05e8\u05d9\u05d4 \u05d0\u05e8\u05d5\u05db\u05d4 \u2014 \u05de\u05d5\u05e6\u05d2\u05d5\u05ea 500 \u05e8\u05e9\u05d5\u05de\u05d5\u05ea \u05d4\u05d0\u05d7\u05e8\u05d5\u05e0\u05d5\u05ea \u05d1\u05dc\u05d1\u05d3. \u05dc\u05e6\u05e4\u05d9\u05d9\u05d4 \u05d1\u05ea\u05e7\u05d5\u05e4\u05d4 \u05de\u05d5\u05e7\u05d3\u05de\u05ea \u2014 \u05d4\u05e9\u05ea\u05de\u05e9 \u05d1\u05e1\u05d9\u05e0\u05d5\u05df \u05ea\u05d0\u05e8\u05d9\u05da.' +
+          '</div>';
+      }
+      if (missingTimestampCount > 0) {
+        banner += '<div class="audit-warning-banner">' +
+          '<i class="fas fa-info-circle"></i> ' +
+          missingTimestampCount + ' \u05e8\u05e9\u05d5\u05de\u05d5\u05ea \u05d7\u05e1\u05e8 \u05d1\u05d4\u05df \u05d7\u05d5\u05ea\u05de\u05ea \u05d6\u05de\u05df \u2014 \u05de\u05d5\u05e6\u05d2\u05d5\u05ea \u05d1\u05e1\u05d5\u05e3 \u05d4\u05e8\u05e9\u05d9\u05de\u05d4.' +
+          '</div>';
+      }
 
       if (this.entries.length === 0) {
-        content.innerHTML = '<div class="audit-empty"><i class="fas fa-clipboard-list"></i><p>\u05dc\u05d0 \u05e0\u05de\u05e6\u05d0\u05d5 \u05e8\u05e9\u05d5\u05de\u05d5\u05ea</p></div>';
+        content.innerHTML = banner + '<div class="audit-empty"><i class="fas fa-clipboard-list"></i><p>\u05dc\u05d0 \u05e0\u05de\u05e6\u05d0\u05d5 \u05e8\u05e9\u05d5\u05de\u05d5\u05ea</p></div>';
         return;
       }
 
@@ -659,7 +706,9 @@
         const cat = _getActionCategory(entry.action);
         const actionLabel = ACTION_LABELS[entry.action] || entry.action;
         const timeStr = _formatTimestamp(entry.timestamp, entry.timestampLocal);
-        const detailsStr = _formatDetails(entry.details);
+        const rawDetails = _formatDetails(entry.details);
+        const escapedDetails = _escapeHtml(rawDetails);
+        const escapedTarget = _escapeHtml(entry.target || '');
         const sourceIcon = entry.source === 'audit'
           ? '<i class="fas fa-shield-alt" style="color:#9333ea;font-size:11px" title="\u05e4\u05e2\u05d5\u05dc\u05ea \u05de\u05e0\u05d4\u05dc"></i>'
           : '<i class="fas fa-user" style="color:#6b7280;font-size:11px" title="\u05e4\u05e2\u05d9\u05dc\u05d5\u05ea \u05de\u05e9\u05ea\u05de\u05e9"></i>';
@@ -668,14 +717,14 @@
 
         rows += '<tr>' +
           '<td style="text-align:center">' + sourceIcon + '</td>' +
-          '<td class="audit-time-cell">' + timeStr + '</td>' +
+          '<td class="audit-time-cell">' + _escapeHtml(timeStr) + '</td>' +
           '<td><span class="audit-action-badge ' + cat + '">' + _escapeHtml(actionLabel) + '</span></td>' +
-          '<td class="' + targetCls + '" title="' + _escapeHtml(entry.target || '') + '">' + _escapeHtml(entry.target || '') + '</td>' +
-          '<td class="audit-details" title="' + _escapeHtml(detailsStr) + '">' + detailsStr + '</td>' +
+          '<td class="' + targetCls + '" title="' + escapedTarget + '">' + escapedTarget + '</td>' +
+          '<td class="audit-details" title="' + escapedDetails + '">' + escapedDetails + '</td>' +
           '</tr>';
       });
 
-      content.innerHTML =
+      content.innerHTML = banner +
         '<table class="audit-table">' +
           '<thead>' +
             '<tr>' +
@@ -812,12 +861,42 @@
     return {};
   }
 
+  /**
+   * Convert any Firestore timestamp format to milliseconds.
+   * Handles: Timestamp instance, { seconds, nanoseconds } from JSON round-trip,
+   *          { _seconds, _nanoseconds } from some SDKs, and timestampLocal fallback.
+   */
+  function _timestampToMillis(ts, localStr) {
+    if (ts) {
+      if (typeof ts.toMillis === 'function') {
+        return ts.toMillis();
+      }
+      if (typeof ts.seconds === 'number') {
+        return ts.seconds * 1000 + Math.floor((ts.nanoseconds || 0) / 1e6);
+      }
+      if (typeof ts._seconds === 'number') {
+        return ts._seconds * 1000 + Math.floor((ts._nanoseconds || 0) / 1e6);
+      }
+    }
+    if (localStr) {
+      const d = new Date(localStr);
+      if (!isNaN(d.getTime())) {
+        return d.getTime();
+      }
+    }
+    return 0;
+  }
+
   function _formatTimestamp(ts, localStr) {
-    if (!ts && !localStr) {
- return '-';
-}
+    const ms = _timestampToMillis(ts, localStr);
+    if (!ms) {
+      return '-';
+    }
     try {
-      const date = ts && ts.toDate ? ts.toDate() : new Date(localStr);
+      const date = new Date(ms);
+      if (isNaN(date.getTime())) {
+        return '-';
+      }
       const day = String(date.getDate()).padStart(2, '0');
       const month = String(date.getMonth() + 1).padStart(2, '0');
       const hours = String(date.getHours()).padStart(2, '0');
@@ -828,16 +907,19 @@
     }
   }
 
+  /**
+   * Returns raw (unescaped) summary string. Caller must escape before HTML injection.
+   */
   function _formatDetails(details) {
     if (!details) {
- return '';
-}
+      return '';
+    }
     const obj = _parseDetails(details);
     if (typeof obj === 'object' && Object.keys(obj).length > 0) {
-      return _escapeHtml(_summarizeObject(obj));
+      return _summarizeObject(obj);
     }
     if (typeof details === 'string') {
-      return _escapeHtml(details.substring(0, 80));
+      return details.substring(0, 80);
     }
     return '';
   }

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -480,21 +480,16 @@
 
       const profile = this.selectedProfile;
       const uid = profile.authUID;
-      const email = profile.email;
+      const actionFilter = this.detailFilters.action;
 
       try {
-        // Query both collections in parallel by userId
+        // Query both collections by userId (indexed)
         const queries = [];
 
         if (uid) {
           queries.push(this._queryUserCollection('audit_log', 'userId', uid));
           queries.push(this._queryUserCollection('activity_log', 'userId', uid));
         }
-
-        // Also query by email fields as fallback
-        queries.push(this._queryUserCollection('audit_log', 'performedBy', email));
-        queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
-        queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
 
         const allResults = await Promise.all(queries);
 
@@ -522,9 +517,9 @@
         this._buildActionDropdown(results);
 
         // Apply action filter if set
-        if (this.detailFilters.action) {
+        if (actionFilter) {
           results = results.filter(function(e) {
-            return e.action === self.detailFilters.action;
+            return e.action === actionFilter;
           });
           this.entries = results;
         }

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -20,6 +20,46 @@
     config: ['system_config_updated', 'system_config_rollback']
   };
 
+  // Role-based action classification
+  const USER_ACTIONS = [
+    // activity_log (lowercase)
+    'login', 'logout', 'create_task', 'edit_task', 'delete_task',
+    'complete_task', 'extend_deadline', 'update_progress',
+    'create_timesheet', 'edit_timesheet', 'delete_timesheet',
+    'create_client', 'edit_client', 'delete_client', 'block_client', 'unblock_client',
+    'generate_report', 'export_data',
+    // audit_log (UPPERCASE — user-initiated via Functions)
+    'CREATE_TASK', 'COMPLETE_TASK', 'CANCEL_TASK', 'EXTEND_TASK_DEADLINE',
+    'ADJUST_BUDGET', 'ADD_TIME_TO_TASK', 'CREATE_TIMESHEET_ENTRY_V2',
+    'CREATE_TIMESHEET_ENTRY', 'CREATE_CLIENT', 'ADD_SERVICE_TO_CLIENT',
+    'CREATE_CASE', 'ADD_SERVICE_TO_CASE'
+  ];
+
+  const ADMIN_ACTIONS = [
+    // User management
+    'VIEW_USER_DETAILS', 'CREATE_USER', 'UPDATE_USER', 'DELETE_USER',
+    'USER_CREATED', 'USER_UPDATED', 'USER_DELETED', 'USER_BLOCKED', 'USER_UNBLOCKED',
+    'delete_user_data_selective',
+    // Tasks — admin
+    'UPDATE_TASK_BY_ADMIN', 'TASK_UPDATED_BY_ADMIN', 'MOVE_TO_NEXT_STAGE',
+    // Timesheet — admin
+    'CREATE_QUICK_LOG_ENTRY',
+    // Clients & cases — admin
+    'UPDATE_CLIENT', 'DELETE_CLIENT', 'CHANGE_CLIENT_STATUS', 'CLOSE_CASE',
+    // Services & packages — admin
+    'ADD_SERVICE', 'ADD_PACKAGE', 'DELETE_SERVICE',
+    'CHANGE_SERVICE_STATUS', 'COMPLETE_SERVICE',
+    'SET_SERVICE_OVERRIDE', 'REMOVE_SERVICE_OVERRIDE',
+    'RESOLVE_SERVICE_OVERDRAFT', 'UNRESOLVE_SERVICE_OVERDRAFT',
+    'ADD_PACKAGE_TO_SERVICE', 'ADD_PACKAGE_TO_STAGE',
+    // Fee agreements
+    'UPLOAD_FEE_AGREEMENT', 'DELETE_FEE_AGREEMENT',
+    // System config
+    'system_config_updated', 'system_config_rollback',
+    // Migration (admin-initiated)
+    'MIGRATE_CLIENTS_TO_CASES', 'MIGRATE_CASES_TO_CLIENTS'
+  ];
+
   function getActionCategory(action) {
     for (const [cat, actions] of Object.entries(ACTION_CATEGORIES)) {
       if (actions.includes(action)) {
@@ -157,7 +197,7 @@
     currentPage: 1,
     totalLoaded: 0,
     loading: false,
-    source: 'all', // 'all', 'activity', 'audit'
+    source: 'all', // 'all', 'user', 'admin'
     filters: {
       action: '',
       user: '',
@@ -192,8 +232,8 @@
           <div class="audit-filters">
             <div class="audit-source-tabs" id="source-tabs">
               <button class="audit-source-tab active" data-source="all">הכל</button>
-              <button class="audit-source-tab" data-source="activity">פעילות משתמשים</button>
-              <button class="audit-source-tab" data-source="audit">פעולות מנהל</button>
+              <button class="audit-source-tab" data-source="user">פעילות משתמשים</button>
+              <button class="audit-source-tab" data-source="admin">פעולות מנהל</button>
             </div>
 
             <div class="audit-filter-group">
@@ -201,44 +241,92 @@
               <select class="audit-filter-select" id="filter-action">
                 <option value="">הכל</option>
 
-                <optgroup label="כניסה/יציאה">
+                <!-- ═══ User Actions ═══ -->
+                <optgroup label="כניסה/יציאה" data-source="user">
                   <option value="login">כניסה (~2,400)</option>
                   <option value="logout">יציאה (8)</option>
                 </optgroup>
 
-                <optgroup label="משימות — פעילות משתמשים">
-                  <option value="create_task">יצירת משימה (משתמש) (~20)</option>
-                  <option value="complete_task">השלמת משימה (משתמש) (10)</option>
-                </optgroup>
-
-                <optgroup label="משימות — פעולות מנהל">
-                  <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
-                  <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
+                <optgroup label="משימות (משתמש)" data-source="user">
+                  <option value="create_task">יצירת משימה — activity (20)</option>
+                  <option value="edit_task">עריכת משימה</option>
+                  <option value="delete_task">מחיקת משימה</option>
+                  <option value="complete_task">השלמת משימה — activity (10)</option>
+                  <option value="extend_deadline">הארכת דדליין — activity</option>
+                  <option value="update_progress">עדכון התקדמות</option>
+                  <option value="CREATE_TASK">יצירת משימה (~700)</option>
+                  <option value="COMPLETE_TASK">השלמת משימה (~300)</option>
                   <option value="CANCEL_TASK">ביטול משימה (~45)</option>
                   <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
                   <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
                   <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
+                </optgroup>
+
+                <optgroup label="שעתון (משתמש)" data-source="user">
+                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
+                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות — גרסה קודמת (~490)</option>
+                  <option value="create_timesheet">רישום שעות — activity</option>
+                  <option value="edit_timesheet">עריכת שעות</option>
+                  <option value="delete_timesheet">מחיקת שעות</option>
+                </optgroup>
+
+                <optgroup label="לקוחות ותיקים (משתמש)" data-source="user">
+                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
+                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                  <option value="create_client">יצירת לקוח — activity</option>
+                  <option value="edit_client">עריכת לקוח</option>
+                  <option value="delete_client">מחיקת לקוח</option>
+                  <option value="block_client">חסימת לקוח</option>
+                  <option value="unblock_client">ביטול חסימת לקוח</option>
+                </optgroup>
+
+                <optgroup label="שירותים (משתמש)" data-source="user">
+                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
+                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                </optgroup>
+
+                <optgroup label="דוחות (משתמש)" data-source="user">
+                  <option value="generate_report">הפקת דוח</option>
+                  <option value="export_data">ייצוא נתונים</option>
+                </optgroup>
+
+                <!-- ═══ Admin Actions ═══ -->
+                <optgroup label="ניהול משתמשים" data-source="admin">
+                  <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
+                  <option value="CREATE_USER">יצירת משתמש (7)</option>
+                  <option value="UPDATE_USER">עדכון משתמש (~30)</option>
+                  <option value="DELETE_USER">מחיקת משתמש (7)</option>
+                  <option value="USER_CREATED">יצירת משתמש — legacy</option>
+                  <option value="USER_UPDATED">עדכון משתמש — legacy</option>
+                  <option value="USER_DELETED">מחיקת משתמש — legacy</option>
+                  <option value="USER_BLOCKED">חסימת משתמש</option>
+                  <option value="USER_UNBLOCKED">ביטול חסימת משתמש</option>
+                  <option value="delete_user_data_selective">מחיקת נתוני משתמש — חלקית (~25)</option>
+                </optgroup>
+
+                <optgroup label="משימות (ניהול)" data-source="admin">
                   <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
-                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
+                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה — legacy (3)</option>
                   <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
                 </optgroup>
 
-                <optgroup label="שעתון">
-                  <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
-                  <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
+                <optgroup label="שעתון (ניהול)" data-source="admin">
                   <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
 
-                <optgroup label="לקוחות ותיקים">
-                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
-                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                <optgroup label="לקוחות ותיקים (ניהול)" data-source="admin">
+                  <option value="UPDATE_CLIENT">עדכון לקוח</option>
+                  <option value="DELETE_CLIENT">מחיקת לקוח</option>
+                  <option value="CHANGE_CLIENT_STATUS">שינוי סטטוס לקוח</option>
+                  <option value="CLOSE_CASE">סגירת תיק</option>
                   <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
                   <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
 
-                <optgroup label="שירותים וחבילות">
-                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
-                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                <optgroup label="שירותים (ניהול)" data-source="admin">
+                  <option value="ADD_SERVICE">הוספת שירות</option>
+                  <option value="ADD_PACKAGE">הוספת חבילה</option>
+                  <option value="DELETE_SERVICE">מחיקת שירות</option>
                   <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
                   <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
                   <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
@@ -249,21 +337,14 @@
                   <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
                 </optgroup>
 
-                <optgroup label="הסכמי שכ״ט">
+                <optgroup label="הסכמי שכ״ט" data-source="admin">
                   <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
                   <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
                 </optgroup>
 
-                <optgroup label="ניהול משתמשים">
-                  <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
-                  <option value="CREATE_USER">יצירת משתמש (7)</option>
-                  <option value="UPDATE_USER">עדכון משתמש (~30)</option>
-                  <option value="DELETE_USER">מחיקת משתמש (7)</option>
-                  <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
-                </optgroup>
-
-                <optgroup label="מערכת">
+                <optgroup label="מערכת" data-source="admin">
                   <option value="system_config_updated">עדכון הגדרות (6)</option>
+                  <option value="system_config_rollback">שחזור הגדרות</option>
                 </optgroup>
               </select>
             </div>
@@ -308,6 +389,7 @@
 });
           tab.classList.add('active');
           self.source = tab.dataset.source;
+          self._updateDropdownBySource();
           self.currentPage = 1;
           self.loadData();
         });
@@ -327,6 +409,7 @@
         self.filters = { action: '', user: '', dateFrom: '', dateTo: '' };
         self.currentPage = 1;
         self.loadData();
+        self._updateDropdownBySource();
       });
 
       // Enter key on user filter
@@ -346,6 +429,29 @@
       this.loadData();
     },
 
+    _updateDropdownBySource: function() {
+      const select = document.getElementById('filter-action');
+      if (!select) {
+return;
+}
+      const source = this.source;
+
+      select.querySelectorAll('optgroup[data-source]').forEach(function(og) {
+        const ds = og.getAttribute('data-source');
+        if (source === 'all') {
+          og.style.display = '';
+        } else {
+          og.style.display = (ds === source) ? '' : 'none';
+        }
+      });
+
+      // If selected option is in a hidden optgroup — reset to "all"
+      const sel = select.options[select.selectedIndex];
+      if (sel && sel.parentElement.tagName === 'OPTGROUP' && sel.parentElement.style.display === 'none') {
+        select.value = '';
+      }
+    },
+
     // ═══════════════════════════════════════════
     // Data Loading
     // ═══════════��═══════════════════════════════
@@ -360,56 +466,64 @@
       content.innerHTML = '<div class="audit-loading"><i class="fas fa-spinner fa-spin"></i> טוען נתונים...</div>';
 
       try {
-        const results = [];
+        let results = [];
 
-        // Load from activity_log
-        if (this.source === 'all' || this.source === 'activity') {
-          const activityDocs = await this._queryCollection('activity_log');
-          activityDocs.forEach(function(doc) {
-            const data = doc.data();
-            // Prefer username (Hebrew) over email, never show raw UID
-            const displayUser = data.username || data.userEmail || _emailFromUid(data.userId) || '';
-            results.push({
-              id: doc.id,
-              source: 'activity',
-              action: data.action || data.type || '',
-              user: displayUser,
-              username: data.username || '',
-              target: data.targetUser || '',
-              details: data.details || '',
-              severity: data.severity || 'info',
-              timestamp: data.timestamp,
-              timestampLocal: data.timestampLocal || null
-            });
-          });
-        }
+        // Always query both collections in parallel
+        const [activityDocs, auditDocs] = await Promise.all([
+          this._queryCollection('activity_log'),
+          this._queryCollection('audit_log')
+        ]);
 
-        // Load from audit_log
-        if (this.source === 'all' || this.source === 'audit') {
-          const auditDocs = await this._queryCollection('audit_log');
-          auditDocs.forEach(function(doc) {
-            const data = doc.data();
-            // Prefer name (Hebrew) over email, never show raw UID
-            const displayUser = data.performedByName || data.username || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
-            // Extract target from details if not in top-level field
-            const det = _parseDetails(data.details);
-            let target = data.targetUser || data.targetUserEmail || '';
-            if (!target) {
-              target = det.targetEmail || det.targetUser || det.clientName || '';
-            }
-            results.push({
-              id: doc.id,
-              source: 'audit',
-              action: data.action || '',
-              user: displayUser,
-              username: data.performedByName || data.username || '',
-              target: target,
-              details: data.details || '',
-              severity: data.severity || 'info',
-              timestamp: data.timestamp,
-              timestampLocal: data.timestampLocal || null
-            });
+        // Map activity_log docs
+        activityDocs.forEach(function(doc) {
+          const data = doc.data();
+          const displayUser = data.username || data.userEmail || _emailFromUid(data.userId) || '';
+          results.push({
+            id: doc.id,
+            source: 'activity',
+            action: data.action || data.type || '',
+            user: displayUser,
+            username: data.username || '',
+            target: data.targetUser || '',
+            details: data.details || '',
+            severity: data.severity || 'info',
+            timestamp: data.timestamp,
+            timestampLocal: data.timestampLocal || null
           });
+        });
+
+        // Map audit_log docs
+        auditDocs.forEach(function(doc) {
+          const data = doc.data();
+          const displayUser = data.performedByName || data.username || data.performedBy || data.adminEmail || _emailFromUid(data.userId) || '';
+          const det = _parseDetails(data.details);
+          let target = data.targetUser || data.targetUserEmail || '';
+          if (!target) {
+            target = det.targetEmail || det.targetUser || det.clientName || '';
+          }
+          results.push({
+            id: doc.id,
+            source: 'audit',
+            action: data.action || '',
+            user: displayUser,
+            username: data.performedByName || data.username || '',
+            target: target,
+            details: data.details || '',
+            severity: data.severity || 'info',
+            timestamp: data.timestamp,
+            timestampLocal: data.timestampLocal || null
+          });
+        });
+
+        // Filter by role
+        if (this.source === 'user') {
+          results = results.filter(function(e) {
+ return USER_ACTIONS.includes(e.action);
+});
+        } else if (this.source === 'admin') {
+          results = results.filter(function(e) {
+ return ADMIN_ACTIONS.includes(e.action);
+});
         }
 
         // Sort by timestamp desc
@@ -495,17 +609,17 @@
  return;
 }
 
-      const actCount = this.entries.filter(function(e) {
- return e.source === 'activity';
+      const userCount = this.entries.filter(function(e) {
+ return USER_ACTIONS.includes(e.action);
 }).length;
-      const audCount = this.entries.filter(function(e) {
- return e.source === 'audit';
+      const adminCount = this.entries.filter(function(e) {
+ return ADMIN_ACTIONS.includes(e.action);
 }).length;
 
       statsEl.innerHTML =
         '<span class="audit-stat"><strong>' + this.entries.length + '</strong> רשומות</span>' +
-        '<span class="audit-stat"><strong>' + actCount + '</strong> פעילות</span>' +
-        '<span class="audit-stat"><strong>' + audCount + '</strong> ניהול</span>';
+        '<span class="audit-stat"><strong>' + userCount + '</strong> משתמשים</span>' +
+        '<span class="audit-stat"><strong>' + adminCount + '</strong> ניהול</span>';
     },
 
     _renderTable: function() {

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -480,15 +480,20 @@
 
       const profile = this.selectedProfile;
       const uid = profile.authUID;
+      const email = profile.email;
       const actionFilter = this.detailFilters.action;
 
       try {
-        // Query both collections by userId (indexed)
+        // Query both collections — by userId (indexed) or email fallback
         const queries = [];
 
         if (uid) {
           queries.push(this._queryUserCollection('audit_log', 'userId', uid));
           queries.push(this._queryUserCollection('activity_log', 'userId', uid));
+        } else {
+          // No authUID — fallback to email-based queries
+          queries.push(this._queryUserCollection('audit_log', 'adminEmail', email));
+          queries.push(this._queryUserCollection('activity_log', 'userEmail', email));
         }
 
         const allResults = await Promise.all(queries);

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -206,55 +206,56 @@
                   <option value="logout">יציאה (8)</option>
                 </optgroup>
 
-                <optgroup label="משימות — פעילות משתמשים" data-source="activity">
-                  <option value="create_task">יצירת משימה (משתמש) (~20)</option>
-                  <option value="complete_task">השלמת משימה (משתמש) (10)</option>
-                </optgroup>
-
-                <optgroup label="משימות — פעולות מנהל" data-source="audit">
-                  <option value="CREATE_TASK">יצירת משימה (מנהל) (~700)</option>
-                  <option value="COMPLETE_TASK">השלמת משימה (מנהל) (~300)</option>
+                <optgroup label="משימות — משתמש" data-source="activity">
+                  <option value="create_task">יצירת משימה — activity (~20)</option>
+                  <option value="complete_task">השלמת משימה — activity (10)</option>
+                  <option value="CREATE_TASK">יצירת משימה (~700)</option>
+                  <option value="COMPLETE_TASK">השלמת משימה (~300)</option>
                   <option value="CANCEL_TASK">ביטול משימה (~45)</option>
                   <option value="EXTEND_TASK_DEADLINE">הארכת דדליין (~330)</option>
                   <option value="ADJUST_BUDGET">התאמת תקציב (~80)</option>
                   <option value="ADD_TIME_TO_TASK">הוספת שעות למשימה (~110)</option>
-                  <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
-                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
-                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
                 </optgroup>
 
-                <optgroup label="שעתון" data-source="audit">
+                <optgroup label="שעתון — משתמש" data-source="activity">
                   <option value="CREATE_TIMESHEET_ENTRY_V2">רישום שעות (~570)</option>
                   <option value="CREATE_TIMESHEET_ENTRY">רישום שעות (גרסה קודמת) (~490)</option>
+                </optgroup>
+
+                <optgroup label="לקוחות ותיקים — משתמש" data-source="activity">
+                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
+                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
+                  <option value="CREATE_CASE">יצירת תיק (6)</option>
+                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                </optgroup>
+
+                <optgroup label="משימות — מנהל" data-source="audit">
+                  <option value="UPDATE_TASK_BY_ADMIN">עדכון משימה ע"י מנהל (10)</option>
+                  <option value="TASK_UPDATED_BY_ADMIN">עדכון משימה ע"י מנהל — legacy (3)</option>
+                </optgroup>
+
+                <optgroup label="שעתון — מנהל" data-source="audit">
                   <option value="CREATE_QUICK_LOG_ENTRY">רישום מהיר (~200)</option>
                 </optgroup>
 
-                <optgroup label="לקוחות ותיקים" data-source="audit">
-                  <option value="CREATE_CLIENT">יצירת לקוח (~140)</option>
-                  <option value="CREATE_CASE">יצירת תיק (6)</option>
-                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
-                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
-                </optgroup>
-
-                <optgroup label="שירותים וחבילות" data-source="audit">
-                  <option value="ADD_SERVICE_TO_CLIENT">הוספת שירות ללקוח (~65)</option>
-                  <option value="ADD_SERVICE_TO_CASE">הוספת שירות לתיק (~15)</option>
+                <optgroup label="לקוחות ושירותים — מנהל" data-source="audit">
+                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
+                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
+                  <option value="MOVE_TO_NEXT_STAGE">מעבר לשלב הבא (4)</option>
                   <option value="CHANGE_SERVICE_STATUS">שינוי סטטוס שירות (3)</option>
                   <option value="COMPLETE_SERVICE">השלמת שירות (1)</option>
                   <option value="SET_SERVICE_OVERRIDE">ביטול חסימת שירות (~15)</option>
                   <option value="REMOVE_SERVICE_OVERRIDE">הסרת ביטול חסימה (3)</option>
                   <option value="RESOLVE_SERVICE_OVERDRAFT">פתרון חריגת שירות (1)</option>
                   <option value="UNRESOLVE_SERVICE_OVERDRAFT">ביטול פתרון חריגה (1)</option>
-                  <option value="ADD_PACKAGE_TO_SERVICE">הוספת חבילה לשירות (4)</option>
-                  <option value="ADD_PACKAGE_TO_STAGE">הוספת חבילה לשלב (1)</option>
                 </optgroup>
 
-                <optgroup label="הסכמי שכ״ט" data-source="audit">
+                <optgroup label="הסכמי שכ״ט — מנהל" data-source="audit">
                   <option value="UPLOAD_FEE_AGREEMENT">העלאת הסכם שכ"ט (10)</option>
                   <option value="DELETE_FEE_AGREEMENT">מחיקת הסכם שכ"ט (1)</option>
                 </optgroup>
 
-                <optgroup label="ניהול משתמשים" data-source="audit">
+                <optgroup label="ניהול משתמשים — מנהל" data-source="audit">
                   <option value="VIEW_USER_DETAILS">צפייה בפרטי משתמש (~970)</option>
                   <option value="CREATE_USER">יצירת משתמש (7)</option>
                   <option value="UPDATE_USER">עדכון משתמש (~30)</option>
@@ -262,8 +263,13 @@
                   <option value="delete_user_data_selective">מחיקת נתוני משתמש (חלקית) (~25)</option>
                 </optgroup>
 
-                <optgroup label="מערכת" data-source="audit">
+                <optgroup label="מערכת — מנהל" data-source="audit">
                   <option value="system_config_updated">עדכון הגדרות (6)</option>
+                </optgroup>
+
+                <optgroup label="פעולות מערכת (legacy)">
+                  <option value="MIGRATE_CLIENTS_TO_CASES">העברת לקוחות לתיקים (6)</option>
+                  <option value="MIGRATE_CASES_TO_CLIENTS">העברת תיקים ללקוחות (2)</option>
                 </optgroup>
               </select>
             </div>

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -427,6 +427,34 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "audit_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "adminEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "activity_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userEmail",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -401,6 +401,20 @@
       ]
     },
     {
+      "collectionGroup": "activity_log",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "timestamp",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "audit_log",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -138,20 +138,18 @@ service cloud.firestore {
       allow write: if false; // Only through Cloud Functions
     }
 
-    // ✅ Activity Log: User can read their own, admins can read all
+    // ✅ Activity Log: User can read their own (by userId), admins can read all
     match /activity_log/{logId} {
       allow read: if isAuthenticated() && (
-        resource.data.performedBy == request.auth.token.email ||
+        resource.data.userId == request.auth.uid ||
         isAdmin()
       );
       allow write: if false; // Only through Cloud Functions
     }
 
-    // ✅ Audit Log: Read-only for authenticated users
-    // Note: Sensitive operations logged server-side only
-    // Future: Restrict to admin-only with custom claims
+    // ✅ Audit Log: Admin-only (contains sensitive admin actions, deletions, etc.)
     match /audit_log/{logId} {
-      allow read: if isAuthenticated();
+      allow read: if isAdmin();
       allow write: if false; // Only through Cloud Functions
     }
 


### PR DESCRIPTION
## Summary
Deploying audit trail rebuild + security hardening to PROD.

### Features included
- **User profiles view** replacing tab-based filtering (PR #208)
- **Client-side filtering** instead of per-click Firestore queries (PR #209)
- **Security + correctness hardening** (PR #210):
  - Firestore rules: audit_log now admin-only
  - activity_log rule: userId-based (was broken with non-existent performedBy field)
  - Race condition guard on profile switch
  - Timestamp format compatibility (Firestore Timestamp, {seconds}, {_seconds}, localStr)
  - Truncation + missing-timestamp warning banners
  - Double-escape fix in tooltips
  - NaN guard in _formatTimestamp

### DEV verification
✅ Full flow tested on DEV by Haim — works correctly

### Firestore changes
- Indexes: 3 new composite indexes (activity_log.userId, audit_log.adminEmail, activity_log.userEmail) — **already deployed**
- Rules: audit_log admin-only, activity_log userId-based — **already deployed**

### Test plan for PROD
- [ ] Hard refresh admin panel PROD (cache-bust v=20260417a)
- [ ] Open audit trail — profile list loads
- [ ] Click a profile — activity loads
- [ ] Action filter + date filter work
- [ ] No console errors
- [ ] Non-admin user cannot read audit_log

🤖 Generated with [Claude Code](https://claude.com/claude-code)