### PR TITLE
feat(user-app): deadline format toggle + cards polish + timesheet align

### DIFF
--- a/apps/user-app/css/cards.css
+++ b/apps/user-app/css/cards.css
@@ -868,17 +868,6 @@
 
 /* כותרת יפה עם מסגרת מתרחבת */
 
-/* תגיות מידע בכרטיס (Case + Service) */
-.linear-card-badges {
-  position: absolute;
-  top: 8px; /* ✅ הוזז עוד יותר למעלה - קרוב לכותרת */
-  left: 12px;
-  z-index: var(--z-card-badge);
-  display: inline-flex; /* ✅ רק רוחב התוכן */
-  width: fit-content; /* ✅ לא לכל הרוחב */
-  max-width: calc(100% - 24px); /* ✅ מקסימום עד קצה הכרטיס */
-}
-
 /*
  * Card title — Claude.ai: full name is shown, the card grows as needed.
  * No line-clamp, no ellipsis, no "+" affordance for the hidden remainder.

--- a/apps/user-app/css/cards.css
+++ b/apps/user-app/css/cards.css
@@ -8,21 +8,440 @@
  */
 
 /* ==========================================================================
+   CARD PROGRESS ROWS — horizontal bars (Linear / Vercel style)
+
+   Replaces the SVG rings block with two compact rows:
+     label | bar | value | percent | optional action
+   Reads top-to-bottom in one glance, shaves ~60px per card, and the bar
+   fill color carries the 2-signals palette (gray default → red on alarm).
+   ========================================================================== */
+
+.card-progress-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 4px 0 10px;
+  direction: rtl;
+}
+
+.progress-row {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--gray-700);
+  direction: rtl;
+  width: 100%;
+  min-width: 0;
+}
+
+/* Fixed-width label for column alignment across the two rows */
+.progress-row-label {
+  flex-shrink: 0;
+  flex-grow: 0;
+  width: 40px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--gray-500);
+  text-align: right;
+}
+
+/* Bar track — soft gray pill, expands to fill remaining row width */
+.progress-row-bar {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 7px;
+  background: var(--gray-200);
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+  transition: background-color 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/*
+ * Row-level hover: the track darkens slightly and the fill picks up a
+ * brighter highlight overlay. This gives the "sheen / hover surface"
+ * feel the user asked for — the bar reads as an interactive element
+ * that's alive under the cursor, matching Claude.ai's row-hover feel.
+ */
+.progress-row:hover .progress-row-bar {
+  background: var(--gray-300);
+}
+
+.progress-row-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    180deg,
+    rgb(255 255 255 / 25%) 0%,
+    rgb(255 255 255 / 0%) 60%
+  );
+  opacity: 0;
+  transition: opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+  pointer-events: none;
+}
+
+.progress-row:hover .progress-row-fill::after {
+  opacity: 1;
+}
+
+/*
+ * Bar fill — progressive color based on a data-level attribute set from
+ * the JS render. The level encodes where the bar stands on a 4-stage
+ * severity ramp:
+ *
+ *   low     (0–49%)   = calm blue
+ *   medium  (50–79%)  = deeper blue-teal
+ *   high    (80–99%)  = amber (getting close — early warning)
+ *   alarm   (>=100%)  = red (overrun / overdue)
+ *
+ * Using a gradient (not a flat color) gives the bar a subtle sheen that
+ * reads as a hover-style surface, matching the Claude.ai feel the user
+ * asked for. background-image is animated with a short transition so
+ * the color shift feels smooth when data updates.
+ */
+.progress-row-fill {
+  display: block;
+  position: relative;
+  height: 100%;
+  border-radius: 4px;
+  background: linear-gradient(
+    180deg,
+    rgb(59 130 246 / 95%) 0%,
+    rgb(37 99 235 / 100%) 100%
+  );
+  transition:
+    width 400ms cubic-bezier(0.23, 1, 0.32, 1),
+    background 220ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.progress-row-fill[data-level="medium"] {
+  background: linear-gradient(
+    180deg,
+    rgb(37 99 235 / 100%) 0%,
+    rgb(29 78 216 / 100%) 100%
+  );
+}
+
+.progress-row-fill[data-level="high"] {
+  background: linear-gradient(
+    180deg,
+    rgb(245 158 11 / 100%) 0%,
+    rgb(217 119 6 / 100%) 100%
+  );
+}
+
+.progress-row-fill[data-level="alarm"] {
+  background: linear-gradient(
+    180deg,
+    rgb(239 68 68 / 100%) 0%,
+    rgb(220 38 38 / 100%) 100%
+  );
+}
+
+/*
+ * Row in alarm state — percent text follows the bar color so the whole
+ * row reads as a single red signal. The value text stays neutral (gray)
+ * so the signal is unambiguous.
+ */
+.progress-row.is-alarm .progress-row-percent {
+  color: #dc2626;
+}
+
+/*
+ * Invisible placeholder reserving the same width as .progress-row-action
+ * (22px box + no margin/padding since the flex gap handles spacing).
+ * Keeps both rows' bars ending at the identical x-coordinate regardless
+ * of whether a row has an update/extend button.
+ */
+.progress-row-action-placeholder {
+  flex-shrink: 0;
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+}
+
+/*
+ * Main value — fixed width (not min-width). Both rows use the same 88px
+ * so "2.4ש / 3.3ש" (budget row) and "13 ימים" (deadline row) occupy the
+ * same column, guaranteeing the bars end at the same x-position in both
+ * rows. Without this, the deadline bar ends up noticeably longer than
+ * the budget bar purely because its value text is shorter — which reads
+ * like a data difference that isn't real.
+ */
+.progress-row-value {
+  flex-shrink: 0;
+  flex-grow: 0;
+  width: 78px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-800);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/*
+ * Percent — fixed width, same reason as above. Keeping it fixed at 44px
+ * lets "100%", "129%" and "7%" all stay aligned on the right edge.
+ */
+.progress-row-percent {
+  flex-shrink: 0;
+  flex-grow: 0;
+  width: 38px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-900);
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+  letter-spacing: -0.01em;
+}
+
+/* Inline "(עודכן)" hint inside the value cell — quiet caption */
+.progress-row-adjusted {
+  color: var(--gray-500);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+/* Inline action button (עדכן תקציב / הארך יעד) — icon-only pill next to
+ * the row. Claude.ai style: transparent default, soft gray on hover. */
+.progress-row-action {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--gray-600);
+  cursor: pointer;
+  font-size: 10px;
+  transform-origin: center;
+  transition:
+    background-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.progress-row-action:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+  border-color: var(--gray-300);
+}
+
+.progress-row-action:active {
+  transform: scale(0.95);
+}
+
+.progress-row-action:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
+}
+
+/*
+ * Per-icon hover micro-motion — Claude.ai choreography.
+ *
+ * Each icon gets a 2-stage keyframe animation on hover: an overshoot
+ * frame (50%) that goes further than the resting position, then the
+ * rest frame (100%) that settles back. The easing curve
+ * cubic-bezier(0.34, 1.56, 0.64, 1) pushes past the destination and
+ * springs back, giving the motion a physical "bounce" feel rather than
+ * a flat linear glide.
+ *
+ * Duration 320ms is long enough to read the motion without feeling
+ * sluggish on a hover-only interaction. Emil's "don't animate things
+ * triggered 100x/day" rule is satisfied — a hover on an icon-only
+ * action button is a deliberate, occasional gesture.
+ */
+.progress-row-action i {
+  display: inline-block;
+  transform-origin: center;
+  transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.progress-row-action:hover .fa-edit {
+  animation: pencil-write-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.progress-row-action:hover .fa-calendar-plus {
+  animation: calendar-open-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/*
+ * Keyframe amplitudes trimmed after user feedback: the earlier version
+ * (translate -3px + rotate -15°) read as "dramatic", not subtle. The
+ * new values still have overshoot (cubic-bezier spring applies to them)
+ * but the resting rotation is only 4° and the translate is ~1px,
+ * giving a tactile-but-quiet feel.
+ */
+@keyframes pencil-write-hover {
+  0% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+
+  55% {
+    transform: translate(-2px, -2px) rotate(-10deg);
+  }
+
+  100% {
+    transform: translate(-1px, -1px) rotate(-4deg);
+  }
+}
+
+@keyframes calendar-open-hover {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+
+  55% {
+    transform: scale(1.18) rotate(4deg);
+  }
+
+  100% {
+    transform: scale(1.08) rotate(0deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-row-action i {
+    transition: none;
+  }
+
+  .progress-row-action:hover .fa-edit,
+  .progress-row-action:hover .fa-calendar-plus {
+    animation: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-row-fill,
+  .progress-row-action {
+    transition: none;
+  }
+
+  .progress-row-action:active {
+    transform: none;
+  }
+}
+
+/* ==========================================================================
+   DEADLINE FORMAT TOGGLE — quiet segmented control next to view-tabs
+
+   Two-state switch (תאריך | ימים) that lets the user pick how deadlines
+   are rendered. Intentionally lower-key than the view-tabs beside it:
+   smaller footprint, no shadow, subtle active-state inversion. This is
+   a display preference, not a primary navigation, so it should recede
+   visually until the user reaches for it.
+   ========================================================================== */
+.deadline-format-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--gray-100, #f3f4f6);
+  border: 1px solid var(--gray-200, #e5e7eb);
+  border-radius: 8px;
+  direction: rtl;
+}
+
+.deadline-format-btn {
+  appearance: none;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-600, #4b5563);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.deadline-format-btn:hover:not(.active) {
+  color: var(--gray-900, #111827);
+  background: rgb(255 255 255 / 60%);
+}
+
+.deadline-format-btn.active {
+  background: #fff;
+  color: var(--gray-900, #111827);
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+}
+
+.deadline-format-btn:active {
+  transform: scale(0.97);
+}
+
+.deadline-format-btn:focus-visible {
+  outline: 2px solid var(--blue, #3b82f6);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deadline-format-btn {
+    transition: none;
+  }
+
+  .deadline-format-btn:active {
+    transform: none;
+  }
+}
+
+/* ==========================================================================
    CARDS - כרטיסיות בסגנון Linear
    ========================================================================== */
 
-/* Grid layouts - 3 כרטיסיות ריבועיות בשורה כמו Linear */
+/*
+ * Grid — density first, flat on the page.
+ *
+ * 300px minimum (comfortably fits 2 rings + card content), no
+ * max-width (grid fills whatever container the app gives it).
+ * Screens become denser instead of blank:
+ *   13" ≈ 1280px viewport → 3 cards
+ *   15" ≈ 1440px viewport → 4 cards
+ *   24" ≈ 1920px viewport → 5-6 cards
+ *   30" ≈ 2560px viewport → 7-8 cards
+ *
+ * No surrounding container, no gray tray, no border — the cards
+ * themselves carry the visual structure (white with thin gray border).
+ * This matches Claude.ai / Linear / Vercel where content grids are
+ * flat on the page, not nested inside wrapper boxes.
+ */
 .cards-grid,
 .budget-cards-grid,
 .timesheet-cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); /* ✅ רוחב מינימום קבוע - כולם זהים! */
-  gap: 24px;
-  padding: 0 12px; /* padding מצדדים לתאימות עם הטבלה */
-  margin: 32px auto;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 12px;
+  padding: 0;
+  margin: 16px 0 12px;
   direction: rtl;
-  max-width: 1200px; /* ✅ רוחב מקסימלי גדול יותר */
   width: 100%;
+}
+
+/* On very wide screens (24"+) give the grid more breathing padding so
+ * cards don't crash into the viewport edge, but keep filling the width. */
+@media (width >= 1920px) {
+  .cards-grid,
+  .budget-cards-grid,
+  .timesheet-cards-grid {
+    padding: 0 40px;
+    gap: 20px;
+  }
 }
 
 /* Container משותף לכרטיסיות וטבלה - עיצוב אחיד */
@@ -85,35 +504,55 @@
   width: 100%;
 }
 
+/*
+ * Actions dropdown button — Claude.ai-style pill.
+ * Default: subtle gray button (no colored border, no gradient background).
+ * Hover: gray fills in. The chevron still rotates 180° on hover because
+ * it conveys state ("about to open"), which Emil allows as a micro-cue
+ * on hover (not idle).
+ */
 .actions-dropdown-btn {
-  padding: 6px 10px; /* הקטנה נוספת */
-  border: 2px solid #3b82f6;
-  border-radius: 4px; /* הקטנה */
-  background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);
-  color: #3b82f6;
+  padding: 6px 10px;
+  border: 1px solid var(--gray-300);
+  border-radius: 6px;
+  background: #fff;
+  color: var(--gray-700);
   cursor: pointer;
-  transition: all 0.2s ease;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 11px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 3px; /* הקטנה */
+  gap: 4px;
   direction: rtl;
-  width: 60px; /* הקטנה ל-60px */
+  width: 60px;
   white-space: nowrap;
+  transform-origin: center;
+  transition:
+    background-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .actions-dropdown-btn:hover {
-  background: #3b82f6;
-  color: white;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgb(59 130 246 / 30%);
+  background: var(--gray-50);
+  color: var(--gray-900);
+  border-color: var(--gray-400);
+}
+
+.actions-dropdown-btn:active {
+  transform: scale(0.97);
+}
+
+.actions-dropdown-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
 }
 
 .actions-dropdown-btn i {
   font-size: 10px;
-  transition: transform 0.2s ease;
+  transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .actions-dropdown-btn:hover i {
@@ -344,52 +783,17 @@
 
 /* תאריך יצירה - כבר מוגדר ב-tables.css */
 
-/* אזור התקדמות ויזואלי - כבר מוגדר ב-tables.css */
+/*
+ * "2 Signals Only" progress fills — Emil: color as signal, not decoration.
+ * Only overrun (>= 100%) earns red; earlier levels share a gray ramp.
+ * No gradients, no infinite shine overlay.
+ */
 .progress-high {
-  background: linear-gradient(
-    90deg,
-    #f59e0b 0%,
-    #d97706 100%
-  ); /* כתום - אזהרה */
+  background: var(--gray-700);
 }
 
 .progress-complete {
-  background: linear-gradient(
-    90deg,
-    #ef4444 0%,
-    #dc2626 100%
-  ); /* אדום - חריגה */
-}
-
-/* אפקט ברק על הבר */
-.linear-progress-fill::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgb(255 255 255 / 40%),
-    transparent
-  );
-  animation: progressShine 2s ease-in-out infinite;
-}
-
-@keyframes progressShine {
-  0% {
-    left: -100%;
-  }
-
-  50% {
-    left: 100%;
-  }
-
-  100% {
-    left: 100%;
-  }
+  background: #dc2626;
 }
 
 /* טקסט אחוז ליד הבר - סדר נכון לעברית */
@@ -414,11 +818,16 @@
   color: #6b7280;
 }
 
-/* מידע זמנים */
+/*
+ * Time info — Emil / Claude.ai: typography hierarchy, no colored chips.
+ * Label is the demoted role, value is the hero. Removed the blue-tinted
+ * planned chip and green-tinted actual chip — they read as decorative
+ * state, not information (both are just numbers that describe the task).
+ */
 .linear-time-info {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 8px;
+  gap: 12px;
   font-size: 11px;
   direction: rtl;
 }
@@ -428,33 +837,33 @@
   flex-direction: column;
   gap: 2px;
   text-align: center;
-  padding: 6px;
-  background: rgb(59 130 246 / 5%);
-  border-radius: 6px;
-  border: 1px solid rgb(59 130 246 / 10%);
+  padding: 4px 0;
+  background: transparent;
+  border: none;
 }
 
 .time-label {
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
+  font-weight: 500;
+  color: var(--gray-500);
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 11px;
 }
 
 .time-value {
-  font-weight: 700;
-  color: #1f2328;
-  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-900);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
 }
 
-/* צבע שונה לזמן בפועל */
-.time-item.actual {
-  background: rgb(16 185 129 / 5%);
-  border-color: rgb(16 185 129 / 10%);
-}
-
+/*
+ * .time-item.actual historically was tinted green to mean "done". We keep
+ * the modifier so existing markup still matches, but give it no visual
+ * distinction — the column label ("בפועל") already says what this is.
+ */
 .time-item.actual .time-value {
-  color: #059669;
+  color: var(--gray-900);
 }
 
 /* כותרת יפה עם מסגרת מתרחבת */
@@ -470,38 +879,38 @@
   max-width: calc(100% - 24px); /* ✅ מקסימום עד קצה הכרטיס */
 }
 
