### PR TITLE
chore: cache-bust post Sprint 1 (v=e02c45c)

### DIFF
--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -44,14 +44,14 @@
 
     <!-- ===== Master Admin Panel Styles ===== -->
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="css/components.css?v=a816380">
-    <link rel="stylesheet" href="css/user-details.css?v=a816380">
-    <link rel="stylesheet" href="css/delete-data-side-panel.css?v=a816380">
-    <link rel="stylesheet" href="css/admin-thread-view.css?v=a816380">
-    <link rel="stylesheet" href="css/message-categories.css?v=a816380">
-    <link rel="stylesheet" href="css/performance-tab.css?v=a816380">
-    <link rel="stylesheet" href="css/task-approval-side-panel.css?v=a816380">
-    <link rel="stylesheet" href="components/task-approval-system/styles/task-approval-dialog.css?v=a816380">
+    <link rel="stylesheet" href="css/components.css?v=e02c45c">
+    <link rel="stylesheet" href="css/user-details.css?v=e02c45c">
+    <link rel="stylesheet" href="css/delete-data-side-panel.css?v=e02c45c">
+    <link rel="stylesheet" href="css/admin-thread-view.css?v=e02c45c">
+    <link rel="stylesheet" href="css/message-categories.css?v=e02c45c">
+    <link rel="stylesheet" href="css/performance-tab.css?v=e02c45c">
+    <link rel="stylesheet" href="css/task-approval-side-panel.css?v=e02c45c">
+    <link rel="stylesheet" href="components/task-approval-system/styles/task-approval-dialog.css?v=e02c45c">
 
     <!-- ===== Pre-Flight Auth Check ===== -->
     <script>
@@ -197,18 +197,18 @@
     </div>
 
     <!-- ===== Core Scripts ===== -->
-    <script src="js/core/firebase.js?v=a816380"></script>
-    <script src="js/core/system-constants.js?v=a816380"></script>
-    <script src="js/core/config-loader.js?v=a816380"></script>
+    <script src="js/core/firebase.js?v=e02c45c"></script>
+    <script src="js/core/system-constants.js?v=e02c45c"></script>
+    <script src="js/core/config-loader.js?v=e02c45c"></script>
     <!-- ✅ Load dependencies BEFORE auth.js -->
-    <script src="js/modules/logger.js?v=a816380"></script>
-    <script src="js/modules/presence-system.js?v=a816380"></script>
-    <script src="js/modules/idle-timeout-manager.js?v=a816380"></script>
-    <script src="js/core/auth.js?v=a816380"></script>
-    <script src="js/core/constants.js?v=a816380"></script>
+    <script src="js/modules/logger.js?v=e02c45c"></script>
+    <script src="js/modules/presence-system.js?v=e02c45c"></script>
+    <script src="js/modules/idle-timeout-manager.js?v=e02c45c"></script>
+    <script src="js/core/auth.js?v=e02c45c"></script>
+    <script src="js/core/constants.js?v=e02c45c"></script>
 
     <!-- ===== Navigation Component ===== -->
-    <script src="js/ui/Navigation.js?v=a816380"></script>
+    <script src="js/ui/Navigation.js?v=e02c45c"></script>
 
     <!-- ===== System Announcements Components ===== -->
     <script src="js/models/SystemAnnouncement.js"></script>
@@ -216,52 +216,52 @@
     <script src="js/ui/AnnouncementEditor.js"></script>
 
     <!-- ===== Phase 2: Data & UI Components ===== -->
-    <script src="js/managers/DataManager.js?v=a816380"></script>
-    <script src="js/ui/StatsCards.js?v=a816380"></script>
-    <script src="js/ui/UsersTable.js?v=a816380"></script>
-    <script src="js/ui/FilterBar.js?v=a816380"></script>
-    <script src="js/ui/Pagination.js?v=a816380"></script>
-    <script src="js/ui/DashboardUI.js?v=a816380"></script>
+    <script src="js/managers/DataManager.js?v=e02c45c"></script>
+    <script src="js/ui/StatsCards.js?v=e02c45c"></script>
+    <script src="js/ui/UsersTable.js?v=e02c45c"></script>
+    <script src="js/ui/FilterBar.js?v=e02c45c"></script>
+    <script src="js/ui/Pagination.js?v=e02c45c"></script>
+    <script src="js/ui/DashboardUI.js?v=e02c45c"></script>
 
     <!-- ===== Phase 3: User Management Logic ===== -->
