### PR TITLE
UI polish Sprint 1: button interactions (emil-design-eng)

### DIFF
--- a/apps/user-app/css/buttons.css
+++ b/apps/user-app/css/buttons.css
@@ -54,7 +54,8 @@
 }
 
 .btn:active {
-  transform: translateY(0);
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
 }
 
 .btn:disabled {
@@ -101,6 +102,11 @@
   transform: translateY(-1px);
 }
 
+.btn-secondary:active {
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
+}
+
 .btn-success {
   background: linear-gradient(
     135deg,
@@ -114,6 +120,11 @@
 .btn-success:hover {
   background: linear-gradient(135deg, var(--green-dark) 0%, #047857 100%);
   box-shadow: 0 4px 12px rgb(16 185 129 / 25%);
+}
+
+.btn-success:active {
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
 }
 
 /* Primary Button - Blue with rounded corners */
@@ -160,6 +171,11 @@
   box-shadow: 0 4px 12px rgb(249 115 22 / 25%);
 }
 
+.btn-warning:active {
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
+}
+
 .btn-danger {
   background: linear-gradient(
     135deg,
@@ -173,6 +189,11 @@
 .btn-danger:hover {
   background: linear-gradient(135deg, var(--red-dark) 0%, #b91c1c 100%);
   box-shadow: 0 4px 12px rgb(239 68 68 / 25%);
+}
+
+.btn-danger:active {
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
 }
 
 /* כפתור פלוס - 2025 Modern */
@@ -362,4 +383,20 @@ button[onclick*="addTimesheet"]:hover,
 button[onclick*="addBudget"]:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
+}
+
+#addTaskBtn:active,
+#addTimesheetBtn:active,
+#addBudgetBtn:active,
+.add-task-btn:active,
+.add-timesheet-btn:active,
+.add-budget-btn:active,
+.btn-add-task:active,
+.btn-add-timesheet:active,
+.btn-add-budget:active,
+button[onclick*="addTask"]:active,
+button[onclick*="addTimesheet"]:active,
+button[onclick*="addBudget"]:active {
+  transform: scale(0.97);
+  transition: transform 100ms ease-out;
 }

--- a/apps/user-app/css/buttons.css
+++ b/apps/user-app/css/buttons.css
@@ -28,26 +28,6 @@
   overflow: hidden;
 }
 
-.btn::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgb(255 255 255 / 15%),
-    transparent
-  );
-  transition: var(--transition-smooth);
-}
-
-.btn:hover::before {
-  left: 100%;
-}
-
 .btn:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);

--- a/apps/user-app/css/buttons.css
+++ b/apps/user-app/css/buttons.css
@@ -219,7 +219,6 @@
               0 0 0 0 rgb(16 185 129 / 0%);
   transform-origin: center;
   position: relative;