+/*
+ * Card title — Claude.ai: full name is shown, the card grows as needed.
+ * No line-clamp, no ellipsis, no "+" affordance for the hidden remainder.
+ * The reader never has to click to learn what a task is called. Cards
+ * end up with varying heights on a row, and that's the correct tradeoff —
+ * Claude / Linear do exactly this.
+ *
+ * The badge icons sit in the corner of the card (absolute positioning),
+ * so `padding-left: 70px` reserves room on the left side (RTL: visual
+ * left, CSS `padding-left`) for their ~64px cluster + 6px breathing room.
+ */
 .linear-card-title {
-  /* Typography */
   font-size: 15px;
   font-weight: 600;
-  color: #1f2328;
-  line-height: 1.5;
+  color: var(--gray-900);
+  line-height: 1.4;
+  letter-spacing: -0.01em;
 
-  /* Layout */
-  margin: 0;
-  margin-top: 4px; /* ממש בתחילת הכרטיסייה */
-  margin-left: -20px; /* ✅ מרחיב את הקו לכל הרוחב */
-  margin-right: -20px; /* ✅ מרחיב את הקו לכל הרוחב */
-  padding-top: 6px;
-  padding-bottom: 12px;
-  padding-left: 94px; /* מקום לאייקונים בצד שמאל */
-  padding-right: 20px; /* ✅ פיצוי על ה-margin השלילי */
-  margin-bottom: 16px; /* ✅ מרווח מהתוכן */
-  min-height: 44px; /* ✅ גובה קבוע - הקו תמיד באותו מקום! */
+  margin: 0 -14px 10px;
+  padding: 2px 14px 10px;
 
-  /* Display */
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
+  display: block;
   text-align: right;
   direction: rtl;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 
-  /* Border */
-  border-bottom: 0.5px solid #e5e7eb; /* ✅ קו עדין ודק */
+  border-bottom: 1px solid var(--gray-100);
 
-  /* Behavior */
   cursor: default;
-  position: relative; /* For tooltip positioning */
+  position: relative;
+  transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 /* כותרות */
@@ -543,49 +952,47 @@
   text-align: center;
 }
 
-/* רספונסיביות - כרטיסיות אחידות */
+/*
+ * Tablet — same density rule as desktop (300px min). Previously this
+ * stepped down to 320px + re-imposed max-height: 380px, which reintroduced
+ * the "2 giant cards on a 13-inch" problem. Now the grid just keeps going.
+ */
 @media (width <= 1024px) {
   .cards-grid,
   .budget-cards-grid,
   .timesheet-cards-grid {
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); /* ✅ 2 כרטיסים בטאבלט */
-    gap: 20px;
-  }
-
-  .linear-minimal-card {
-    min-height: 380px;
-    max-height: 380px;
+    gap: 12px;
+    padding: 12px;
   }
 }
 
+/*
+ * Phone — keep 300px min so horizontal scroll doesn't kick in unnecessarily.
+ * min-height relaxed further because content is the only thing keeping
+ * the card tall at narrow widths.
+ */
 @media (width <= 768px) {
   .cards-grid,
   .budget-cards-grid,
   .timesheet-cards-grid {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* ✅ אחיד גם במובייל */
-    gap: 16px;
-    padding: 0 8px;
+    gap: 10px;
+    padding: 10px;
   }
 
-  .linear-minimal-card {
-    min-height: 360px;
-    max-height: 360px;
-  }
+  /* No min-height override on tablet — desktop rule (auto) wins */
 }
 
 @media (width <= 480px) {
   .cards-grid,
   .budget-cards-grid,
   .timesheet-cards-grid {
-    grid-template-columns: 1fr; /* ✅ כרטיס אחד במובייל קטן */
-    gap: 16px;
-    padding: 0 4px;
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 10px;
   }
 
   .linear-minimal-card {
-    min-height: 340px;
-    max-height: 340px;
-    padding: 16px;
+    padding: 12px 12px 36px;
   }
 
   .linear-card-title {
@@ -620,41 +1027,42 @@
   font-weight: 600;
 }
 
+/*
+ * "2 Signals Only" deadline info — Emil: color is reserved for a real
+ * alarm. Overdue is red (something is actually wrong). Urgent/soon earn
+ * weight, not color or pulsing — the calendar number already conveys
+ * urgency to the reader.
+ */
 .deadline-info.overdue i {
   color: #dc2626;
-  animation: pulse-danger 2s infinite;
 }
 
-/* Urgent - דחוף (כתום עם אנימציה) */
 .deadline-info.urgent {
-  background: rgb(234 88 12 / 10%);
-  border: 1px solid #ea580c;
-  padding: 6px 12px;
-  border-radius: 6px;
+  background: transparent;
+  border: none;
+  padding: 4px 0;
   font-weight: 600;
+  color: var(--gray-900);
 }
 
 .deadline-info.urgent i {
-  color: #ea580c;
-  animation: pulse-warning 2s infinite;
+  color: var(--gray-700);
 }
 
-/* Soon - בקרוב (צהוב) */
 .deadline-info.soon {
-  background: rgb(202 138 4 / 10%);
-  border: 1px solid #ca8a04;
-  padding: 6px 12px;
-  border-radius: 6px;
+  background: transparent;
+  border: none;
+  padding: 4px 0;
   font-weight: 500;
+  color: var(--gray-800);
 }
 
 .deadline-info.soon i {
-  color: #ca8a04;
+  color: var(--gray-600);
 }
 
-/* Regular deadline - רגיל (אפור) */
 .deadline-info:not(.overdue, .urgent, .soon) i {
-  color: #6b7280;
+  color: var(--gray-500);
 }
 
 /* Completed Badge - תג הושלם */
@@ -665,34 +1073,37 @@
 }
 
 .completed-badge i {
-  color: #10b981;
-  font-size: 20px;
+  color: var(--gray-700);
+  font-size: 18px;
   animation: fadeIn 0.3s ease;
 }
 
-/* Pending Approval Badge - תג ממתין לאישור */
+/*
+ * Pending approval badge — flat amber pill, no gradient, no pulse.
+ * The dashed card border + reduced opacity already tell the reader this
+ * task is locked awaiting approval; an infinitely pulsing badge is noise.
+ */
 .pending-approval-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   margin-right: 8px;
   padding: 4px 12px;
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: white;
+  background: #fef3c7;
+  color: #92400e;
   border-radius: 12px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  animation: pulse-warning 2s ease-in-out infinite;
 }
 
 .pending-approval-badge i {
-  font-size: 14px;
+  font-size: 13px;
 }
 
-/* Pending Approval Card - כרטיס ממתין לאישור */
+/* Pending Approval Card — flat gray, dashed border still communicates locked state */
 .linear-minimal-card.pending-approval {
-  background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%) !important;
-  border: 2px dashed #9ca3af !important;
+  background: var(--gray-50) !important;
+  border: 2px dashed var(--gray-400) !important;
   opacity: 0.75;
   pointer-events: none;
   position: relative;
@@ -722,40 +1133,11 @@
   cursor: not-allowed;
 }
 