-    <script src="js/managers/AuditLogger.js?v=a816380"></script>
-    <script src="js/ui/Modals.js?v=a816380"></script>
-    <script src="js/ui/Notifications.js?v=a816380"></script>
-    <script src="js/ui/UserForm.js?v=a816380"></script>
-    <script src="js/ui/UserDetailsModal.js?v=a816380"></script>
-    <script src="js/managers/ReportGenerator.js?v=a816380"></script>
-    <script src="js/ui/DeleteDataSidePanel.js?v=a816380"></script>
-    <script src="js/managers/UsersActions.js?v=a816380"></script>
+    <script src="js/managers/AuditLogger.js?v=e02c45c"></script>
+    <script src="js/ui/Modals.js?v=e02c45c"></script>
+    <script src="js/ui/Notifications.js?v=e02c45c"></script>
+    <script src="js/ui/UserForm.js?v=e02c45c"></script>
+    <script src="js/ui/UserDetailsModal.js?v=e02c45c"></script>
+    <script src="js/managers/ReportGenerator.js?v=e02c45c"></script>
+    <script src="js/ui/DeleteDataSidePanel.js?v=e02c45c"></script>
+    <script src="js/managers/UsersActions.js?v=e02c45c"></script>
 
     <!-- ===== Alert Communication System ===== -->
-    <script src="js/managers/AlertEngine.js?v=a816380"></script>
-    <script src="js/managers/AlertsAnalyticsService.js?v=a816380"></script>
+    <script src="js/managers/AlertEngine.js?v=e02c45c"></script>
+    <script src="js/managers/AlertsAnalyticsService.js?v=e02c45c"></script>
 
     <!-- ===== WhatsApp Messaging System ===== -->
-    <script src="js/managers/WhatsAppMessageDialog.js?v=a816380"></script>
+    <script src="js/managers/WhatsAppMessageDialog.js?v=e02c45c"></script>
 
-    <script src="js/config/message-categories.js?v=a816380"></script>
-    <script src="js/managers/AlertCommunicationManager.js?v=a816380"></script>
-    <script src="js/ui/UserAlertsPanel.js?v=a816380"></script>
-    <script src="js/ui/QuickMessageDialog.js?v=a816380"></script>
-    <script src="js/ui/MessagesFullscreenModal.js?v=a816380"></script>
-    <script src="js/ui/AdminThreadView.js?v=a816380"></script>
+    <script src="js/config/message-categories.js?v=e02c45c"></script>
+    <script src="js/managers/AlertCommunicationManager.js?v=e02c45c"></script>
+    <script src="js/ui/UserAlertsPanel.js?v=e02c45c"></script>
+    <script src="js/ui/QuickMessageDialog.js?v=e02c45c"></script>
+    <script src="js/ui/MessagesFullscreenModal.js?v=e02c45c"></script>
+    <script src="js/ui/AdminThreadView.js?v=e02c45c"></script>
 
     <!-- ===== Task Approval System (for Side Panel) ===== -->
     <script type="module">
         // Load task approval services globally for side panel
-        import { taskApprovalService } from './components/task-approval-system/services/task-approval-service.js?v=a816380';
-        import { TaskApprovalDialog } from './components/task-approval-system/TaskApprovalDialog.js?v=a816380';
+        import { taskApprovalService } from './components/task-approval-system/services/task-approval-service.js?v=e02c45c';
+        import { TaskApprovalDialog } from './components/task-approval-system/TaskApprovalDialog.js?v=e02c45c';
 
         window.taskApprovalService = taskApprovalService;
         window.TaskApprovalDialog = TaskApprovalDialog;
 
         console.log('✅ Task Approval Services loaded globally');
     </script>
-    <script src="js/ui/TaskApprovalSidePanel.js?v=a816380"></script>
+    <script src="js/ui/TaskApprovalSidePanel.js?v=e02c45c"></script>
 
     <!-- ✅ NotificationBell - For admins who are also users -->
-    <script src="js/modules/notification-bell.js?v=a816380"></script>
+    <script src="js/modules/notification-bell.js?v=e02c45c"></script>
     <script>
         // NotificationBell is already initialized by the module itself
         // Just verify it's available
