### PR TITLE
fix(user-app): completed tab default sort by recent, not deadline

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -1477,11 +1477,14 @@ return;
       this.filteredBudgetTasks = [...this.budgetTasks];
     }
 
-    // Apply current sort preference (default 'deadline') — prevents real-time
-    // listener updates from rendering tasks in arbitrary Firestore order
+    // Apply current sort preference — prevents real-time listener updates
+    // from rendering tasks in arbitrary Firestore order.
+    // Default differs by tab: active uses deadline (closest first),
+    // completed uses recent (most recently updated/completed first).
+    const defaultSort = this.currentTaskFilter === 'completed' ? 'recent' : 'deadline';
     this.filteredBudgetTasks = Search.sortBudgetTasks(
       this.filteredBudgetTasks,
-      this.currentBudgetSort || 'deadline'
+      this.currentBudgetSort || defaultSort
     );
 
     this.renderBudgetView();


### PR DESCRIPTION
## Summary
Edge case fix on top of PR #223. When real-time listener fires while user is on the 'completed' tab, the previous fix would re-sort completed tasks by deadline (oldest deadline first) instead of by completion date. Now active tasks default to 'deadline' and completed tasks default to 'recent'.

**Files changed:** `apps/user-app/js/main.js` — 6 lines

## Why
- Active tab: user wants closest deadline first ✅ (PR #223)
- Completed tab: user wants most recently completed first ✅ (this PR)
- The toggleBudgetView path already loads completed tasks ordered by `completedAt desc` from server — unaffected
- Only the listener-driven `filterBudgetTasks()` path needed this fix

## Verification
- ✅ Verified in DEV by reporter — completed tab sort still shows newest-first
- ✅ Active tab regression check passed — deadline sort still works
- ✅ User selections from sort dropdown still respected (no impact)

## Backward compatibility
None needed — purely default value change inside a function.

## Test plan
- [ ] Hard refresh https://gh-law-office-system.netlify.app after merge
- [ ] Click "הושלמו" tab → newest-completed appears first
- [ ] Click "פעילות" tab → closest deadline appears first
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)