-@keyframes pulse-warning {
-  0%, 100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.8;
-    transform: scale(1.02);
-  }
-}
-
-/* Animations - אנימציות */
-@keyframes pulse-danger {
-  0%, 100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.7;
-    transform: scale(1.1);
-  }
-}
-
-@keyframes pulse-warning {
-  0%, 100% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.6;
-  }
-}
+/*
+ * @keyframes pulse-warning + pulse-danger removed — no longer referenced.
+ * (They drove deadline-info and pending-approval-badge animations, which
+ * are now static per Emil's "never animate frequently-viewed UI" rule.)
+ */
 
 @keyframes fadeIn {
   from {

--- a/apps/user-app/css/description-tooltips.css
+++ b/apps/user-app/css/description-tooltips.css
@@ -278,23 +278,35 @@
    CARD TITLE WITH INFO ICON
    ======================================== */
 
-/* Card title wrapper */
+/*
+ * Card title wrapper — no clamping (Claude-style: show the full name,
+ * let the card grow). Was previously `display: flex` + `white-space:
+ * nowrap` + `text-overflow: ellipsis`, which forced the title onto one
+ * line and cut off long task names. The user relies on seeing the full
+ * task name at a glance and should never have to click to reveal it.
+ *
+ * `position: relative` is kept so child tooltips (.card-description-tooltip)
+ * still anchor correctly.
+ */
 .linear-card-title {
   position: relative;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: block;
+  overflow: visible;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
-/* Card title text */
+/*
+ * .linear-card-title-text — used only when the title is split into a
+ * separate span for an info-icon sibling. Kept flexible (wraps, grows)
+ * to match the parent's new behavior.
+ */
 .linear-card-title-text {
   flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow: visible;
+  white-space: normal;
+  word-break: break-word;
   min-width: 0;
 }
 

--- a/apps/user-app/css/info-popups.css
+++ b/apps/user-app/css/info-popups.css
@@ -163,12 +163,98 @@
 .combined-info-badge i {
   font-size: 14px;
   color: #6b7280;
-  transition: color 0.15s ease;
+  display: inline-block;
+  transform-origin: center;
+  transition:
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-/* Hover - slightly darker, that's it */
 .combined-info-badge:hover i {
   color: #374151;
+}
+
+/*
+ * Per-icon micro-motion on badge hover — each Font Awesome glyph gets
+ * its own keyframed choreography that hints at the concept it represents.
+ * All share the same spring easing + duration for a consistent feel,
+ * so hovering the badge triggers a coordinated "come alive" moment.
+ *
+ *   📁 fa-folder         → tips open (rotate + light lift)
+ *   💼 fa-briefcase      → hops up  (translate up + slight back rotate)
+ *   ⚖️ fa-balance-scale  → sways    (rotate left, right, settle)
+ */
+.combined-info-badge:hover .fa-folder {
+  animation: badge-folder-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.combined-info-badge:hover .fa-briefcase {
+  animation: badge-briefcase-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+.combined-info-badge:hover .fa-balance-scale {
+  animation: badge-balance-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/*
+ * Unified gentle "tilt + scale" family — the user explicitly preferred
+ * the folder's soft motion style over the more active translate / swing
+ * variants. Briefcase and balance now share the same gesture with only
+ * the tilt direction changing, so the whole badge reads as one
+ * coordinated family rather than three different moods.
+ */
+@keyframes badge-folder-hover {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  55% {
+    transform: rotate(-10deg) scale(1.15);
+  }
+
+  100% {
+    transform: rotate(-4deg) scale(1.08);
+  }
+}
+
+@keyframes badge-briefcase-hover {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  55% {
+    transform: rotate(8deg) scale(1.15);
+  }
+
+  100% {
+    transform: rotate(4deg) scale(1.08);
+  }
+}
+
+@keyframes badge-balance-hover {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  55% {
+    transform: rotate(-8deg) scale(1.15);
+  }
+
+  100% {
+    transform: rotate(0deg) scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .combined-info-badge i {
+    transition: color 160ms ease;
+  }
+
+  .combined-info-badge:hover .fa-folder,
+  .combined-info-badge:hover .fa-briefcase,
+  .combined-info-badge:hover .fa-balance-scale {
+    animation: none;
+  }
 }
 
 /* ===== Combined Popup ===== */

--- a/apps/user-app/css/style-hitech-addon.css
+++ b/apps/user-app/css/style-hitech-addon.css
@@ -84,53 +84,18 @@
   pointer-events: none;
 }
 
-/* Budget Adjusted Note - כחול */
-.budget-adjusted-note {
-  position: relative;
-  padding: 8px 14px;
-  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
-  border: 1.5px solid #3b82f6;
-  border-radius: 20px;
-  color: #1e3a8a;
-  font-size: 13px;
-  font-weight: 600;
-  overflow: hidden;
-}
-
-.budget-adjusted-note i {
-  margin-left: 6px;
-  position: relative;
-  z-index: 1;
-}
-
-/* Shimmer Effect - כחול */
-.budget-adjusted-note::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  right: -100%;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgb(255 255 255 / 45%) 50%,
-    transparent 100%
-  );
-  animation: shimmerSlide 3s infinite;
-  animation-delay: 1s;
-  pointer-events: none;
-}
-
-/* Shimmer Animation - מימין לשמאל */
-@keyframes shimmerSlide {
-  0% {
-    right: -100%;
-  }
-
-  100% {
-    right: 100%;
-  }
+/*
+ * Budget-adjusted hint — inline annotation that sits next to the ring's
+ * value, not on a separate row. The previous "row underneath" treatment
+ * (large pill with gradient + shimmer) cost ~30px on every adjusted card.
+ * Now it's a quiet 2-character tag whose only job is to whisper "this
+ * number is the post-adjustment value".
+ */
+.budget-adjusted-inline {
+  color: var(--gray-500);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 /* ===============================================
@@ -280,101 +245,86 @@
    SVG RINGS - Circular Progress Indicators
    =============================================== */
 
-/* Dual rings layout */
+/*
+ * SVG Rings — Claude.ai / Emil minimal.
+ *
+ * Sized to match the JS rewrite (createSVGRing): 72x72 wrapper, thin
+ * 3px stroke, flat stroke (no gradient <defs>). No drop-shadow (flat UI
+ * stays flat), no hover-lift, no infinite pulse — the red stroke alone
+ * is the overrun signal. Per-icon Font Awesome tspan was removed from
+ * the ring, so the percentage text is now the sole inner content.
+ */
+
+/*
+ * Compact rings — 56px to free vertical space without losing readability.
+ * Pairs with the JS rewrite (createSVGRing + createDeadlineDisplay) which
+ * also shrank the SVG geometry.
+ */
 .svg-rings-dual-layout {
   display: flex;
-  gap: 28px;
+  gap: 24px;
   justify-content: center;
   align-items: flex-start;
-  margin: 14px 0;
+  margin: 6px 0;
   direction: rtl;
 }
 
-/* Single ring container */
 .svg-ring-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  min-width: 110px;
+  gap: 6px;
+  min-width: 78px;
 }
 
-/* Ring wrapper (SVG + percentage overlay) - META CLEAN STYLE */
 .svg-ring-wrapper {
   position: relative;
-  width: 80px;
-  height: 80px;
-
-  /* Clean shadow - no glow, just depth */
-  filter: drop-shadow(0 2px 4px rgb(0 0 0 / 8%))
-          drop-shadow(0 1px 2px rgb(0 0 0 / 6%));
-  transform: translateZ(0);
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  width: 56px;
+  height: 56px;
 }
 
-/* 🎯 Hover Effect - Instagram style (micro-interaction) */
-.svg-ring-wrapper:hover {
-  filter: drop-shadow(0 4px 12px rgb(0 0 0 / 12%))
-          drop-shadow(0 2px 6px rgb(0 0 0 / 8%));
-  transform: translateY(-2px) translateZ(0);
-}
-
-/* 🔴 Danger State - Minimal Pulse (only when overage) */
-.svg-ring-wrapper.status-danger {
-  animation: metaPulse 2.5s ease-in-out infinite;
-}
-
-/* Meta Minimal Pulse - 2% scale only */
-@keyframes metaPulse {
-  0%, 100% {
-    transform: scale(1) translateZ(0);
-  }
-
-  50% {
-    transform: scale(1.02) translateZ(0);
-  }
-}
-
-/* SVG ring */
 .svg-ring {
   width: 100%;
   height: 100%;
 }
 
-/* Progress circle animation - Clean transition only */
 .svg-ring-progress {
-  transition: stroke-dashoffset 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: stroke-dashoffset 400ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-/* Percentage text overlay */
+/* Center text — sits inside the ring. 14px reads cleanly at 56px. */
 .svg-ring-percentage {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 18px;
-  font-weight: 700;
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
   pointer-events: none;
-  text-shadow: 0 1px 2px rgb(255 255 255 / 80%);
+  letter-spacing: -0.01em;
+  line-height: 1;
 }
 
-/* Ring info (label + value) */
 .svg-ring-info {
   text-align: center;
   direction: rtl;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .svg-ring-label {
-  font-size: 10px;
-  font-weight: 600;
-  color: #6b7280;
-  margin-bottom: 2px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--gray-500);
 }
 
 .svg-ring-value {
-  font-size: 11px;
-  font-weight: 700;
-  color: #1f2937;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-900);
+  font-variant-numeric: tabular-nums;
 }
 
 .svg-ring-overdue-badge {
@@ -388,59 +338,60 @@
   display: inline-block;
 }
 
-/* Action button מתחת לרינג */
+/*
+ * Inline action button under a ring — compact icon-first.
+ *
+ * Was a 28-32px tall pill below the ring with full label text; that
+ * added a whole vertical row to every overrun/extension card. Now: small
+ * icon-only button (24x24) that sits flush under the ring's value text.
+ * Hover swaps to a soft gray pill so the affordance is still discoverable.
+ *
+ * Label text still rendered for screen-reader users via the inline `i`
+ * label and the surrounding context — the visible label is condensed to
+ * the icon alone (visual users have the icon + tooltip, AT users have
+ * the inline text after the <i>).
+ */
 .svg-ring-action-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  margin-top: 8px;
-  color: #fff;
-  border: none;
-  border-radius: 20px; /* יותר מעוגל */
+  justify-content: center;
+  gap: 4px;
+  padding: 0 6px;
+  margin-top: 4px;
+  height: 22px;
+  background: transparent;
+  color: var(--gray-600);
+  border: 1px solid transparent;
+  border-radius: 11px;
   font-size: 10px;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   white-space: nowrap;
+  transform-origin: center;
+  transition:
+    background-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-/* Budget button - כחול */
-.svg-ring-action-btn.budget-btn {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  box-shadow: 0 2px 6px rgb(59 130 246 / 25%);
+.svg-ring-action-btn:hover {
+  background: var(--gray-100);
+  color: var(--gray-900);
+  border-color: var(--gray-300);
 }
 
-.svg-ring-action-btn.budget-btn:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 10px rgb(59 130 246 / 35%);
+.svg-ring-action-btn:active {
+  transform: scale(0.95);
 }
 
-.svg-ring-action-btn.budget-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgb(59 130 246 / 20%);
-}
-
-/* Deadline button - כחול */
-.svg-ring-action-btn.deadline-btn {
-  background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  box-shadow: 0 2px 6px rgb(59 130 246 / 25%);
-}
-
-.svg-ring-action-btn.deadline-btn:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 10px rgb(59 130 246 / 35%);
-}
-
-.svg-ring-action-btn.deadline-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 4px rgb(59 130 246 / 20%);
+.svg-ring-action-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
 }
 
 .svg-ring-action-btn i {
-  font-size: 9px;
+  font-size: 10px;
 }
 
 /* Overage indicator */
@@ -454,16 +405,21 @@
   gap: 8px;
 }
 
+/*
+ * Overage badge — flat red on light red tint. The overrun is a true
+ * alarm (the whole point of "2 signals only"), so it keeps its red,
+ * just without the gradient and the wider saturation.
+ */
 .svg-ring-overage-badge {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 12px;
-  background: linear-gradient(135deg, #fee2e2, #fecaca);
+  padding: 5px 10px;
+  background: #fee2e2;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 600;
-  color: #dc2626;
+  color: #991b1b;
 }
 
 .svg-ring-overage-badge i {
@@ -474,33 +430,46 @@
   font-size: 13px;
 }
 
-/* Overage action button */
+/*
+ * Overage action button — Claude.ai pill. Was a saturated amber gradient
+ * pill which competed visually with the red overrun badge directly above.
+ * Now a calm gray pill; the amber badge is the one saying "there is a
+ * problem" and the button is the one saying "here's what you can do".
+ */
 .svg-ring-overage-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 14px;
-  background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-  color: #fff;
-  border: none;
+  padding: 5px 12px;
+  background: #fff;
+  color: var(--gray-700);
+  border: 1px solid var(--gray-300);
   border-radius: 8px;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 4px rgb(245 158 11 / 20%);
   white-space: nowrap;
+  transform-origin: center;
+  transition:
+    background-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .svg-ring-overage-btn:hover {
-  background: linear-gradient(135deg, #d97706 0%, #b45309 100%);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 8px rgb(245 158 11 / 30%);
+  background: var(--gray-100);
+  color: var(--gray-900);
+  border-color: var(--gray-400);
 }
 
 .svg-ring-overage-btn:active {
-  transform: translateY(0);
-  box-shadow: 0 1px 2px rgb(245 158 11 / 20%);
+  transform: scale(0.97);
+}
+
+.svg-ring-overage-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
 }
 
 .svg-ring-overage-btn i {

--- a/apps/user-app/css/tables.css
+++ b/apps/user-app/css/tables.css
@@ -2019,16 +2019,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* .linear-client-row removed — no longer used; meta footer is a flat row. */
-
-.linear-client-label {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--gray-500);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
 .linear-client-name {
   font-weight: 500;
   color: var(--gray-900);

--- a/apps/user-app/css/tables.css
+++ b/apps/user-app/css/tables.css
@@ -1790,67 +1790,80 @@
   transform: translateY(-2px);
 }
 
-/* כרטיס לינארי ריבועי - Ultra Minimal - גובה אחיד! */
+/*
+ * Linear Minimal Card — Claude.ai / Emil polish.
+ *
+ * Default: flat white, thin border, no shadow, no gradient. The grid's
+ * soft gray canvas (in cards.css) provides the separation between cards;
+ * each card itself is just a clean white surface.
+ *
+ * Hover: border firms up, very soft shadow appears — no lift, no
+ * background re-tint. The card is content's container, not a dramatic
+ * object.
+ *
+ * Density: padding reduced from --space-5 to 16px (a meaningful trim at
+ * 13" where every pixel counts), min-height reduced to 280px so shorter
+ * content no longer forces artificial white space. max-height stays
+ * removed so cards grow with content instead of clipping.
+ */
 .linear-minimal-card {
-  background: linear-gradient(135deg, #fafbfc 0%, #f8f9fb 100%); /* ✅ gradient מט ועדין */
-  border: 1px solid #e5e7eb;
-  border-radius: var(--radius-lg);
+  background: #fff;
+  border: 1px solid var(--gray-200);
+  border-radius: 10px;
   cursor: pointer;
-  transition: var(--transition-smooth);
   position: relative;
 
-  /* ✅ גובה ורוחב קבועים - כולם זהים! */
   width: 100%;
-  min-height: 380px; /* גובה מינימלי אחיד */
-  max-height: 380px; /* גובה מקסימלי אחיד */
-  overflow: visible; /* ✅ שונה מ-hidden - מאפשר לאלמנטים להיות גלויים */
-  padding: var(--space-5);
-  padding-bottom: 70px; /* מקום לכפתור + meta */
 
-  box-shadow: 0 2px 8px rgb(0 0 0 / 4%), 0 1px 3px rgb(0 0 0 / 6%); /* ✅ צל יותר בולט ומקצועי */
+  /*
+   * No min-height — cards take only the height their content needs.
+   * Cards in the same row will have different heights (different title
+   * lengths, presence of overrun buttons), which matches Claude.ai's
+   * variable-height list pattern. Padding-bottom is the floor (40px)
+   * needed to keep the absolute meta footer + expand button readable.
+   */
+  overflow: visible;
+  padding: 14px 14px 40px;
+
   direction: rtl;
   text-align: right;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 8px;
+
+  transition:
+    border-color 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    box-shadow 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .linear-minimal-card:hover {
-  background: linear-gradient(135deg, #fff 0%, #fafbfc 100%); /* ✅ gradient בהיר יותר ב-hover */
-  border-color: #d1d5db;
-  box-shadow: 0 4px 16px rgb(0 0 0 / 8%), 0 2px 6px rgb(0 0 0 / 4%); /* ✅ צל יותר בולט ב-hover */
-  transform: translateY(-2px);
+  border-color: var(--gray-300);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 4%);
 }
 
 /* תאריך יצירה בפינה ימנית עליונה - עיצוב מקצועי */
 .card-creation-date {
   position: absolute;
-  top: 10px; /* ✅ בתוך ה-padding */
-  right: 10px; /* ✅ בתוך ה-padding */
+  top: 10px;
+  right: 10px;
   font-size: 10px;
   font-weight: 500;
-  color: #6b7280;
-  opacity: 0.75;
-  font-style: normal;
+  color: var(--gray-500);
+  opacity: 0.8;
   z-index: 10;
-  background: rgb(255 255 255 / 95%);
+  background: transparent;
   padding: 3px 7px;
-  border-radius: 3px;
-  border: 1px solid rgb(229 231 235 / 60%);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 4%);
-  transition: all 0.2s ease;
-  letter-spacing: 0.01em;
   line-height: 1.4;
-  max-width: calc(100% - 40px); /* ✅ מונע overflow */
+  max-width: calc(100% - 40px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  transition: opacity 150ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .linear-minimal-card:hover .card-creation-date {
-  opacity: 0.95;
-  background: rgb(255 255 255 / 100%);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+  opacity: 1;
+  color: var(--gray-700);
 }
 
 /* תגי שירות ותיק בפינה ימנית עליונה - עיצוב ultra-minimal */
@@ -1883,56 +1896,130 @@
   padding-bottom: 80px; /* ✅ הוגדל (היה 60px) - יותר מרווח מהקו התחתון */
 }
 
-/* כפתור הרחבה - למטה בצד שמאל */
+/*
+ * Expand button — Claude.ai-style pill. Transparent by default so it fades
+ * into the card. Hover reveals a soft gray pill; :active scale gives the
+ * tactile press feedback Emil calls for on every pressable element.
+ */
 .linear-expand-btn {
   position: absolute;
   bottom: 10px;
   left: 10px;
   width: 28px;
   height: 28px;
-  border-radius: var(--radius-sm);
-  background: #fff;
-  border: 1px solid var(--gray-300);
-  color: var(--gray-700);
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: var(--gray-500);
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: var(--transition);
   z-index: 2;
-  font-size: 10px;
+  font-size: 11px;
+  padding: 0;
+  transform-origin: center;
+  transition:
+    background-color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .linear-expand-btn:hover {
-  background: var(--gray-50);
-  border-color: var(--gray-400);
-  transform: translateY(-1px);
+  background: var(--gray-100);
+  color: var(--gray-900);
 }
 
-/* מטא-נתונים משופרים של הכרטיס - מוצמד לתחתית */
+/*
+ * Plus icon micro-motion on hover — "opening" feel.
+ * Icon rotates 90° with a small overshoot and settles at ~95° + scale,
+ * hinting that clicking will expand/open more detail. Spring easing
+ * gives it the same physical bounce as the pencil/calendar actions.
+ */
+.linear-expand-btn i {
+  display: inline-block;
+  transform-origin: center;
+  transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.linear-expand-btn:hover i {
+  animation: plus-open-hover 320ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+
+/*
+ * Softened plus rotation — first version (90°) read as dramatic. The
+ * user preferred the folder's gentle "tilt + scale" style, so this
+ * mirrors that: a small clockwise hint (not a full turn) + subtle
+ * scale up. Still readable as "something opens on click".
+ */
+@keyframes plus-open-hover {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  55% {
+    transform: rotate(12deg) scale(1.15);
+  }
+
+  100% {
+    transform: rotate(8deg) scale(1.08);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .linear-expand-btn i {
+    transition: none;
+  }
+
+  .linear-expand-btn:hover i {
+    animation: none;
+  }
+}
+
+.linear-expand-btn:active {
+  background: var(--gray-200);
+  transform: scale(0.95);
+}
+
+.linear-expand-btn:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
+}
+
+/*
+ * Meta footer — single horizontal row consolidating badge + client + date.
+ *
+ * Was a stacked column with a top border that added ~30px to every card.
+ * The new flat row sits flush at the card bottom with no separator and
+ * lets all metadata read at a glance: 🏢 case · client · 13/04 [+]
+ *
+ * Pinned to the bottom (absolute) so cards with variable-height titles
+ * still align their footers cleanly.
+ */
 .linear-card-meta {
-  position: absolute; /* מוצמד לתחתית כמו הכפתור */
-  bottom: 15px; /* אותו גובה כמו כפתור הפלוס */
-  right: 0; /* ✅ לכל הרוחב של הכרטיס */
-  left: 60px; /* מרווח מהכפתור פלוס בצד שמאל */
+  position: absolute;
+  bottom: 12px;
+  right: 16px;
+  left: 48px; /* leaves clearance for the absolute "+" expand button */
+
   display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 6px;
-  padding-top: 14px; /* ✅ הוגדל (היה 8px) - יותר מרווח מהקו */
-  padding-right: 24px; /* ✅ padding פנימי לטקסט */
-  border-top: 0.5px solid #e5e7eb; /* ✅ קו עדין ודק - אותו כמו העליון */
-  font-size: 13px;
+  flex-wrap: wrap;
+
+  font-size: 11px;
   color: var(--gray-600);
   direction: rtl;
   text-align: right;
+  line-height: 1.3;
 }
 
-/* שורת לקוח */
-.linear-client-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.linear-card-meta-date {
+  color: var(--gray-500);
+  font-variant-numeric: tabular-nums;
 }
+
+/* .linear-client-row removed — no longer used; meta footer is a flat row. */
 
 .linear-client-label {
   font-size: 11px;
@@ -1993,11 +2080,12 @@
   text-align: center;
 }
 
-.linear-expand-btn:hover {
-  background: #e2e8f0;
-  transform: scale(1.1);
-  border-color: #3b82f6;
-}
+/*
+ * Duplicate .linear-expand-btn:hover removed — the canonical hover rule
+ * lives near the button's base definition (~line 1923) and follows the
+ * Claude.ai transparent-pill pattern. This version added scale(1.1) +
+ * a blue border on hover, fighting the calm polish.
+ */
 
 /* אזור התקדמות ויזואלי באמצע הכרטיס */
 .linear-progress-section {
@@ -2083,39 +2171,11 @@
   direction: rtl;
 }
 
-.time-item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  text-align: center;
-  padding: 6px;
-  background: rgb(59 130 246 / 5%);
-  border-radius: 6px;
-  border: 1px solid rgb(59 130 246 / 10%);
-}
-
-.time-label {
-  font-weight: 600;
-  color: #6b7280;
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.time-value {
-  font-weight: 700;
-  color: #1f2328;
-  font-size: 12px;
-}
-
-/* צבע שונה לזמן בפועל */
-.time-item.actual {
-  background: rgb(16 185 129 / 5%);
-  border-color: rgb(16 185 129 / 10%);
-}
-
-.time-item.actual .time-value {
-  color: #059669;
-}
+/*
+ * .time-item / .time-label / .time-value / .time-item.actual rules moved
+ * to cards.css (Emil / Claude.ai typography-first, no colored chips).
+ * Duplicates here were overriding with blue/green tinted chips.
+ */
 
 /* Card title wrapper - holds title and badges */
 .card-title-wrapper {
@@ -2126,93 +2186,89 @@
   direction: rtl;
 }
 
-/* כותרת כרטיס - שורה אחת בלבד + Tooltip */
+/*
+ * Card title — Emil: "task name never truncated to one line".
+ * Superseded by the Claude-style block below (kept for context).
+ */
+
+/*
+ * Card title — Claude-style: show the full task name, let the card grow.
+ * No -webkit-line-clamp, no text-overflow, no min-height. The card owns
+ * whatever height the title needs; sibling cards in the row will naturally
+ * have different heights, which matches how Claude / Linear present lists
+ * of variable-length items. cards.css has its own `.linear-card-title`
+ * rule that wins via load order — this block is only kept for safety in
+ * contexts where cards.css isn't loaded (none in the User App today).
+ */
 .linear-card-title {
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--gray-900);
-  line-height: 1.5;
+  line-height: 1.4;
   letter-spacing: -0.01em;
-  margin: 0;
-  margin-top: 4px; /* ממש בתחילת הכרטיסייה */
-  padding-top: 2px;
-  padding-bottom: 16px;
-  padding-left: 70px; /* מקום לאייקונים */
-  margin-bottom: 20px; /* ✅ מוריד את התוכן שאחרי הקו */
-  min-height: 48px; /* ✅ גובה קבוע - הקו תמיד באותו מקום! */
+  margin: 0 0 12px;
+  padding: 4px 60px 10px 0;
   text-align: right;
   direction: rtl;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; /* שורה אחת בלבד */
-  border-bottom: 1px solid #e2e8f0; /* הקו תמיד באותו גובה */
+  word-break: break-word;
+  overflow-wrap: anywhere;
+
+  border-bottom: 1px solid var(--gray-100);
   cursor: default;
-  transition: color 0.2s ease;
+  transition: color 150ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
-.linear-card-title:hover {
-  color: var(--primary-600);
-}
-
-/* ===== Card Badges Button (Click to open modal) ===== */
+/*
+ * Card badges button — Claude.ai pill. Transparent by default, fills in
+ * on hover; no shadow (Emil: flat UI stays flat).
+ */
 .card-badges-button {
   display: flex;
   align-items: center;
   gap: 4px;
   padding: 4px 8px;
-  background: var(--gray-50);
+  background: transparent;
   border: 1px solid var(--gray-200);
   border-radius: 6px;
   font-size: 12px;
   color: var(--gray-600);
   cursor: pointer;
-  transition: var(--transition);
   flex-shrink: 0;
+  transform-origin: center;
+  transition:
+    background-color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    border-color 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 100ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 
 .card-badges-button:hover {
-  background: #fff;
+  background: var(--gray-50);
   border-color: var(--gray-300);
-  color: var(--gray-700);
-  box-shadow: 0 2px 4px rgb(0 0 0 / 6%);
+  color: var(--gray-900);
 }
 
 .card-badges-button:active {
   transform: scale(0.96);
 }
 
-/* הוספת tooltip לכותרת ארוכה */
-.linear-card-title::after {
-  content: attr(data-full-text);
-  position: absolute;
-  bottom: 100%;
-  right: 50%;
-  transform: translateX(50%);
-  background: #1f2328;
-  color: white;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  white-space: nowrap;
-  z-index: 10;
-  opacity: 0;
-  visibility: hidden;
-  transition: all 0.2s ease;
-  pointer-events: none;
-  max-width: 300px;
-  text-overflow: ellipsis;
-  overflow: hidden;
+.card-badges-button:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 1px;
 }
 
-.linear-card-title:hover::after {
-  opacity: 1;
-  visibility: visible;
-  bottom: calc(100% + 8px);
-}
+/*
+ * Custom ::after tooltip removed.
+ * It relied on `data-full-text` (which the HTML template never provides)
+ * and on the title being truncated. Now that the title is never
+ * truncated, there's no "hidden remainder" to reveal on hover. The
+ * :hover partial gray overlay the user noticed was this pseudo-element
+ * rendering with transparent background at certain paint stages.
+ */
 
-/* אנימציה על hover */
+/* Hover on the card lifts the title underline color — calm, not a highlight */
 .linear-minimal-card:hover .linear-card-title {
-  border-color: var(--gray-300);
+  border-color: var(--gray-200);
 }
 
 /* כותרות */
@@ -2291,9 +2347,9 @@
     aspect-ratio: 1.2/1; /* קצת פחות ריבועי בנייד */
   }
 
+  /* .linear-minimal-card mobile override — only padding, height auto */
   .linear-minimal-card {
-    height: 72px;
-    padding: 16px 20px;
+    padding: 12px 14px 36px;
   }
 
   .client-name,

--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -123,64 +123,64 @@
       buttons without icons. See CLAUDE.md "What happens if the network is
       slow?" and the adversarial review from 2026-04-22.
     -->
-    <script src="lib/lucide.min.js?v=5132798" defer></script>
+    <script src="lib/lucide.min.js?v=doiievw" defer></script>
     <!-- ===== DESIGN SYSTEM - Must be loaded first ===== -->
-    <link rel="stylesheet" href="css/design-system.css?v=5132798" />
-    <link rel="stylesheet" href="css/style.css?v=5132798" />
-    <link rel="stylesheet" href="css/header.css?v=5132798" />
-    <link rel="stylesheet" href="css/content-areas.css?v=5132798" />
-    <link rel="stylesheet" href="css/login-modern.css?v=5132798" />
-    <link rel="stylesheet" href="css/buttons.css?v=5132798" />
-    <link rel="stylesheet" href="css/forms.css?v=5132798" />
-    <link rel="stylesheet" href="css/tables.css?v=5132798" />
-    <link rel="stylesheet" href="css/timesheet-cards.css?v=5132798" />
-    <link rel="stylesheet" href="css/modals.css?v=5132798" />
-    <link rel="stylesheet" href="css/quick-actions-extend-deadline.css?v=5132798" />
-    <link rel="stylesheet" href="css/case-creation-dialog.css?v=5132798" />
-    <link rel="stylesheet" href="css/popups-unified.css?v=5132798" />
-    <link rel="stylesheet" href="css/popups-rtl.css?v=5132798" />
-    <link rel="stylesheet" href="css/edge-polish-modals.css?v=5132798" />
-    <link rel="stylesheet" href="css/expanded-cards.css?v=5132798" />
-    <link rel="stylesheet" href="css/advanced-popups.css?v=5132798" />
-    <link rel="stylesheet" href="css/info-popups.css?v=5132798" />
-    <link rel="stylesheet" href="css/description-tooltips.css?v=5132798" />
-    <link rel="stylesheet" href="css/cards.css?v=5132798" />
-    <link rel="stylesheet" href="css/list-view.css?v=5132798" />
-    <link rel="stylesheet" href="css/combobox.css?v=5132798" />
-    <link rel="stylesheet" href="css/notification-system.css?v=5132798" />
-    <link rel="stylesheet" href="css/user-alerts.css?v=5132798" />
-    <link rel="stylesheet" href="css/thread-view.css?v=5132798" />
-    <link rel="stylesheet" href="css/style-hitech-addon.css?v=5132798" />
-    <link rel="stylesheet" href="css/tabs.css?v=5132798" />
-    <link rel="stylesheet" href="css/statistics.css?v=5132798" />
-    <link rel="stylesheet" href="css/sort.css?v=5132798" />
+    <link rel="stylesheet" href="css/design-system.css?v=doiievw" />
+    <link rel="stylesheet" href="css/style.css?v=doiievw" />
+    <link rel="stylesheet" href="css/header.css?v=doiievw" />
+    <link rel="stylesheet" href="css/content-areas.css?v=doiievw" />
+    <link rel="stylesheet" href="css/login-modern.css?v=doiievw" />
+    <link rel="stylesheet" href="css/buttons.css?v=doiievw" />
+    <link rel="stylesheet" href="css/forms.css?v=doiievw" />
+    <link rel="stylesheet" href="css/tables.css?v=doiievw" />
+    <link rel="stylesheet" href="css/timesheet-cards.css?v=doiievw" />
+    <link rel="stylesheet" href="css/modals.css?v=doiievw" />
+    <link rel="stylesheet" href="css/quick-actions-extend-deadline.css?v=doiievw" />
+    <link rel="stylesheet" href="css/case-creation-dialog.css?v=doiievw" />
+    <link rel="stylesheet" href="css/popups-unified.css?v=doiievw" />
+    <link rel="stylesheet" href="css/popups-rtl.css?v=doiievw" />
+    <link rel="stylesheet" href="css/edge-polish-modals.css?v=doiievw" />
+    <link rel="stylesheet" href="css/expanded-cards.css?v=doiievw" />
+    <link rel="stylesheet" href="css/advanced-popups.css?v=doiievw" />
+    <link rel="stylesheet" href="css/info-popups.css?v=doiievw" />
+    <link rel="stylesheet" href="css/description-tooltips.css?v=doiievw" />
+    <link rel="stylesheet" href="css/cards.css?v=doiievw" />
+    <link rel="stylesheet" href="css/list-view.css?v=doiievw" />
+    <link rel="stylesheet" href="css/combobox.css?v=doiievw" />
+    <link rel="stylesheet" href="css/notification-system.css?v=doiievw" />
+    <link rel="stylesheet" href="css/user-alerts.css?v=doiievw" />
+    <link rel="stylesheet" href="css/thread-view.css?v=doiievw" />
+    <link rel="stylesheet" href="css/style-hitech-addon.css?v=doiievw" />
+    <link rel="stylesheet" href="css/tabs.css?v=doiievw" />
+    <link rel="stylesheet" href="css/statistics.css?v=doiievw" />
+    <link rel="stylesheet" href="css/sort.css?v=doiievw" />
     <link rel="stylesheet" href="css/reports.css" />
-    <link rel="stylesheet" href="css/pagination.css?v=5132798" />
+    <link rel="stylesheet" href="css/pagination.css?v=doiievw" />
 
     <!-- TaskTimeline Component -->
-    <link rel="stylesheet" href="components/task-timeline/TaskTimeline.css?v=5132798" />
+    <link rel="stylesheet" href="components/task-timeline/TaskTimeline.css?v=doiievw" />
     <!-- Utility Classes - כלי עזר -->
-    <link rel="stylesheet" href="css/utilities.css?v=5132798" />
+    <link rel="stylesheet" href="css/utilities.css?v=doiievw" />
     <!-- Smart Combo Selector - בורר תיאורים חכם -->
-    <link rel="stylesheet" href="css/smart-combo-selector.css?v=5132798" />
-    <link rel="stylesheet" href="css/guided-text-input.css?v=5132798" />
+    <link rel="stylesheet" href="css/smart-combo-selector.css?v=doiievw" />
+    <link rel="stylesheet" href="css/guided-text-input.css?v=doiievw" />
     <!-- Responsive Design - מדיה queries -->
-    <link rel="stylesheet" href="css/responsive.css?v=5132798" />
+    <link rel="stylesheet" href="css/responsive.css?v=doiievw" />
 
     <!-- Virtual Assistant Styles - TEMPORARILY DISABLED -->
-    <!-- <link rel="stylesheet" href="js/modules/virtual-assistant/virtual-assistant.css?v=5132798" /> -->
+    <!-- <link rel="stylesheet" href="js/modules/virtual-assistant/virtual-assistant.css?v=doiievw" /> -->
 
     <!-- ===== AI CHAT SYSTEM (NEW) ===== -->
-    <link rel="stylesheet" href="js/modules/ai-system/ai-chat.css?v=5132798">
+    <link rel="stylesheet" href="js/modules/ai-system/ai-chat.css?v=doiievw">
 
     <!-- ===== SYSTEM ANNOUNCEMENT TICKER ===== -->
-    <link rel="stylesheet" href="css/system-announcement-ticker.css?v=5132798" />
+    <link rel="stylesheet" href="css/system-announcement-ticker.css?v=doiievw" />
 
     <!-- ===== SYSTEM ANNOUNCEMENT POPUP ===== -->
-    <link rel="stylesheet" href="css/system-announcement-popup.css?v=5132798" />
+    <link rel="stylesheet" href="css/system-announcement-popup.css?v=doiievw" />
 
     <!-- ===== BREAK BUTTON ===== -->
-    <link rel="stylesheet" href="css/break-button.css?v=5132798" />
+    <link rel="stylesheet" href="css/break-button.css?v=doiievw" />
 
     <!-- ===== SECURITY MODALS STYLES ===== -->
     <!-- Google Fonts - Inter for Linear-style Idle Warning -->
@@ -714,6 +714,38 @@
                 </button>
               </div>
 
+              <!--
+                Deadline format toggle — segmented control.
+                Lets each user pick whether deadlines read as an absolute
+                date (15.04.26) or a relative day count (5 ימים). Saved to
+                localStorage via STATE_CONFIG so the choice survives refresh.
+                Affects cards + table cell + compact ring center.
+              -->
+              <div
+                class="deadline-format-toggle"
+                role="group"
+                aria-label="פורמט תצוגת דדליין"
+              >
+                <button
+                  type="button"
+                  class="deadline-format-btn active"
+                  data-format="date"
+                  onclick="manager.switchDeadlineFormat('date')"
+                  title="תצוגת דדליין: תאריך"
+                >
+                  תאריך
+                </button>
+                <button
+                  type="button"
+                  class="deadline-format-btn"
+                  data-format="days"
+                  onclick="manager.switchDeadlineFormat('days')"
+                  title="תצוגת דדליין: ימים"
+                >
+                  ימים
+                </button>
+              </div>
+
               <div class="search-filter-row">
                 <!-- Task Filter Icon Buttons -->
                 <div class="task-filter-buttons">
@@ -1205,61 +1237,61 @@
     <!-- SCRIPTS AND STYLES -->
     <!-- ===== 🔇 Production Logger - MUST BE FIRST ===== -->
     <!-- מערכת לוגים מרכזית - מצב ייצור (מינימום לוגים) -->
-    <script src="js/modules/logger.js?v=5132798"></script>
-    <script src="js/core/system-constants.js?v=5132798"></script>
-    <script src="js/core/config-loader.js?v=5132798"></script>
+    <script src="js/modules/logger.js?v=doiievw"></script>
+    <script src="js/core/system-constants.js?v=doiievw"></script>
+    <script src="js/core/config-loader.js?v=doiievw"></script>
 
     <!-- ===== ⚡ Lazy Loader - Dynamic Script Loading ===== -->
     <!-- טעינה דינמית של סקריפטים - שיפור ביצועים -->
-    <script defer src="js/modules/lazy-loader.js?v=5132798"></script>
+    <script defer src="js/modules/lazy-loader.js?v=doiievw"></script>
 
-    <script defer src="js/modules/dates.js?v=5132798"></script>
-    <script defer src="js/modules/statistics.js?v=5132798"></script>
-    <script defer src="js/modules/pagination.js?v=5132798"></script>
-    <script defer src="js/modules/activity-logger.js?v=5132798"></script>
+    <script defer src="js/modules/dates.js?v=doiievw"></script>
+    <script defer src="js/modules/statistics.js?v=doiievw"></script>
+    <script defer src="js/modules/pagination.js?v=doiievw"></script>
+    <script defer src="js/modules/activity-logger.js?v=doiievw"></script>
 
     <!-- ===== 🚀 NEW ARCHITECTURE v2.0 - Event-Driven System ===== -->
     <!-- Type-safe Event Bus + Firebase Facade -->
-    <script type="module" src="dist/js/core/event-bus.js?v=5132798"></script>
-    <script type="module" src="dist/js/services/firebase-service.js?v=5132798"></script>
+    <script type="module" src="dist/js/core/event-bus.js?v=doiievw"></script>
+    <script type="module" src="dist/js/services/firebase-service.js?v=doiievw"></script>
 
     <!-- ✨ NEW: Modular Deduction System -->
     <!-- Shared library for hours calculation and deduction logic -->
-    <script type="module" src="src/modules/deduction/index.js?v=5132798"></script>
+    <script type="module" src="src/modules/deduction/index.js?v=doiievw"></script>
 
-    <script defer src="js/modules/task-actions.js?v=5132798"></script>
+    <script defer src="js/modules/task-actions.js?v=doiievw"></script>
     <!-- ✨ NEW: Task Completion Validation System -->
     <!-- Industry-standard task completion with time gap validation -->
-    <script defer src="js/modules/task-completion-validation.js?v=5132798"></script>
+    <script defer src="js/modules/task-completion-validation.js?v=doiievw"></script>
     <!-- ✨ NEW: TaskTimeline Component -->
     <!-- Unified timeline display for task history -->
-    <script defer src="components/task-timeline/TaskTimeline.js?v=5132798"></script>
-    <script type="module" src="js/modules/firebase-pagination.js?v=5132798"></script>
-    <script defer src="js/modules/integration-manager.js?v=5132798"></script>
+    <script defer src="components/task-timeline/TaskTimeline.js?v=doiievw"></script>
+    <script type="module" src="js/modules/firebase-pagination.js?v=doiievw"></script>
+    <script defer src="js/modules/integration-manager.js?v=doiievw"></script>
     <!-- Firebase Functions Migration - Server-side Integration -->
-    <script defer src="js/modules/api-client-v2.js?v=5132798"></script>
-    <script src="js/modules/firebase-server-adapter.js?v=5132798"></script>
+    <script defer src="js/modules/api-client-v2.js?v=doiievw"></script>
+    <script src="js/modules/firebase-server-adapter.js?v=doiievw"></script>
     <!-- Employees Management System - ניהול עובדים -->
-    <script type="module" src="js/modules/employees-manager.js?v=5132798"></script>
+    <script type="module" src="js/modules/employees-manager.js?v=doiievw"></script>
     <!-- ✅ Presence System - מעקב משתמשים בזמן אמת (Realtime Database) -->
-    <script defer src="js/modules/presence-system.js?v=5132798"></script>
+    <script defer src="js/modules/presence-system.js?v=doiievw"></script>
     <!-- ✅ NEW: Idle Timeout Manager - התנתקות אוטומטית אחרי חוסר פעילות -->
-    <script src="js/modules/idle-timeout-manager.js?v=5132798"></script>
+    <script src="js/modules/idle-timeout-manager.js?v=doiievw"></script>
 
     <!-- Cases Management System - ניהול תיקים -->
-    <script src="js/cases.js?v=5132798"></script>
-    <script src="js/cases-integration.js?v=5132798"></script>
+    <script src="js/cases.js?v=doiievw"></script>
+    <script src="js/cases-integration.js?v=doiievw"></script>
 
 
     <!-- ===== Lottie Animations Configuration ===== -->
     <!-- MUST BE LOADED BEFORE NotificationSystem -->
-    <script src="js/modules/lottie-animations.js?v=5132798"></script>
-    <script src="js/modules/lottie-manager.js?v=5132798"></script>
+    <script src="js/modules/lottie-animations.js?v=doiievw"></script>
+    <script src="js/modules/lottie-manager.js?v=doiievw"></script>
 
     <!-- ===== Notification System ===== -->
     <!-- Toast notifications with Lottie animations -->
-    <script defer src="js/modules/notification-messages.js?v=5132798"></script>
-    <script src="js/modules/notification-system.js?v=5132798"></script>
+    <script defer src="js/modules/notification-messages.js?v=doiievw"></script>
+    <script src="js/modules/notification-system.js?v=doiievw"></script>
 
     <!-- ===== 🎯 NEW: Unified UI System - Step 1: Load Components ===== -->
     <!-- Feature Flags - Controls whether to use new or legacy system -->
@@ -1277,57 +1309,57 @@
 
     <!-- ===== NEW: Modals Manager System ===== -->
     <!-- Centralized modal management -->
-    <script src="js/modules/modals-manager.js?v=5132798"></script>
+    <script src="js/modules/modals-manager.js?v=doiievw"></script>
     <!-- Compatibility layer for smooth migration -->
-    <script defer src="js/modules/modals-compat.js?v=5132798"></script>
+    <script defer src="js/modules/modals-compat.js?v=doiievw"></script>
 
     <!-- ===== Shared Service Card Renderer ===== -->
     <!-- Prevents code duplication between modules -->
-    <script defer src="js/modules/service-card-renderer.js?v=5132798"></script>
+    <script defer src="js/modules/service-card-renderer.js?v=doiievw"></script>
 
     <!-- ===== Shared Client Search Component ===== -->
     <!-- Unified client search and filtering logic -->
-    <script defer src="js/modules/ui/client-search.js?v=5132798"></script>
+    <script defer src="js/modules/ui/client-search.js?v=doiievw"></script>
 
     <!-- ===== NEW: Client-Case Selector Component ===== -->
     <!-- Unified two-step client→case selection -->
-    <script defer src="js/modules/client-case-selector.js?v=5132798"></script>
+    <script defer src="js/modules/client-case-selector.js?v=doiievw"></script>
     <!-- Client-Case Selectors Initialization -->
-    <script defer src="js/modules/selectors-init.js?v=5132798"></script>
+    <script defer src="js/modules/selectors-init.js?v=doiievw"></script>
 
     <!-- ===== 🔍 Performance Monitoring System ===== -->
     <!-- Real-time performance tracking for critical operations -->
-    <script defer src="js/modules/monitoring/performance-monitor.js?v=5132798"></script>
+    <script defer src="js/modules/monitoring/performance-monitor.js?v=doiievw"></script>
 
     <!-- ===== 🧪 TESTING: New Case Creation Module ===== -->
     <!-- Modern modular case creation system - currently in testing -->
-    <script defer src="js/modules/case-creation/case-number-generator.js?v=5132798"></script>
-    <script defer src="js/modules/case-creation/case-form-validator.js?v=5132798"></script>
-    <script defer src="js/modules/case-creation/case-creation-dialog.js?v=5132798"></script>
+    <script defer src="js/modules/case-creation/case-number-generator.js?v=doiievw"></script>
+    <script defer src="js/modules/case-creation/case-form-validator.js?v=doiievw"></script>
+    <script defer src="js/modules/case-creation/case-creation-dialog.js?v=doiievw"></script>
 
     <!-- ===== Smart Descriptions System ===== -->
     <!-- Structured descriptions manager for tasks and work entries -->
-    <script defer src="js/modules/descriptions/category-mapping.js?v=5132798"></script>
-    <script defer src="js/modules/descriptions/descriptions-manager.js?v=5132798"></script>
-    <script defer src="js/modules/descriptions/smart-combo-selector.js?v=5132798"></script>
-    <script defer src="js/modules/descriptions/GuidedTextInput.js?v=5132798"></script>
+    <script defer src="js/modules/descriptions/category-mapping.js?v=doiievw"></script>
+    <script defer src="js/modules/descriptions/descriptions-manager.js?v=doiievw"></script>
+    <script defer src="js/modules/descriptions/smart-combo-selector.js?v=doiievw"></script>
+    <script defer src="js/modules/descriptions/GuidedTextInput.js?v=doiievw"></script>
 
     <!-- ===== Core Utilities Module ===== -->
     <!-- Must load before dialogs.js (provides safeText) -->
-    <script type="module" src="js/modules/core-utils.js?v=5132798"></script>
+    <script type="module" src="js/modules/core-utils.js?v=doiievw"></script>
 
     <!-- ===== Dialogs Module ===== -->
     <!-- Task completion, advanced dialogs, and other modals + Smart Descriptions -->
-    <script defer src="js/modules/dialogs.js?v=5132798"></script>
+    <script defer src="js/modules/dialogs.js?v=doiievw"></script>
 
     <!-- ===== System Diagnostics & Snapshot Tool ===== -->
     <!-- Full system state comparison for debugging -->
-    <script defer src="js/modules/system-snapshot.js?v=5132798"></script>
+    <script defer src="js/modules/system-snapshot.js?v=doiievw"></script>
     <!-- Event Flow Analyzer - DEV ONLY - removed to prevent CSP errors in production -->
-    <!-- <script defer src="js/modules/event-analyzer.js?v=5132798"></script> -->
+    <!-- <script defer src="js/modules/event-analyzer.js?v=doiievw"></script> -->
 
     <!-- ===== SVG RINGS MODULE ===== -->
-    <script defer src="js/modules/svg-rings.js?v=5132798"></script>
+    <script defer src="js/modules/svg-rings.js?v=doiievw"></script>
 
     <!-- ===== INLINE EXPANSION POPOVER (CSS-only) ===== -->
     <!-- popover-positioning.js removed - file does not exist -->
@@ -1335,23 +1367,23 @@
     <!-- ===== Messaging System ===== -->
     <!-- ===== NEW: Main Application (ES6 Modules) ===== -->
     <!-- Modern modular architecture with ActionFlowManager + Smart Descriptions -->
-    <script type="module" src="js/main.js?v=5132798"></script>
-    <script type="module" src="js/modules/description-tooltips.js?v=5132798"></script>
+    <script type="module" src="js/main.js?v=doiievw"></script>
+    <script type="module" src="js/modules/description-tooltips.js?v=doiievw"></script>
 
     <!-- ===== SYSTEM ANNOUNCEMENT TICKER ===== -->
     <!-- Loaded as module by main.js -->
 
     <!-- Work Hours Calculator - Smart Calendar System -->
-    <script defer src="js/modules/work-hours-calculator.js?v=5132798"></script>
+    <script defer src="js/modules/work-hours-calculator.js?v=doiievw"></script>
 
     <!-- ===== KNOWLEDGE BASE 1.0.0 - מרכז עזרה וידע ===== -->
     <!-- ⚡ KB scripts lazy-loaded on first help click (see authentication.js showApp) -->
 
     <!-- CSS -->
-    <link rel="stylesheet" href="js/modules/knowledge-base/knowledge-base.css?v=5132798">
+    <link rel="stylesheet" href="js/modules/knowledge-base/knowledge-base.css?v=doiievw">
 
     <!-- ===== Virtual Assistant 3.9.0 - TEMPORARILY DISABLED ===== -->
-    <!-- <script src="js/modules/virtual-assistant/virtual-assistant-complete.js?v=5132798"></script> -->
+    <!-- <script src="js/modules/virtual-assistant/virtual-assistant-complete.js?v=doiievw"></script> -->
 
     <!-- ===== AI CHAT SYSTEM (NEW) - LAZY LOADED ===== -->
     <!-- ⚡ NotificationBell is also lazy-loaded (requires authenticated user) -->
@@ -1361,10 +1393,10 @@
     <!-- See: authentication.js -> initAIChatSystem() -->
 
     <!-- OLD: Legacy FAQ Bot (backup) -->
-    <!-- <script type="module" src="js/modules/smart-faq-bot.js?v=5132798"></script> -->
+    <!-- <script type="module" src="js/modules/smart-faq-bot.js?v=doiievw"></script> -->
 
     <!-- ===== OLD: Legacy script.js (DEPRECATED - will be removed) ===== -->
-    <!-- <script src="script.js?v=5132798"></script> -->
+    <!-- <script src="script.js?v=doiievw"></script> -->
 
 
 

--- a/apps/user-app/js/config/state-config.js
+++ b/apps/user-app/js/config/state-config.js
@@ -51,7 +51,8 @@ export const DEFAULTS = {
   BUDGET_VIEW: 'list',             // ✅ ניתן לשמור (Phase 0: default changed from 'cards' to 'list')
   TIMESHEET_VIEW: 'table',         // ✅ ניתן לשמור
   BUDGET_SORT: 'deadline',         // ✅ session-only — תמיד מתחיל ב-deadline
-  TIMESHEET_SORT: 'recent'         // ✅ ניתן לשמור
+  TIMESHEET_SORT: 'recent',        // ✅ ניתן לשמור
+  DEADLINE_FORMAT: 'date'          // ✅ 'date' (15.04.26) | 'days' (5 ימים) — user preference
 };
 
 /* ═══════════════════════════════════════════════════════════════
@@ -87,7 +88,8 @@ export const SESSION_ONLY_KEYS = [
 export const PERSISTED_KEYS = [
   'budgetView',           // ✅ cards/table preference
   'timesheetView',        // ✅ cards/table preference
-  'timesheetSort'         // ✅ sort preference
+  'timesheetSort',        // ✅ sort preference
+  'deadlineFormat'        // ✅ date vs days preference for deadline rendering
 ];
 
 /* ═══════════════════════════════════════════════════════════════

--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -119,6 +119,7 @@ class LawOfficeManager {
     this.currentTimesheetFilter = STATE_CONFIG.getStateValue('timesheetFilter'); // ✅ Always 'month'
     this.currentBudgetView = STATE_CONFIG.getStateValue('budgetView'); // ✅ Persisted
     this.currentTimesheetView = STATE_CONFIG.getStateValue('timesheetView'); // ✅ Persisted
+    this.currentDeadlineFormat = STATE_CONFIG.getStateValue('deadlineFormat'); // ✅ Persisted ('date'|'days')
 
     // Filtered Data
     this.filteredBudgetTasks = [];
@@ -1626,6 +1627,7 @@ return;
       formatShort: CoreUtils.formatShort,
       currentBudgetSort: this.currentBudgetSort,
       currentTaskFilter: this.currentTaskFilter,
+      currentDeadlineFormat: this.currentDeadlineFormat, // 'date' | 'days'
       paginationStatus: null, // Will be added when pagination is implemented
       taskActionsManager: this.taskActionsManager
     };
@@ -1635,6 +1637,21 @@ return;
 
     // Wire stats-bar filter clicks (idempotent — attaches listener once).
     this.setupStatsFilterDelegation();
+
+    // Sync the deadline-format toggle's active state with the current
+    // preference so the correct button is highlighted after initial
+    // render (HTML markup defaults to 'date' active; if the user's
+    // persisted preference is 'days' we need to flip it here).
+    const toggle = document.querySelector('.deadline-format-toggle');
+    if (toggle) {
+      toggle.querySelectorAll('.deadline-format-btn').forEach(btn => {
+        if (btn.dataset.format === this.currentDeadlineFormat) {
+          btn.classList.add('active');
+        } else {
+          btn.classList.remove('active');
+        }
+      });
+    }
 
     if (this.currentBudgetView === 'cards') {
       BudgetTasks.renderBudgetCards(this.filteredBudgetTasks, options);
@@ -1686,6 +1703,44 @@ return;
         document.documentElement.scrollTop = 0;
       }
     });
+  }
+
+  /**
+   * Switch how deadlines are rendered across the budget views.
+   * Persisted via STATE_CONFIG so the user's choice sticks across sessions.
+   *
+   * @param {'date'|'days'} format - 'date' shows dd.mm.yy, 'days' shows
+   *   relative "5 ימים" / "איחור 6 ימים".
+   *
+   * Affected surfaces: cards view (progress-row-value), table deadline
+   * cell, and the compact deadline ring's center label.
+   *
+   * We re-render the current view rather than patching the DOM in place
+   * so the transition is atomic — no half-date / half-days state ever
+   * reaches the user.
+   */
+  switchDeadlineFormat(format) {
+    if (format !== 'date' && format !== 'days') {
+      return;
+    }
+    if (this.currentDeadlineFormat === format) {
+      return;
+    }
+    STATE_CONFIG.setStateValue('deadlineFormat', format);
+    this.currentDeadlineFormat = format;
+
+    const toggle = document.querySelector('.deadline-format-toggle');
+    if (toggle) {
+      toggle.querySelectorAll('.deadline-format-btn').forEach(btn => {
+        if (btn.dataset.format === format) {
+          btn.classList.add('active');
+        } else {
+          btn.classList.remove('active');
+        }
+      });
+    }
+
+    this.renderBudgetView();
   }
 
   /**

--- a/apps/user-app/js/modules/budget-tasks.js
+++ b/apps/user-app/js/modules/budget-tasks.js
@@ -539,89 +539,187 @@ export function getCompletedTasksCount(budgetTasks) {
  * @param {number} daysUntilDeadline - Days until deadline
  * @returns {string} SVG Rings HTML
  */
-function renderSVGRingsSection(
-  task, progress, actualHours, estimatedHours, originalEstimate,
-  wasAdjusted, isOverOriginal, overageMinutes, daysUntilDeadline
-) {
-  if (!window.SVGRings) {
-return '';
+/**
+ * Horizontal progress rows — Linear / Vercel style replacement for SVG rings.
+ *
+ * Two rows (budget + deadline), each is a label + thin horizontal bar +
+ * value + percentage. The bar is gray in the default state and flips to
+ * red when the metric overruns (>=100% for budget, <0 days for deadline),
+ * matching the 2-signals palette used everywhere else in the card.
+ *
+ * ~60px of vertical space saved vs the previous 56px rings layout, and
+ * the card reads top-to-bottom in one glance instead of requiring the
+ * eye to travel between two round shapes.
+ *
+ * Inline action buttons (עדכן תקציב / הארך יעד) sit at the end of their
+ * respective row when applicable — no separate action row below.
+ */
+
+/**
+ * Format a deadline for display in the progress-row value column, the
+ * table cell, and the compact ring center. Two modes:
+ *
+ *   'date' (default) — absolute calendar date "15.04.26". Users asked
+ *     for this because relative day counts ("5 ימים") are ambiguous
+ *     when scanning the list across multiple sessions; the date is a
+ *     fixed anchor you can plan a week around.
+ *
+ *   'days' — relative counter: "5 ימים" / "איחור 6 ימים". Preserved
+ *     for users who prefer the at-a-glance urgency read.
+ *
+ * The function returns `{ text, title }`:
+ *   - `text` is what goes in the visible cell
+ *   - `title` is the opposite format, used as a native hover tooltip
+ *     so the other reading is always one hover away
+ *
+ * @param {Date} deadline - The deadline Date object
+ * @param {number} daysUntil - Signed days until deadline (negative = overdue)
+ * @param {'date'|'days'} format - User preference from STATE_CONFIG
+ * @returns {{text: string, title: string}}
+ */
+function formatDeadlineValue(deadline, daysUntil, format) {
+  const isOverdue = daysUntil < 0;
+  const absDays = Math.abs(daysUntil);
+  const dd = String(deadline.getDate()).padStart(2, '0');
+  const mm = String(deadline.getMonth() + 1).padStart(2, '0');
+  const yy = String(deadline.getFullYear()).slice(-2);
+  const dateText = `${dd}.${mm}.${yy}`;
+  const daysText = isOverdue ? `איחור ${absDays} ימים` : `${absDays} ימים`;
+
+  if (format === 'days') {
+    return { text: daysText, title: dateText };
+  }
+  // default: date
+  return { text: dateText, title: daysText };
 }
 
-  const now = new Date();
+function renderSVGRingsSection(
+  task, progress, actualHours, estimatedHours, originalEstimate,
+  wasAdjusted, isOverOriginal, overageMinutes, daysUntilDeadline,
+  deadlineFormat
+) {
   const deadline = new Date(task.deadline);
-  const createdAt = task.createdAt ? new Date(task.createdAt) : now;
+  const isDeadlineOverdue = daysUntilDeadline < 0;
+  const absDays = Math.abs(daysUntilDeadline);
+  const wasExtended = task.deadlineExtensions && task.deadlineExtensions.length > 0;
 
-  // 🔧 FIX: Handle case where deadline is before createdAt (data inconsistency)
-  // Use deadline as start point if it's earlier than createdAt
+  // Deadline bar % — linear countdown from creation to deadline.
+  // When overdue (<0 days remaining) the bar is rendered full-red regardless.
+  const now = new Date();
+  const createdAt = task.createdAt ? new Date(task.createdAt) : now;
   const startDate = createdAt < deadline ? createdAt : deadline;
   const totalDays = Math.max(1, (deadline - startDate) / (1000 * 60 * 60 * 24));
   const elapsedDays = (now - startDate) / (1000 * 60 * 60 * 24);
-  // ✅ FIX: הסרת הגבלת 100% - מאפשר להראות איחור אמיתי (למשל 120% = איחור של 20%)
-  const deadlineProgress = Math.max(0, Math.round((elapsedDays / totalDays) * 100));
-  const isDeadlineOverdue = daysUntilDeadline < 0;
-  const overdueDays = Math.abs(Math.min(0, daysUntilDeadline));
+  const deadlineFillPercent = isDeadlineOverdue
+    ? 100
+    : Math.min(100, Math.max(0, Math.round((elapsedDays / totalDays) * 100)));
 
-  // Budget Ring Config
-  const budgetRingConfig = {
-    progress, // ✅ No 100% cap - shows 150%+ for overage
-    color: getProgressColor(progress), // שימוש בפונקציה המשותפת
-    icon: 'fas fa-clock',
-    label: 'תקציב זמן',
-    value: `${actualHours}ש / ${estimatedHours}ש`,
-    size: 80,
-    button: isOverOriginal ? { // ✅ Removed !wasAdjusted - allows repeated budget updates
-      text: wasAdjusted ? 'עדכן שוב' : 'עדכן תקציב',
-      onclick: `event.stopPropagation(); manager.showAdjustBudgetDialog('${task.id}')`,
-      icon: 'fas fa-edit',
-      cssClass: 'budget-btn',
-      show: true
-    } : null
+  // Budget bar % — capped visually at 100% (overrun is carried by the red
+  // color + the textual "129%" counter, not by a bar that overflows).
+  const budgetFillPercent = Math.min(100, Math.round(progress));
+
+  const budgetAlarm = progress >= 100;
+  const adjustedHint = wasAdjusted
+    ? ' <span class="progress-row-adjusted">(עודכן)</span>'
+    : '';
+
+  /*
+   * Map a progress percentage to a severity level that the CSS uses to
+   * pick a bar color. Thresholds:
+   *   <50   low     → calm blue
+   *   50–79 medium  → deeper blue
+   *   80–99 high    → amber (early warning — user asked for color change
+   *                   before the last moment, not only at overrun)
+   *   >=100 alarm   → red
+   */
+  const levelForPercent = (pct) => {
+    if (pct >= 100) {
+ return 'alarm';
+}
+    if (pct >= 80)  {
+ return 'high';
+}
+    if (pct >= 50)  {
+ return 'medium';
+}
+    return 'low';
   };
 
-  // Deadline Ring Config
-  const wasExtended = task.deadlineExtensions && task.deadlineExtensions.length > 0;
+  const budgetLevel = levelForPercent(progress);
+  const deadlineLevel = isDeadlineOverdue
+    ? 'alarm'
+    : levelForPercent(deadlineFillPercent);
 
-  // ✅ FIX: צבע דינמי מתאים לאחוז התקדמות (כולל מעל 100%)
-  let deadlineColor = 'blue'; // ברירת מחדל - כחול
-  if (deadlineProgress >= 100) {
-    deadlineColor = 'red'; // אדום - איחור
-  } else if (deadlineProgress >= 85) {
-    deadlineColor = 'orange'; // כתום - התקרבות ליעד
-  }
+  /*
+   * Action slot is always rendered (even when empty), so both rows have
+   * the same trailing column width and therefore the same bar width.
+   * Without a placeholder, a row without an action button ends up with
+   * its bar ~32px longer than the one with an action — reads as a data
+   * difference that isn't real.
+   */
+  const budgetUpdateBtn = isOverOriginal ? `
+    <button
+      class="progress-row-action"
+      onclick="event.stopPropagation(); manager.showAdjustBudgetDialog('${task.id}')"
+      title="${wasAdjusted ? 'עדכן שוב' : 'עדכן תקציב'}"
+      aria-label="${wasAdjusted ? 'עדכן שוב' : 'עדכן תקציב'}"
+    >
+      <i class="fas fa-edit"></i>
+    </button>
+  ` : '<span class="progress-row-action-placeholder" aria-hidden="true"></span>';
 
-  // 🐛 DEBUG: Log deadline progress for task with overdue
-  if (deadlineProgress > 100) {
-    console.log(`🔍 Task ${task.id.substring(0, 8)}: deadlineProgress = ${deadlineProgress}%`);
-  }
+  const deadlineExtendBtn = isDeadlineOverdue ? `
+    <button
+      class="progress-row-action"
+      onclick="event.stopPropagation(); manager.showExtendDeadlineDialog('${task.id}')"
+      title="${wasExtended ? 'הארך שוב' : 'הארך יעד'}"
+      aria-label="${wasExtended ? 'הארך שוב' : 'הארך יעד'}"
+    >
+      <i class="fas fa-calendar-plus"></i>
+    </button>
+  ` : '<span class="progress-row-action-placeholder" aria-hidden="true"></span>';
 
-  // ✅ NEW: Use createDeadlineDisplay instead of createSVGRing for deadline
-  const budgetRingHTML = window.SVGRings.createSVGRing(budgetRingConfig);
-  const deadlineRingHTML = window.SVGRings.createDeadlineDisplay({
-    deadline: deadline,
-    daysRemaining: daysUntilDeadline,
-    size: 80,
-    button: isDeadlineOverdue ? {
-      text: wasExtended ? 'הארך שוב' : 'הארך יעד',
-      onclick: `event.stopPropagation(); manager.showExtendDeadlineDialog('${task.id}')`,
-      icon: 'fas fa-calendar-plus',
-      cssClass: 'deadline-btn',
-      show: true
-    } : null
-  });
+  // Deadline value — user-chosen format (date dd.mm.yy or relative days).
+  // The opposite reading is exposed via native title tooltip so no info
+  // is lost when switching formats. Overdue coloring is carried by the
+  // red bar + the is-alarm row class, not by textual prefixes.
+  const deadlineDisplay = formatDeadlineValue(
+    deadline,
+    daysUntilDeadline,
+    deadlineFormat
+  );
+  const deadlineValueText = deadlineDisplay.text;
+  const deadlineValueTitle = deadlineDisplay.title;
 
-  let ringsHTML = `
-    <div class="svg-rings-dual-layout">
-      ${budgetRingHTML}
-      ${deadlineRingHTML}
+  // Always render a percent — keeps the column alignment consistent
+  // between the two rows (otherwise the budget row's "0%" sits in a
+  // column the deadline row leaves empty, breaking the visual grid).
+  // For overdue, "100%" reads as "the window is fully consumed" and
+  // pairs cleanly with the red bar + "איחור N ימים" value.
+  const deadlinePercentText = `${Math.round(deadlineFillPercent)}%`;
+
+  return `
+    <div class="card-progress-rows">
+      <div class="progress-row ${budgetAlarm ? 'is-alarm' : ''}">
+        <span class="progress-row-label">תקציב</span>
+        <span class="progress-row-bar">
+          <span class="progress-row-fill" data-level="${budgetLevel}" style="width: ${budgetFillPercent}%"></span>
+        </span>
+        <span class="progress-row-value">${actualHours}ש / ${estimatedHours}ש${adjustedHint}</span>
+        <span class="progress-row-percent">${Math.min(100, Math.round(progress))}%</span>
+        ${budgetUpdateBtn}
+      </div>
+      <div class="progress-row ${isDeadlineOverdue ? 'is-alarm' : ''}">
+        <span class="progress-row-label">דדליין</span>
+        <span class="progress-row-bar">
+          <span class="progress-row-fill" data-level="${deadlineLevel}" style="width: ${deadlineFillPercent}%"></span>
+        </span>
+        <span class="progress-row-value" title="${deadlineValueTitle}">${deadlineValueText}</span>
+        <span class="progress-row-percent">${deadlinePercentText}</span>
+        ${deadlineExtendBtn}
+      </div>
     </div>
   `;
-
-  // Add info note if budget was adjusted
-  if (wasAdjusted) {
-    ringsHTML += `<div class="budget-adjusted-note" style="text-align: center; margin-top: 12px; font-size: 11px; color: #3b82f6;"><i class="fas fa-info-circle"></i> תקציב עודכן ל-${estimatedHours}ש</div>`;
-  }
-
-  return ringsHTML;
 }
 
 /* ===========================
@@ -635,7 +733,8 @@ return '';
  * @returns {string} HTML string
  */
 export function createTaskCard(task, options = {}) {
-  const { safeText, formatDate, formatShort } = options;
+  const { safeText, formatDate, formatShort, currentDeadlineFormat } = options;
+  const deadlineFormat = currentDeadlineFormat === 'days' ? 'days' : 'date';
 
   const safeTask = sanitizeTaskData(task);
   const progress = calculateSimpleProgress(safeTask);
@@ -698,8 +797,9 @@ export function createTaskCard(task, options = {}) {
 
   // ✅ REMOVED: pendingApprovalIndicator - not needed in UI
 
-  // 🎯 Combined info badge (case + service + stage)
-  // Pass serviceId directly - mapping will be done in the popup
+  // 🎯 Combined info badge (case + service + stage). Rendered into the
+  // meta footer (not the top corner) so all task metadata sits together
+  // and the title gets the full top width.
   const combinedBadge = createCombinedInfoBadge(
     safeTask.caseNumber,
     safeTask.serviceName,
@@ -707,18 +807,24 @@ export function createTaskCard(task, options = {}) {
     safeTask.serviceId || ''
   );
 
-  const badgesRow = combinedBadge ? `
-    <div class="linear-card-badges">
-      ${combinedBadge}
-    </div>
-  ` : '';
+  // Compact creation date string for the unified meta footer.
+  const creationDateText = safeTask.createdAt
+    ? formatDate(safeTask.createdAt)
+    : '';
 
   // For completed tasks — static summary (no live rings).
   const completedSummary = isCompleted ? buildCompletedCardSummary(safeTask) : '';
 
+  /*
+   * Layout — Claude.ai compact card.
+   *
+   * Top corner is now empty. Title gets the full top space. The combined
+   * info badge, client name, and creation date are all consolidated into
+   * a single meta footer row at the bottom, which sits next to the
+   * expand "+" button.
+   */
   return `
     <div class="linear-minimal-card ${isPendingApproval ? 'pending-approval' : ''}" data-task-id="${safeTask.id}">
-      ${badgesRow}
       <div class="linear-card-content">
         <h3 class="linear-card-title" title="${safeClientName}">
           ${safeDescription}
@@ -726,24 +832,17 @@ export function createTaskCard(task, options = {}) {
         </h3>
 
         <!-- 🎯 SVG RINGS (active only) / Completion summary (completed) -->
-        ${!isCompleted && window.SVGRings ? renderSVGRingsSection(safeTask, progress, actualHours, estimatedHours, originalEstimate, wasAdjusted, isOverOriginal, overageMinutes, daysUntilDeadline) : ''}
+        ${!isCompleted && window.SVGRings ? renderSVGRingsSection(safeTask, progress, actualHours, estimatedHours, originalEstimate, wasAdjusted, isOverOriginal, overageMinutes, daysUntilDeadline, deadlineFormat) : ''}
         ${completedSummary}
       </div>
 
-      <!-- החלק התחתון - מחוץ ל-content -->
+      <!-- Meta footer: badge · client · creation date · expand button -->
       <div class="linear-card-meta">
-        <div class="linear-client-row">
-          <span class="linear-client-label">לקוח:</span>
-          <span class="linear-client-name" title="${safeClientName}">
-            ${clientDisplayName}
-          </span>
-        </div>
-        ${safeTask.createdAt ? `
-        <div class="creation-date-tag">
-          <i class="far fa-clock"></i>
-          <span>נוצר ב-${formatDate(safeTask.createdAt)} ${new Date(safeTask.createdAt).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit' })}</span>
-        </div>
-        ` : ''}
+        ${combinedBadge}
+        <span class="linear-client-name" title="${safeClientName}">
+          ${clientDisplayName}
+        </span>
+        ${creationDateText ? `<span class="linear-card-meta-date">· ${creationDateText}</span>` : ''}
       </div>
 
       <button class="linear-expand-btn" onclick="manager.expandTaskCard('${
@@ -762,7 +861,8 @@ export function createTaskCard(task, options = {}) {
  * @returns {string} HTML string
  */
 export function createTableRow(task, options = {}) {
-  const { safeText, formatDate, taskActionsManager } = options;
+  const { safeText, formatDate, taskActionsManager, currentDeadlineFormat } = options;
+  const deadlineFormat = currentDeadlineFormat === 'days' ? 'days' : 'date';
 
   const safeTask = sanitizeTaskData(task);
   const progress = calculateSimpleProgress(safeTask);
@@ -810,7 +910,8 @@ export function createTableRow(task, options = {}) {
         daysRemaining: daysUntilDeadline,
         progress: deadlineProgress,
         deadline: deadline,
-        size: 52
+        size: 52,
+        format: deadlineFormat
       });
     } else {
       deadlineCellHtml = formatDate ? formatDate(safeTask.deadline) : safeTask.deadline;
@@ -990,34 +1091,40 @@ export function renderBudgetCards(tasks, options = {}) {
     </div>
   ` : '';
 
+  /*
+   * Flat layout — Claude.ai / Linear / Vercel pattern.
+   *
+   * Previously the cards grid was wrapped in <div class="modern-cards-container">
+   * with its own white background, border, shadow, and a gradient
+   * <div class="modern-table-header"> carrying the "משימות מתוקצבות" title.
+   * That created a triple-nested "matryoshka" (outer shell + inner grid
+   * canvas + individual cards) which pushed the cards inward, wasted
+   * horizontal space, and gave the UI a heavy framed look.
+   *
+   * The tab context already tells the user what section they're in, so
+   * the title is redundant. Stats + sort controls sit directly above the
+   * grid, and the cards float on the page itself.
+   */
   const html = `
-    <div class="modern-cards-container">
-      <div class="modern-table-header">
-        <h3 class="modern-table-title">
-          <i class="fas fa-chart-bar"></i>
-          משימות מתוקצבות
-        </h3>
+    <div class="stats-with-sort-row">
+      ${statsBar}
+      <div class="sort-dropdown">
+        <label class="sort-label">
+          <i class="fas fa-sort-amount-down"></i>
+          מיין לפי:
+        </label>
+        <select class="sort-select" id="budgetSortSelect" onchange="manager.sortBudgetTasks(event)">
+          <option value="recent" ${currentBudgetSort === 'recent' ? 'selected' : ''}>עדכון אחרון</option>
+          <option value="name" ${currentBudgetSort === 'name' ? 'selected' : ''}>שם (א-ת)</option>
+          <option value="deadline" ${currentBudgetSort === 'deadline' ? 'selected' : ''}>תאריך יעד</option>
+          <option value="progress" ${currentBudgetSort === 'progress' ? 'selected' : ''}>התקדמות</option>
+        </select>
       </div>
-      <div class="stats-with-sort-row">
-        ${statsBar}
-        <div class="sort-dropdown">
-          <label class="sort-label">
-            <i class="fas fa-sort-amount-down"></i>
-            מיין לפי:
-          </label>
-          <select class="sort-select" id="budgetSortSelect" onchange="manager.sortBudgetTasks(event)">
-            <option value="recent" ${currentBudgetSort === 'recent' ? 'selected' : ''}>עדכון אחרון</option>
-            <option value="name" ${currentBudgetSort === 'name' ? 'selected' : ''}>שם (א-ת)</option>
-            <option value="deadline" ${currentBudgetSort === 'deadline' ? 'selected' : ''}>תאריך יעד</option>
-            <option value="progress" ${currentBudgetSort === 'progress' ? 'selected' : ''}>התקדמות</option>
-          </select>
-        </div>
-      </div>
-      <div class="budget-cards-grid">
-        ${tasksHtml}
-      </div>
-      ${loadMoreButton}
     </div>
+    <div class="budget-cards-grid">
+      ${tasksHtml}
+    </div>
+    ${loadMoreButton}
   `;
 
   if (container) {

--- a/apps/user-app/js/modules/svg-rings.js
+++ b/apps/user-app/js/modules/svg-rings.js
@@ -28,135 +28,102 @@
   }
 
   /**
-   * יצירת SVG Ring יחיד
-   * @param {Object} config - Configuration object
-   * @param {number} config.progress - Progress percentage (0-100)
-   * @param {string} config.color - Color theme ('green', 'blue', 'red', 'orange')
-   * @param {string} config.icon - FontAwesome icon class
-   * @param {string} config.label - Label text
-   * @param {string} config.value - Value text (e.g., "12.5h / 20h")
-   * @param {number} [config.size=100] - Ring size in pixels
-   * @param {boolean} [config.overage=false] - Is this an overage ring?
-   * @param {Object} [config.button] - Button configuration { text, onclick, show }
-   * @returns {string} - SVG HTML string
+   * Single SVG ring — Claude.ai / Emil 2-signals minimal.
+   *
+   * Visual language:
+   * - 72x72 ring (was 100x100), 3px stroke (was 6px). A smaller ring lets
+   *   the card breathe and reads as a refined status badge, not a centerpiece.
+   * - Flat strokes, no gradient <defs>, no <linearGradient>. Every decoration
+   *   that didn't carry information is gone.
+   * - "2 signals only" palette: gray for every non-overrun state, red only
+   *   when progress >= 100 (budget overrun) or when the caller passes color
+   *   = 'red' (e.g. overdue deadline from the caller).
+   * - No Font Awesome icon inside the ring — the percentage (or the caller's
+   *   `centerText`) IS the content. Keeps the ring SVG-only (no font deps).
+   *
+   * @param {Object} config
+   * @param {number} config.progress - 0..N; >=100 flips the ring to red
+   * @param {string} [config.color]  - 'red' forces red (e.g. overdue); other
+   *                                   values fall back to the gray ramp
+   * @param {string} config.label    - external label under the ring
+   * @param {string} config.value    - external secondary text under the label
+   * @param {string} [config.centerText] - override text inside the ring;
+   *                                       defaults to `${Math.round(progress)}%`
+   * @param {number} [config.size=72]
+   * @param {boolean} [config.overage=false]
+   * @param {Object} [config.button] - { text, onclick, show, cssClass, icon }
+   * @returns {string} HTML string
    */
   function createSVGRing(config) {
     const {
       progress,
       color,
-      icon,
       label,
       value,
-      size = 100,
+      centerText,
+      size = 56,
       overage = false,
       button = null
     } = config;
 
-    const radius = 32;
-    const strokeWidth = 6;
+    // Ring geometry scaled for the compact 56px size: smaller radius,
+    // thinner stroke (2.5px) reads cleanly without dominating.
+    const radius = 22;
+    const strokeWidth = 2.5;
+    const viewBox = 56;
+    const center = viewBox / 2;
     const circumference = 2 * Math.PI * radius;
-    // ✅ FIX: Allow progress > 100% - ring visual caps at 100%, but text shows actual %
+    // Ring maxes visually at 100% even if progress overruns — the "how much
+    // over" is carried by the red color + the textual label underneath.
     const dashOffset = calculateDashOffset(Math.min(progress, 100), radius);
 
-    // Generate unique gradient ID
-    const gradientId = `ring-gradient-${Math.random().toString(36).substr(2, 9)}`;
+    // 2-signals palette: red only if caller forced it, or if progress is
+    // actually past 100% (real overrun). Otherwise gray.
+    const isAlarm = progress >= 100 || color === 'red';
+    const strokeColor = isAlarm ? '#dc2626' : 'var(--gray-500)';
+    const bgColor = 'var(--gray-200)';
+    const centerColor = isAlarm ? '#dc2626' : 'var(--gray-900)';
 
-    // Color schemes - מילוי צבעוני, רקע אפור
-    const colors = {
-      green: {
-        start: '#059669',
-        end: '#047857',
-        text: '#065f46'
-      },
-      blue: {
-        start: '#2563eb',
-        end: '#1e40af',
-        text: '#1e3a8a'
-      },
-      red: {
-        start: '#dc2626',
-        end: '#b91c1c',
-        text: '#991b1b'
-      },
-      orange: {
-        start: '#ea580c',
-        end: '#c2410c',
-        text: '#9a3412'
-      }
-    };
-
-    const colorScheme = colors[color] || colors.green;
-
-    // הרקע תמיד אפור
-    const bgColor = '#e5e7eb';
-
-    // Meta Clean: Only add status class for DANGER (overage)
-    // Color alone is enough for warning/ok states
-    const statusClass = (progress >= 100 || color === 'red') ? 'status-danger' : '';
+    const statusClass = isAlarm ? 'status-danger' : '';
+    const displayText = centerText !== null && centerText !== undefined ? centerText : `${Math.round(progress)}%`;
 
     return `
       <div class="svg-ring-container ${overage ? 'overage-ring' : ''}">
         <div class="svg-ring-wrapper ${statusClass}">
-          <svg width="${size}" height="${size}" viewBox="0 0 80 80" class="svg-ring">
-            <!-- Background circle (gray) -->
+          <svg width="${size}" height="${size}" viewBox="0 0 ${viewBox} ${viewBox}" class="svg-ring">
             <circle
-              cx="40"
-              cy="40"
+              cx="${center}"
+              cy="${center}"
               r="${radius}"
               fill="none"
               stroke="${bgColor}"
               stroke-width="${strokeWidth}"
             />
-
-            <!-- Progress circle -->
             <circle
-              cx="40"
-              cy="40"
+              cx="${center}"
+              cy="${center}"
               r="${radius}"
               fill="none"
-              stroke="url(#${gradientId})"
+              stroke="${strokeColor}"
               stroke-width="${strokeWidth}"
               stroke-dasharray="${circumference}"
               stroke-dashoffset="${dashOffset}"
               stroke-linecap="round"
-              transform="rotate(-90 40 40)"
+              transform="rotate(-90 ${center} ${center})"
               class="svg-ring-progress"
             />
-
-            <!-- Gradient definition -->
-            <defs>
-              <linearGradient id="${gradientId}" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="${colorScheme.start}" />
-                <stop offset="100%" stop-color="${colorScheme.end}" />
-              </linearGradient>
-            </defs>
-
-            <!-- Center icon (gray) -->
-            <g transform="translate(40, 40)">
-              <text
-                text-anchor="middle"
-                dominant-baseline="central"
-                font-size="18"
-                fill="#6b7280"
-                class="svg-ring-icon">
-                <tspan class="${icon}"></tspan>
-              </text>
-            </g>
           </svg>
 
-          <!-- Percentage text (overlay, gray) -->
-          <div class="svg-ring-percentage" style="color: #6b7280;">
-            ${Math.round(progress)}%
+          <div class="svg-ring-percentage" style="color: ${centerColor};">
+            ${displayText}
           </div>
         </div>
 
-        <!-- Label and value -->
         <div class="svg-ring-info">
           <div class="svg-ring-label">${label}</div>
           <div class="svg-ring-value">${value}</div>
         </div>
 
-        <!-- Action button (if provided) -->
         ${button && button.show ? `
           <button class="svg-ring-action-btn ${button.cssClass || ''}" onclick="${button.onclick}">
             <i class="${button.icon || 'fas fa-edit'}"></i> ${button.text}
@@ -231,7 +198,8 @@
       daysRemaining,
       progress,
       deadline,
-      size = 52
+      size = 52,
+      format = 'date'
     } = config;
 
     const radius = 20;
@@ -263,14 +231,29 @@
 
     const displayDays = Math.abs(daysRemaining);
 
-    // פורמט תאריך מלא DD.MM.YYYY (אם deadline קיים)
+    // Compact date formats:
+    //   shortDate: dd.mm.yy — fits inside the 52px ring center
+    //   fullDate:  dd.mm.yyyy — used as sublabel or tooltip
+    let shortDateStr = '';
     let fullDateStr = '';
     if (deadline) {
       const day = String(deadline.getDate()).padStart(2, '0');
       const month = String(deadline.getMonth() + 1).padStart(2, '0');
       const year = deadline.getFullYear();
+      const yy = String(year).slice(-2);
+      shortDateStr = `${day}.${month}.${yy}`;
       fullDateStr = `${day}.${month}.${year}`;
     }
+
+    // Which token goes in the ring's center vs under the ring depends on
+    // the user's format preference. We keep the ring itself identical so
+    // the visual progress indicator stays consistent across formats.
+    const showDate = format === 'date';
+    const centerText = showDate ? shortDateStr : String(displayDays);
+    const centerFontSize = showDate ? 11 : 16;
+    const sublabelText = showDate
+      ? `${displayDays} ימים`
+      : fullDateStr;
 
     // Flat stroke (no gradient) — Emil: no unnecessary visual effects.
     // Text color on date + label inherits from the ring's colorScheme so
@@ -304,15 +287,14 @@
             y="30"
             text-anchor="middle"
             dominant-baseline="central"
-            font-size="16"
+            font-size="${centerFontSize}"
             font-weight="600"
             fill="${colorScheme.text}"
             class="compact-ring-number">
-            ${displayDays}
+            ${centerText}
           </text>
         </svg>
-        ${fullDateStr ? `<div class="compact-ring-date" style="color: ${colorScheme.text};">${fullDateStr}</div>` : ''}
-        <div class="compact-ring-label-below" style="color: ${colorScheme.text};">${displayDays} ימים</div>
+        <div class="compact-ring-label-below" style="color: ${colorScheme.text};">${sublabelText}</div>
         ${isOverdue ? '<div class="compact-ring-status">איחור!</div>' : ''}
       </div>
     `;
@@ -374,114 +356,78 @@
    * @param {Object} [config.button] - Button configuration { text, onclick, show }
    * @returns {string} - HTML string
    */
+  /*
+   * Deadline ring — Claude.ai / Emil 2-signals minimal.
+   *
+   * Aligned with createSVGRing: 56x56, 2.5px stroke, flat (no gradient
+   * <defs>), gray by default, red only when overdue. Dropped the third
+   * "orange / ≤3 days approaching" scheme — that was a warning signal
+   * competing with the real signal (overdue), exactly what the "2
+   * signals only" rule is meant to prevent.
+   */
   function createDeadlineDisplay(config) {
     const {
       deadline,
       daysRemaining,
-      size = 100,
+      size = 56,
       button = null
     } = config;
 
     const isOverdue = daysRemaining < 0;
-    const absDays = Math.abs(daysRemaining);
-
-    // צבע המילוי משתנה לפי דחיפות
-    let colorScheme;
-
-    if (isOverdue) {
-      colorScheme = {
-        start: '#dc2626',
-        end: '#b91c1c'
-      };
-    } else if (daysRemaining <= 3) {
-      colorScheme = {
-        start: '#ea580c',
-        end: '#c2410c'
-      };
-    } else {
-      colorScheme = {
-        start: '#2563eb',
-        end: '#1e40af'
-      };
-    }
-
-    // הרקע תמיד אפור
-    const bgColor = '#e5e7eb';
-
-    const radius = 32;
-    const strokeWidth = 6;
-    const circumference = 2 * Math.PI * radius;
-    const gradientId = `deadline-gradient-${Math.random().toString(36).substr(2, 9)}`;
-
-    // מספר הימים (יוצג במרכז העיגול)
     const displayDays = Math.abs(daysRemaining);
 
-    // פורמט תאריך מלא DD.MM.YYYY (יוצג מתחת לעיגול)
+    const strokeColor = isOverdue ? '#dc2626' : 'var(--gray-500)';
+    const bgColor = 'var(--gray-200)';
+    const centerColor = isOverdue ? '#dc2626' : 'var(--gray-900)';
+
+    const radius = 22;
+    const strokeWidth = 2.5;
+    const viewBox = 56;
+    const center = viewBox / 2;
+    const circumference = 2 * Math.PI * radius;
+
     const day = String(deadline.getDate()).padStart(2, '0');
     const month = String(deadline.getMonth() + 1).padStart(2, '0');
     const year = deadline.getFullYear();
     const fullDateStr = `${day}.${month}.${year}`;
 
     return `
-      <div class="svg-ring-container">
+      <div class="svg-ring-container ${isOverdue ? 'status-danger' : ''}">
         <div class="svg-ring-wrapper">
-          <svg width="${size}" height="${size}" viewBox="0 0 80 80" class="svg-ring">
-            <!-- Background circle (gray) -->
+          <svg width="${size}" height="${size}" viewBox="0 0 ${viewBox} ${viewBox}" class="svg-ring">
             <circle
-              cx="40"
-              cy="40"
+              cx="${center}"
+              cy="${center}"
               r="${radius}"
               fill="none"
               stroke="${bgColor}"
               stroke-width="${strokeWidth}"
             />
-
-            <!-- Progress circle (colored - full) -->
             <circle
-              cx="40"
-              cy="40"
+              cx="${center}"
+              cy="${center}"
               r="${radius}"
               fill="none"
-              stroke="url(#${gradientId})"
+              stroke="${strokeColor}"
               stroke-width="${strokeWidth}"
               stroke-dasharray="${circumference}"
               stroke-dashoffset="0"
               stroke-linecap="round"
-              transform="rotate(-90 40 40)"
+              transform="rotate(-90 ${center} ${center})"
               class="svg-ring-progress"
             />
-
-            <!-- Gradient definition -->
-            <defs>
-              <linearGradient id="${gradientId}" x1="0%" y1="0%" x2="100%" y2="100%">
-                <stop offset="0%" stop-color="${colorScheme.start}" />
-                <stop offset="100%" stop-color="${colorScheme.end}" />
-              </linearGradient>
-            </defs>
-
-            <!-- Center content: Number of days -->
-            <text
-              x="40"
-              y="40"
-              text-anchor="middle"
-              dominant-baseline="central"
-              font-size="20"
-              font-weight="400"
-              fill="#6b7280"
-              opacity="0.85">
-              ${displayDays}
-            </text>
           </svg>
+          <div class="svg-ring-percentage" style="color: ${centerColor};">
+            ${displayDays}
+          </div>
         </div>
 
-        <!-- Label and value -->
         <div class="svg-ring-info">
           <div class="svg-ring-label">תאריך יעד</div>
           <div class="svg-ring-value">${fullDateStr}</div>
           ${isOverdue ? `<div class="svg-ring-overdue-badge">איחור ${displayDays} ימים</div>` : ''}
         </div>
 
-        <!-- Action button (if provided) -->
         ${button && button.show ? `
           <button class="svg-ring-action-btn ${button.cssClass || ''}" onclick="${button.onclick}">
             <i class="${button.icon || 'fas fa-edit'}"></i> ${button.text}

--- a/apps/user-app/js/modules/timesheet.js
+++ b/apps/user-app/js/modules/timesheet.js
@@ -420,15 +420,16 @@ export function createTimesheetCard(entry) {
     safeEntry.serviceId || ''
   );
 
-  const badgesRow = combinedBadge ? `
-    <div class="linear-card-badges">
-      ${combinedBadge}
-    </div>
-  ` : '';
+  // Creation date — quiet caption in the meta footer, same style as
+  // budget-tasks cards. We keep the formatter local so the timesheet's
+  // "dd.mm.yyyy HH:MM" reading stays intact without reaching back into
+  // DatesModule for a different signature.
+  const creationDateText = safeEntry.createdAt
+    ? `${formatDate(safeEntry.createdAt)} ${new Date(safeEntry.createdAt).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit' })}`
+    : '';
 
   return `
     <div class="linear-minimal-card" data-entry-id="${safeEntry.id}">
-      ${badgesRow}
       <div class="linear-card-content">
         <h3 class="linear-card-title" title="${safeClientName}">
           ${safeAction}
@@ -447,20 +448,11 @@ export function createTimesheetCard(entry) {
         </div>
       </div>
 
-      <!-- החלק התחתון - מחוץ ל-content -->
+      <!-- Meta footer: badge · client · creation date — mirrors budget-tasks cards -->
       <div class="linear-card-meta">
-        <div class="linear-client-row">
-          <span class="linear-client-label">לקוח:</span>
-          <span class="linear-client-name" title="${safeClientName}">
-            ${safeClientName}
-          </span>
-        </div>
-        ${safeEntry.createdAt ? `
-        <div class="creation-date-tag">
-          <i class="far fa-clock"></i>
-          <span>נוצר ב-${formatDate(safeEntry.createdAt)} ${new Date(safeEntry.createdAt).toLocaleTimeString('he-IL', { hour: '2-digit', minute: '2-digit' })}</span>
-        </div>
-        ` : ''}
+        ${combinedBadge}
+        <span class="linear-client-name" title="${safeClientName}">${safeClientName}</span>
+        ${creationDateText ? `<span class="linear-card-meta-date">· ${creationDateText}</span>` : ''}
       </div>
 
       <button class="linear-expand-btn" onclick="event.stopPropagation(); manager.showEditTimesheetDialog('${safeEntry.id}')" title="ערוך">
@@ -608,7 +600,7 @@ export function renderTimesheetTable(entries, stats, paginationStatus, currentSo
         <td style="color: #6b7280; font-size: 13px;">${window.DatesModule.getCreationDateTableCell(entry)}</td>
         <td>${safeText(entry.notes || '—')}</td>
         <td class="actions-column">
-          <button class="action-btn edit-btn" onclick="manager.showEditTimesheetDialog('${entryId}')" title="ערוך שעתון">
+          <button class="action-btn" onclick="manager.showEditTimesheetDialog('${entryId}')" title="ערוך שעתון">
             <i class="fas fa-edit"></i>
           </button>
         </td>


### PR DESCRIPTION
## Summary

Second-phase polish on the budget-tasks cards view plus a user-controlled
deadline display preference that applies across all three budget views
(list / cards / table). Also aligns the timesheet cards/table with the
same design system. Two commits:

- **20b8199** — feature + polish (HTML/JS/CSS)
- **da37ca4** — dead CSS removal (chore)

## What's new for users

### Deadline format toggle (persisted per user)
New segmented control next to the view-tabs: `[תאריך | ימים]`.

- **תאריך** (default): deadlines show `dd.mm.yy` — a fixed calendar
  anchor users can plan a week around
- **ימים**: deadlines show `5 ימים` / `איחור 6 ימים` — urgency read
- Saved via `STATE_CONFIG` as `deadlineFormat`; survives refresh
- Applies uniformly to cards value, table cell, and compact ring
  center. The opposite reading is always available as a native
  `title` tooltip on hover — no info lost
- Default chosen per user report: "users asked for the calendar date,
  not days"

### Cards view — horizontal bars replace SVG rings
- Two compact rows per card: budget + deadline
- Row shape: `label | bar | value | percent | action`
- Fixed column widths + invisible placeholder ensure both rows end at
  the same x-coordinate regardless of action-button presence
- Progressive 4-level color ramp (low=blue, medium=deeper blue,
  high=amber early warning, alarm=red overrun) via `data-level`
- Gradient fill + row-hover sheen overlay for a Claude.ai surface feel
- Shed ~60px of card height vs the previous 56px rings layout
- Both % counters capped at 100% for visual consistency; overrun is
  carried by the red color + the value text (`(עודכן)` / `איחור N`)

### Timesheet cards — aligned with budget-tasks meta footer
- `combinedBadge` moved from the top wrapper down to the meta footer
  (same structure as budget-tasks cards)
- Removed the "לקוח:" prefix row — client name reads bare
- Replaced the noisy creation-date pill with a quiet
  `· dd.mm.yyyy HH:MM` caption via `.linear-card-meta-date`
- Reuses the exact same classes as budget-tasks cards — zero new CSS

### Timesheet table — edit button minimal style
- Removed `edit-btn` class from the row action button; `.action-btn`
  alone (defined in `tables.css`) now governs, giving the same minimal
  transparent Claude.ai style as budget-tasks table buttons
- No CSS changes — the blue `.edit-btn` rule in `timesheet-cards.css`
  is preserved for other consumers (dialogs, etc.)

### Icon micro-motion (hover only)
- Unified "gentle tilt + scale" family for badge icons (folder,
  briefcase, balance) — spring easing `cubic-bezier(0.34, 1.56, 0.64, 1)`
  with 55%/100% keyframes for physical bounce
- Per-icon: pencil-write-hover (edit), calendar-open-hover (extend),
  plus-open-hover (expand) — 320ms, hover-only, purposeful
- `prefers-reduced-motion` honored on every animation

## Dead CSS cleanup (commit `da37ca4`)

Three classes became orphaned after the timesheet card refactor. Audit
confirmed zero consumers in source (only in `dist/assets/` which
regenerates on Netlify build):

- `.linear-card-badges` (cards.css)
- `.linear-client-row` (tables.css stale comment)
- `.linear-client-label` (tables.css)

**Deferred:** `.creation-date-tag` still has a live reference in
`DatesModule.getCreationDateHTML()` (public API, even though no active
callers). Will be handled in a separate audit + cleanup.

## Scope

- View-only — no Firestore queries, indexes, data-model changes
- No `functions/` or admin-panel changes
- New localStorage key: `deadlineFormat` (persisted)
- No new dependencies

## Test plan

- [ ] DEV: toggle `[תאריך | ימים]` appears next to view-tabs
- [ ] DEV: default is "תאריך"; clicking "ימים" updates all visible deadlines
- [ ] DEV: refresh preserves the selection
- [ ] DEV: cards view — horizontal bars aligned, progressive colors, hover sheen
- [ ] DEV: cards view — overrun shows 100% (capped) + red + value text
- [ ] DEV: table view — compact ring center swaps between date/days with toggle
- [ ] DEV: timesheet cards — badge in meta footer, no "לקוח:" prefix, quiet date caption
- [ ] DEV: timesheet table — edit button minimal style (not blue pill)
- [ ] DEV: icon hovers feel intentional (tilt + scale, spring easing)
- [ ] DEV: console clean across all views + toggle states
- [ ] DEV: no regressions in budget-tasks list view (Phase 0 from PR #226)

## Merge order

This PR depends on PR #226 already being on `main` (which it is — that
merge created this branch's base commit `b243627`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)