@@ -273,7 +273,7 @@
     </script>
 
     <!-- ===== Floating Action Button ===== -->
-    <script src="js/ui/FloatingActionButton.js?v=a816380"></script>
+    <script src="js/ui/FloatingActionButton.js?v=e02c45c"></script>
 
     <!-- ===== Initialization Script ===== -->
     <script>

--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -118,61 +118,61 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
     />
     <!-- ===== DESIGN SYSTEM - Must be loaded first ===== -->
-    <link rel="stylesheet" href="css/design-system.css?v=a816380" />
-    <link rel="stylesheet" href="css/style.css?v=a816380" />
-    <link rel="stylesheet" href="css/header.css?v=a816380" />
-    <link rel="stylesheet" href="css/content-areas.css?v=a816380" />
-    <link rel="stylesheet" href="css/login-modern.css?v=a816380" />
-    <link rel="stylesheet" href="css/buttons.css?v=a816380" />
-    <link rel="stylesheet" href="css/forms.css?v=a816380" />
-    <link rel="stylesheet" href="css/tables.css?v=a816380" />
-    <link rel="stylesheet" href="css/timesheet-cards.css?v=a816380" />
-    <link rel="stylesheet" href="css/modals.css?v=a816380" />
-    <link rel="stylesheet" href="css/quick-actions-extend-deadline.css?v=a816380" />
-    <link rel="stylesheet" href="css/case-creation-dialog.css?v=a816380" />
-    <link rel="stylesheet" href="css/popups-unified.css?v=a816380" />
-    <link rel="stylesheet" href="css/popups-rtl.css?v=a816380" />
-    <link rel="stylesheet" href="css/edge-polish-modals.css?v=a816380" />
-    <link rel="stylesheet" href="css/expanded-cards.css?v=a816380" />
-    <link rel="stylesheet" href="css/advanced-popups.css?v=a816380" />
-    <link rel="stylesheet" href="css/info-popups.css?v=a816380" />
-    <link rel="stylesheet" href="css/description-tooltips.css?v=a816380" />
-    <link rel="stylesheet" href="css/cards.css?v=a816380" />
-    <link rel="stylesheet" href="css/combobox.css?v=a816380" />
-    <link rel="stylesheet" href="css/notification-system.css?v=a816380" />
-    <link rel="stylesheet" href="css/user-alerts.css?v=a816380" />
-    <link rel="stylesheet" href="css/thread-view.css?v=a816380" />
-    <link rel="stylesheet" href="css/style-hitech-addon.css?v=a816380" />
-    <link rel="stylesheet" href="css/tabs.css?v=a816380" />
-    <link rel="stylesheet" href="css/statistics.css?v=a816380" />
-    <link rel="stylesheet" href="css/sort.css?v=a816380" />
+    <link rel="stylesheet" href="css/design-system.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/style.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/header.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/content-areas.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/login-modern.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/buttons.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/forms.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/tables.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/timesheet-cards.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/modals.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/quick-actions-extend-deadline.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/case-creation-dialog.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/popups-unified.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/popups-rtl.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/edge-polish-modals.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/expanded-cards.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/advanced-popups.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/info-popups.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/description-tooltips.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/cards.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/combobox.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/notification-system.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/user-alerts.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/thread-view.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/style-hitech-addon.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/tabs.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/statistics.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/sort.css?v=e02c45c" />
     <link rel="stylesheet" href="css/reports.css" />
-    <link rel="stylesheet" href="css/pagination.css?v=a816380" />
+    <link rel="stylesheet" href="css/pagination.css?v=e02c45c" />
 
     <!-- TaskTimeline Component -->
-    <link rel="stylesheet" href="components/task-timeline/TaskTimeline.css?v=a816380" />
+    <link rel="stylesheet" href="components/task-timeline/TaskTimeline.css?v=e02c45c" />
     <!-- Utility Classes - כלי עזר -->
-    <link rel="stylesheet" href="css/utilities.css?v=a816380" />
+    <link rel="stylesheet" href="css/utilities.css?v=e02c45c" />
     <!-- Smart Combo Selector - בורר תיאורים חכם -->
