### PR TITLE
fix(user-app): default budget sort to deadline, session-only

### DIFF
--- a/apps/user-app/js/config/state-config.js
+++ b/apps/user-app/js/config/state-config.js
@@ -50,7 +50,7 @@ export const DEFAULTS = {
   // User Preferences (Can be persisted) - ניתן לשמירה
   BUDGET_VIEW: 'cards',            // ✅ ניתן לשמור
   TIMESHEET_VIEW: 'table',         // ✅ ניתן לשמור
-  BUDGET_SORT: 'recent',           // ✅ ניתן לשמור
+  BUDGET_SORT: 'deadline',         // ✅ session-only — תמיד מתחיל ב-deadline
   TIMESHEET_SORT: 'recent'         // ✅ ניתן לשמור
 };
 
@@ -71,7 +71,8 @@ export const SESSION_ONLY_KEYS = [
   'taskFilter',           // ✅ Always reset to 'active'
   'timesheetFilter',      // ✅ Always reset to 'month'
   'currentPage',          // ✅ Always start at page 1
-  'searchQuery'           // ✅ Always start with empty search
+  'searchQuery',          // ✅ Always start with empty search
+  'budgetSort'            // ✅ Always reset to 'deadline' — closest deadline first
 ];
 
 /**
@@ -86,7 +87,6 @@ export const SESSION_ONLY_KEYS = [
 export const PERSISTED_KEYS = [
   'budgetView',           // ✅ cards/table preference
   'timesheetView',        // ✅ cards/table preference
-  'budgetSort',           // ✅ sort preference
   'timesheetSort'         // ✅ sort preference
 ];
 

--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -1476,6 +1476,14 @@ return;
       // 'all' - show everything (including pending_approval)
       this.filteredBudgetTasks = [...this.budgetTasks];
     }
+
+    // Apply current sort preference (default 'deadline') — prevents real-time
+    // listener updates from rendering tasks in arbitrary Firestore order
+    this.filteredBudgetTasks = Search.sortBudgetTasks(
+      this.filteredBudgetTasks,
+      this.currentBudgetSort || 'deadline'
+    );
+
     this.renderBudgetView();
   }
 


### PR DESCRIPTION
## Summary
Fixes a UX issue where the active tasks list briefly showed correct deadline order on first load, then real-time listener overwrote it with arbitrary Firestore document order ~500ms after login. User saw unsorted tasks until F5 refresh.

**Files changed (only user-facing code in this PR):**
- `apps/user-app/js/config/state-config.js` — 6 lines
- `apps/user-app/js/main.js` — 8 lines added

## Three changes
1. Default `BUDGET_SORT` changed from `'recent'` (last update) to `'deadline'` (closest first)
2. `budgetSort` moved from `PERSISTED_KEYS` to `SESSION_ONLY_KEYS` — user selections from the sort dropdown apply only to the current session and reset on refresh/login
3. `filterBudgetTasks()` now applies the current sort after filtering, so real-time listener updates no longer leave tasks in arbitrary order

## Why session-only?
Reporter (Haim) explicitly requested: every entry to the system should default to deadline-first. If user picks a different sort temporarily, that's fine — but on refresh/login it should reset to deadline.

## Backward compatibility
Existing `localStorage` values for `budgetSort` are silently ignored (no breakage for users who previously had a saved preference — they just get the new default).

## Validation
- ✅ Verified in DEV by reporter — first login now shows deadline-sorted list immediately, no more 6-second flash of arbitrary order
- ✅ Diagnostic spy confirmed root cause: real-time listener wrote to `window.budgetTasks` 553ms after initial load, overwriting the sorted result
- ✅ `Search.sortBudgetTasks` already handles tasks without deadline via fallback `'9999-12-31'`
- ✅ No code references `localStorage.getItem('budgetSort')` directly — all goes through `STATE_CONFIG.getStateValue`

## Test plan
- [ ] Merge triggers Netlify PROD build
- [ ] Hard refresh https://gh-law-office-system.netlify.app
- [ ] Logout + login → tasks immediately sorted by deadline (no flash)
- [ ] F5 → sort preserved
- [ ] Pick "name" from dropdown → tasks re-sort by name
- [ ] F5 → resets to deadline (preference not persisted)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)