-  animation: plusButtonPulse 3s ease-in-out infinite;
 }
 
 .plus-button i {
@@ -231,7 +230,6 @@
   box-shadow: 0 4px 16px rgb(16 185 129 / 35%),
               0 0 0 4px rgb(16 185 129 / 10%);
   background: linear-gradient(135deg, var(--green-dark) 0%, #047857 100%);
-  animation: none;
 }
 
 .plus-button:hover i {
@@ -240,24 +238,11 @@
 
 .plus-button.active {
   transform: rotate(45deg) !important;
-  animation: none;
 }
 
 .plus-button:active {
   transform: scale(0.98);
   box-shadow: 0 1px 4px rgb(16 185 129 / 20%);
-}
-
-@keyframes plusButtonPulse {
-  0%, 100% {
-    box-shadow: 0 2px 8px rgb(59 130 246 / 25%),
-                0 0 0 0 rgb(59 130 246 / 0%);
-  }
-
-  50% {
-    box-shadow: 0 2px 8px rgb(59 130 246 / 25%),
-                0 0 0 6px rgb(59 130 246 / 8%);
-  }
 }
 
 /* כפתור פלוס בפינה עליונה - 2025 Modern */
@@ -288,7 +273,6 @@
   transition: all 0.2s cubic-bezier(0.23, 1, 0.32, 1);
   box-shadow: 0 2px 8px rgb(59 130 246 / 25%),
               0 0 0 0 rgb(59 130 246 / 0%);
-  animation: plusButtonPulse 3s ease-in-out infinite;
 }
 
 /* כשהטיקר פעיל, תזיז את כפתור הפלוס למטה */
@@ -306,7 +290,6 @@ body.ticker-active .plus-button-top {
   transform: scale(1.05) translateY(-1px);
   box-shadow: 0 4px 16px rgb(59 130 246 / 35%),
               0 0 0 4px rgb(59 130 246 / 10%);
-  animation: none;
 }
 
 .plus-button-top:hover i {
@@ -322,7 +305,6 @@ body.ticker-active .plus-button-top {
 .plus-button-top.active {
   transform: rotate(135deg);
   background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
-  animation: none;
 }
 
 .plus-button-top.active:hover {


### PR DESCRIPTION
## Summary

Sprint 1 של UI polish לפי עקרונות emil-design-eng. שלושה שינויים ממוקדים בקובץ יחיד: [apps/user-app/css/buttons.css](apps/user-app/css/buttons.css).

## What changed

| # | Commit | השינוי |
|---|---|---|
| #2 | `9d45107` | הוספת `:active` עם `scale(0.97)` ל-5 קבוצות כפתורים שחסר להן פידבק לחיצה |
| #4 | `1069ff8` | הסרת האנימציה האינסופית (`plusButtonPulse`) מכפתורי ה-`+` |
| #9 | `e02c45c` | הסרת אפקט ה-shine (ברק זוהר) מ-`.btn` הבסיסי |

סה"כ: 1 קובץ שונה, +38 / −39 שורות.

## מה נשמר

- `.btn-primary`, `.plus-button`, `.plus-button-top` — כבר היה להם `:active`, לא נגעתי
- `.btn.loading::before` — spinner אנימציית טעינה, לא נגעתי
- שאר האנימציות בפרויקט (toast, modal, ticker וכו') — לא בטווח

## Known gaps (תועדו לביקורת Devil's Advocate)

Devil's Advocate audit זיהה 6 ממצאים נוספים שלא טופלו ב-Sprint זה:
- FAB (`.plus-button:active`) נשאר ב-`scale(0.98)` במקום `scale(0.97)` — חוסר עקביות
- `login-modern.css:402` דורס את ה-scale על דף login
- `.btn-secondary` override-ים ב-`forms.css`, `user-alerts.css`
- Transition race ב-`.btn-secondary` (release לוקח 250ms מה-`transition: all 0.25s ease`)
- `.plus-button-top.active:active` חסר combined selector
- Cache-bust `?v=` לא עודכן עדיין — **חייב לפני merge ל-production-stable** (לא לפני DEV)

אלו מועמדים ל-Sprint 2.

## Test plan

- [ ] Netlify DEV preview נטען בהצלחה
- [ ] לחיצה על כפתור success/warning/danger/add-task/secondary — תגובת scale קטנה מורגשת
- [ ] כפתורי ה-`+` (קטן וגדול) — ללא "נשימה" אינסופית; hover ו-active עדיין עובדים
- [ ] `.btn` בסיסי — אין shine עוברת ב-hover; elevation + shadow עדיין עובדים
- [ ] ללא console errors
- [ ] ללא regression בדף login, modals, טפסים

## Next steps

אחרי smoke test ב-DEV:
1. אם PASS — להריץ `node update-cache-busting.js` ו-commit לפני merge ל-production-stable
2. אם FAIL — לחזור ולתקן, או revert commits בודדים

🤖 Generated with [Claude Code](https://claude.com/claude-code)