-    <link rel="stylesheet" href="css/smart-combo-selector.css?v=a816380" />
-    <link rel="stylesheet" href="css/guided-text-input.css?v=a816380" />
+    <link rel="stylesheet" href="css/smart-combo-selector.css?v=e02c45c" />
+    <link rel="stylesheet" href="css/guided-text-input.css?v=e02c45c" />
     <!-- Responsive Design - מדיה queries -->
-    <link rel="stylesheet" href="css/responsive.css?v=a816380" />
+    <link rel="stylesheet" href="css/responsive.css?v=e02c45c" />
 
     <!-- Virtual Assistant Styles - TEMPORARILY DISABLED -->
-    <!-- <link rel="stylesheet" href="js/modules/virtual-assistant/virtual-assistant.css?v=a816380" /> -->
+    <!-- <link rel="stylesheet" href="js/modules/virtual-assistant/virtual-assistant.css?v=e02c45c" /> -->
 
     <!-- ===== AI CHAT SYSTEM (NEW) ===== -->
-    <link rel="stylesheet" href="js/modules/ai-system/ai-chat.css?v=a816380">
+    <link rel="stylesheet" href="js/modules/ai-system/ai-chat.css?v=e02c45c">
 
     <!-- ===== SYSTEM ANNOUNCEMENT TICKER ===== -->
-    <link rel="stylesheet" href="css/system-announcement-ticker.css?v=a816380" />
+    <link rel="stylesheet" href="css/system-announcement-ticker.css?v=e02c45c" />
 
     <!-- ===== SYSTEM ANNOUNCEMENT POPUP ===== -->
-    <link rel="stylesheet" href="css/system-announcement-popup.css?v=a816380" />
+    <link rel="stylesheet" href="css/system-announcement-popup.css?v=e02c45c" />
 
     <!-- ===== BREAK BUTTON ===== -->
-    <link rel="stylesheet" href="css/break-button.css?v=a816380" />
+    <link rel="stylesheet" href="css/break-button.css?v=e02c45c" />
 
     <!-- ===== SECURITY MODALS STYLES ===== -->
     <!-- Google Fonts - Inter for Linear-style Idle Warning -->
@@ -1181,61 +1181,61 @@
     <!-- SCRIPTS AND STYLES -->
     <!-- ===== 🔇 Production Logger - MUST BE FIRST ===== -->
     <!-- מערכת לוגים מרכזית - מצב ייצור (מינימום לוגים) -->
-    <script src="js/modules/logger.js?v=a816380"></script>
-    <script src="js/core/system-constants.js?v=a816380"></script>
-    <script src="js/core/config-loader.js?v=a816380"></script>
+    <script src="js/modules/logger.js?v=e02c45c"></script>
+    <script src="js/core/system-constants.js?v=e02c45c"></script>
+    <script src="js/core/config-loader.js?v=e02c45c"></script>
 
     <!-- ===== ⚡ Lazy Loader - Dynamic Script Loading ===== -->
     <!-- טעינה דינמית של סקריפטים - שיפור ביצועים -->
-    <script defer src="js/modules/lazy-loader.js?v=a816380"></script>
+    <script defer src="js/modules/lazy-loader.js?v=e02c45c"></script>
 
-    <script defer src="js/modules/dates.js?v=a816380"></script>
-    <script defer src="js/modules/statistics.js?v=a816380"></script>
-    <script defer src="js/modules/pagination.js?v=a816380"></script>
-    <script defer src="js/modules/activity-logger.js?v=a816380"></script>
+    <script defer src="js/modules/dates.js?v=e02c45c"></script>
+    <script defer src="js/modules/statistics.js?v=e02c45c"></script>
+    <script defer src="js/modules/pagination.js?v=e02c45c"></script>
+    <script defer src="js/modules/activity-logger.js?v=e02c45c"></script>
 
     <!-- ===== 🚀 NEW ARCHITECTURE v2.0 - Event-Driven System ===== -->
     <!-- Type-safe Event Bus + Firebase Facade -->
-    <script type="module" src="dist/js/core/event-bus.js?v=a816380"></script>
-    <script type="module" src="dist/js/services/firebase-service.js?v=a816380"></script>
+    <script type="module" src="dist/js/core/event-bus.js?v=e02c45c"></script>
+    <script type="module" src="dist/js/services/firebase-service.js?v=e02c45c"></script>
 
     <!-- ✨ NEW: Modular Deduction System -->
     <!-- Shared library for hours calculation and deduction logic -->
