### PR TITLE
docs: clarify what PROD means

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ Any PROD action requires:
 - production-stable = PROD
 - Feature branches must be created from main and merged back to main first
 
+## WHAT IS "PROD"?
+"PROD" = the deployed app (Netlify/Firebase), NOT the production-stable branch.
+The branch contains everything (tooling, docs, code) — but only built app
+artifacts reach production. Therefore, merges to production-stable update
+the branch for consistency, not to "release" tooling.
+
 ## DEPLOYMENT RULES
 - Every change must pass DEV before PROD
 - Direct deploy to PROD is forbidden


### PR DESCRIPTION
Adds 4-line clarification to CLAUDE.md explaining that PROD = deployed app (Netlify/Firebase), not the production-stable branch. Prevents agents from assuming branch-level PROD scope boundaries. Ref: prior investigation confirmed production-stable contains all files (tooling, docs, code) — DEV/PROD distinction happens at deploy layer, not git layer.