-    <script type="module" src="src/modules/deduction/index.js?v=a816380"></script>
+    <script type="module" src="src/modules/deduction/index.js?v=e02c45c"></script>
 
-    <script defer src="js/modules/task-actions.js?v=a816380"></script>
+    <script defer src="js/modules/task-actions.js?v=e02c45c"></script>
     <!-- ✨ NEW: Task Completion Validation System -->
     <!-- Industry-standard task completion with time gap validation -->
-    <script defer src="js/modules/task-completion-validation.js?v=a816380"></script>
+    <script defer src="js/modules/task-completion-validation.js?v=e02c45c"></script>
     <!-- ✨ NEW: TaskTimeline Component -->
     <!-- Unified timeline display for task history -->
-    <script defer src="components/task-timeline/TaskTimeline.js?v=a816380"></script>
-    <script type="module" src="js/modules/firebase-pagination.js?v=a816380"></script>
-    <script defer src="js/modules/integration-manager.js?v=a816380"></script>
+    <script defer src="components/task-timeline/TaskTimeline.js?v=e02c45c"></script>
+    <script type="module" src="js/modules/firebase-pagination.js?v=e02c45c"></script>
+    <script defer src="js/modules/integration-manager.js?v=e02c45c"></script>
     <!-- Firebase Functions Migration - Server-side Integration -->
-    <script defer src="js/modules/api-client-v2.js?v=a816380"></script>
-    <script src="js/modules/firebase-server-adapter.js?v=a816380"></script>
+    <script defer src="js/modules/api-client-v2.js?v=e02c45c"></script>
+    <script src="js/modules/firebase-server-adapter.js?v=e02c45c"></script>
     <!-- Employees Management System - ניהול עובדים -->
-    <script type="module" src="js/modules/employees-manager.js?v=a816380"></script>
+    <script type="module" src="js/modules/employees-manager.js?v=e02c45c"></script>
     <!-- ✅ Presence System - מעקב משתמשים בזמן אמת (Realtime Database) -->
-    <script defer src="js/modules/presence-system.js?v=a816380"></script>
+    <script defer src="js/modules/presence-system.js?v=e02c45c"></script>
     <!-- ✅ NEW: Idle Timeout Manager - התנתקות אוטומטית אחרי חוסר פעילות -->
-    <script src="js/modules/idle-timeout-manager.js?v=a816380"></script>
+    <script src="js/modules/idle-timeout-manager.js?v=e02c45c"></script>
 
     <!-- Cases Management System - ניהול תיקים -->
-    <script src="js/cases.js?v=a816380"></script>
-    <script src="js/cases-integration.js?v=a816380"></script>
+    <script src="js/cases.js?v=e02c45c"></script>
+    <script src="js/cases-integration.js?v=e02c45c"></script>
 
 
     <!-- ===== Lottie Animations Configuration ===== -->
     <!-- MUST BE LOADED BEFORE NotificationSystem -->
-    <script src="js/modules/lottie-animations.js?v=a816380"></script>
-    <script src="js/modules/lottie-manager.js?v=a816380"></script>
+    <script src="js/modules/lottie-animations.js?v=e02c45c"></script>
+    <script src="js/modules/lottie-manager.js?v=e02c45c"></script>
 
     <!-- ===== Notification System ===== -->
     <!-- Toast notifications with Lottie animations -->
-    <script defer src="js/modules/notification-messages.js?v=a816380"></script>
-    <script src="js/modules/notification-system.js?v=a816380"></script>
+    <script defer src="js/modules/notification-messages.js?v=e02c45c"></script>
+    <script src="js/modules/notification-system.js?v=e02c45c"></script>
 
     <!-- ===== 🎯 NEW: Unified UI System - Step 1: Load Components ===== -->
     <!-- Feature Flags - Controls whether to use new or legacy system -->
@@ -1253,57 +1253,57 @@
 
     <!-- ===== NEW: Modals Manager System ===== -->
     <!-- Centralized modal management -->
-    <script src="js/modules/modals-manager.js?v=a816380"></script>
+    <script src="js/modules/modals-manager.js?v=e02c45c"></script>
     <!-- Compatibility layer for smooth migration -->
-    <script defer src="js/modules/modals-compat.js?v=a816380"></script>
+    <script defer src="js/modules/modals-compat.js?v=e02c45c"></script>
 
     <!-- ===== Shared Service Card Renderer ===== -->
     <!-- Prevents code duplication between modules -->
-    <script defer src="js/modules/service-card-renderer.js?v=a816380"></script>
+    <script defer src="js/modules/service-card-renderer.js?v=e02c45c"></script>
 
     <!-- ===== Shared Client Search Component ===== -->
     <!-- Unified client search and filtering logic -->
-    <script defer src="js/modules/ui/client-search.js?v=a816380"></script>
+    <script defer src="js/modules/ui/client-search.js?v=e02c45c"></script>
 
     <!-- ===== NEW: Client-Case Selector Component ===== -->
     <!-- Unified two-step client→case selection -->
-    <script defer src="js/modules/client-case-selector.js?v=a816380"></script>
+    <script defer src="js/modules/client-case-selector.js?v=e02c45c"></script>
     <!-- Client-Case Selectors Initialization -->
-    <script defer src="js/modules/selectors-init.js?v=a816380"></script>
+    <script defer src="js/modules/selectors-init.js?v=e02c45c"></script>
 
     <!-- ===== 🔍 Performance Monitoring System ===== -->
     <!-- Real-time performance tracking for critical operations -->
-    <script defer src="js/modules/monitoring/performance-monitor.js?v=a816380"></script>
+    <script defer src="js/modules/monitoring/performance-monitor.js?v=e02c45c"></script>
 
     <!-- ===== 🧪 TESTING: New Case Creation Module ===== -->
     <!-- Modern modular case creation system - currently in testing -->
-    <script defer src="js/modules/case-creation/case-number-generator.js?v=a816380"></script>
-    <script defer src="js/modules/case-creation/case-form-validator.js?v=a816380"></script>
-    <script defer src="js/modules/case-creation/case-creation-dialog.js?v=a816380"></script>
+    <script defer src="js/modules/case-creation/case-number-generator.js?v=e02c45c"></script>
+    <script defer src="js/modules/case-creation/case-form-validator.js?v=e02c45c"></script>
+    <script defer src="js/modules/case-creation/case-creation-dialog.js?v=e02c45c"></script>
 
     <!-- ===== Smart Descriptions System ===== -->
     <!-- Structured descriptions manager for tasks and work entries -->
-    <script defer src="js/modules/descriptions/category-mapping.js?v=a816380"></script>
-    <script defer src="js/modules/descriptions/descriptions-manager.js?v=a816380"></script>
-    <script defer src="js/modules/descriptions/smart-combo-selector.js?v=a816380"></script>
-    <script defer src="js/modules/descriptions/GuidedTextInput.js?v=a816380"></script>
+    <script defer src="js/modules/descriptions/category-mapping.js?v=e02c45c"></script>
+    <script defer src="js/modules/descriptions/descriptions-manager.js?v=e02c45c"></script>
+    <script defer src="js/modules/descriptions/smart-combo-selector.js?v=e02c45c"></script>
+    <script defer src="js/modules/descriptions/GuidedTextInput.js?v=e02c45c"></script>
 
     <!-- ===== Core Utilities Module ===== -->
     <!-- Must load before dialogs.js (provides safeText) -->
-    <script type="module" src="js/modules/core-utils.js?v=a816380"></script>
+    <script type="module" src="js/modules/core-utils.js?v=e02c45c"></script>
 
     <!-- ===== Dialogs Module ===== -->
     <!-- Task completion, advanced dialogs, and other modals + Smart Descriptions -->
-    <script defer src="js/modules/dialogs.js?v=a816380"></script>
+    <script defer src="js/modules/dialogs.js?v=e02c45c"></script>
 
     <!-- ===== System Diagnostics & Snapshot Tool ===== -->
     <!-- Full system state comparison for debugging -->
-    <script defer src="js/modules/system-snapshot.js?v=a816380"></script>
+    <script defer src="js/modules/system-snapshot.js?v=e02c45c"></script>
     <!-- Event Flow Analyzer - DEV ONLY - removed to prevent CSP errors in production -->
-    <!-- <script defer src="js/modules/event-analyzer.js?v=a816380"></script> -->
+    <!-- <script defer src="js/modules/event-analyzer.js?v=e02c45c"></script> -->
 
     <!-- ===== SVG RINGS MODULE ===== -->
-    <script defer src="js/modules/svg-rings.js?v=a816380"></script>
+    <script defer src="js/modules/svg-rings.js?v=e02c45c"></script>
 
     <!-- ===== INLINE EXPANSION POPOVER (CSS-only) ===== -->
     <!-- popover-positioning.js removed - file does not exist -->
@@ -1311,23 +1311,23 @@
     <!-- ===== Messaging System ===== -->
     <!-- ===== NEW: Main Application (ES6 Modules) ===== -->
     <!-- Modern modular architecture with ActionFlowManager + Smart Descriptions -->
-    <script type="module" src="js/main.js?v=a816380"></script>
-    <script type="module" src="js/modules/description-tooltips.js?v=a816380"></script>
+    <script type="module" src="js/main.js?v=e02c45c"></script>
+    <script type="module" src="js/modules/description-tooltips.js?v=e02c45c"></script>
 
     <!-- ===== SYSTEM ANNOUNCEMENT TICKER ===== -->
     <!-- Loaded as module by main.js -->
 
     <!-- Work Hours Calculator - Smart Calendar System -->
-    <script defer src="js/modules/work-hours-calculator.js?v=a816380"></script>
+    <script defer src="js/modules/work-hours-calculator.js?v=e02c45c"></script>
 
     <!-- ===== KNOWLEDGE BASE 1.0.0 - מרכז עזרה וידע ===== -->
     <!-- ⚡ KB scripts lazy-loaded on first help click (see authentication.js showApp) -->
 
     <!-- CSS -->
-    <link rel="stylesheet" href="js/modules/knowledge-base/knowledge-base.css?v=a816380">
+    <link rel="stylesheet" href="js/modules/knowledge-base/knowledge-base.css?v=e02c45c">
 
     <!-- ===== Virtual Assistant 3.9.0 - TEMPORARILY DISABLED ===== -->
-    <!-- <script src="js/modules/virtual-assistant/virtual-assistant-complete.js?v=a816380"></script> -->
+    <!-- <script src="js/modules/virtual-assistant/virtual-assistant-complete.js?v=e02c45c"></script> -->
 
     <!-- ===== AI CHAT SYSTEM (NEW) - LAZY LOADED ===== -->
     <!-- ⚡ NotificationBell is also lazy-loaded (requires authenticated user) -->
@@ -1337,10 +1337,10 @@
     <!-- See: authentication.js -> initAIChatSystem() -->
 
     <!-- OLD: Legacy FAQ Bot (backup) -->
-    <!-- <script type="module" src="js/modules/smart-faq-bot.js?v=a816380"></script> -->
+    <!-- <script type="module" src="js/modules/smart-faq-bot.js?v=e02c45c"></script> -->
 
     <!-- ===== OLD: Legacy script.js (DEPRECATED - will be removed) ===== -->
-    <!-- <script src="script.js?v=a816380"></script> -->
+    <!-- <script src="script.js?v=e02c45c"></script> -->
 
 
 


### PR DESCRIPTION
## Summary

PR #216 (Sprint 1 UI polish) נמזג ל-main עם cache-bust ישן (`?v=a816380`).
ה-commit של cache-bust נדחף אחרי ה-merge ולא הספיק לעלות.

ה-PR הזה מעביר רק את ה-commit החסר (`9b1febe` → cherry-picked כ-`7d639db`).

## What changed

- `apps/user-app/index.html` — 92 `?v=` params updated to `v=e02c45c`
- `apps/admin-panel/index.html` — 45 `?v=` params updated to `v=e02c45c`

## Why this matters

MEMORY `feedback_cache_bust_bump.md`: "Always bump ?v=xxx in HTML when
modifying referenced JS/CSS — or browsers serve stale cached files".

Without this bump, DEV users with old cache won't see Sprint 1 changes
until a hard refresh.

## Test plan

- [ ] Deploy Preview loads successfully
- [ ] Open DevTools Network tab → reload → all CSS/JS requests use `?v=e02c45c`
- [ ] Visual smoke test identical to PR #216 (buttons behave as expected)

## Scope

Cache-bust only. Zero code logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)