### PR TITLE
fix(packages): migrate 7 drifted services + invariant guards

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,7 @@ const commonIgnores = [
   'docs/**',
   '.github/**',
   'functions/**', // ✅ Server-side code (Node.js) - different linting rules
+  'scripts/**',   // ✅ Ad-hoc maintenance/migration scripts (Node.js, console output expected)
   '**/lib/**',    // ✅ Vendored third-party libraries (e.g. lucide.min.js)
   'vite.config.ts',
   'vitest.config.ts',
@@ -73,7 +74,8 @@ export default [
       'devtools/**',
       'docs/**',
       '.github/**',
-      'functions/**'
+      'functions/**',
+      'scripts/**'
     ]
   },
   // TypeScript files - with type checking

--- a/functions/scheduled/index.js
+++ b/functions/scheduled/index.js
@@ -380,6 +380,42 @@ const dailyInvariantCheck = onSchedule({
       }
     });
 
+    // Check 5: package drift — service.totalHours vs Σ(packages.hours)
+    // Catches the regression pattern fixed in commit 974152d (renewServiceHours
+    // updated totalHours but skipped pushing the new package).
+    // Tolerance: 0.05h (3min) to allow rounding noise.
+    const PKG_DRIFT_TOLERANCE = 0.05;
+    clientsSnapshot.docs.forEach(clientDoc => {
+      const data = clientDoc.data();
+      const clientName = data.clientName || data.name || clientDoc.id;
+      (data.services || []).forEach(svc => {
+        const isHours = svc.type === ST.HOURS || svc.serviceType === ST.HOURS;
+        if (!isHours) return;
+        const packages = Array.isArray(svc.packages) ? svc.packages : [];
+        if (packages.length === 0) {
+          // Service with no packages — skip (separate concern)
+          return;
+        }
+        const sumPkgHours = packages.reduce((sum, p) => sum + (p.hours || 0), 0);
+        const totalHours = svc.totalHours || 0;
+        const drift = Math.abs(totalHours - sumPkgHours);
+        if (drift > PKG_DRIFT_TOLERANCE) {
+          discrepancies.push({
+            type: 'package_drift',
+            clientId: clientDoc.id,
+            clientName,
+            serviceId: svc.id,
+            serviceName: svc.name || svc.serviceName || svc.id,
+            totalHours: parseFloat(totalHours.toFixed(2)),
+            sumPkgHours: parseFloat(sumPkgHours.toFixed(2)),
+            drift: parseFloat(drift.toFixed(2)),
+            packageCount: packages.length,
+            renewalHistoryCount: (svc.renewalHistory || []).length
+          });
+        }
+      });
+    });
+
     // Save result to system_health_checks
     if (discrepancies.length > 0) {
       await db.collection('system_health_checks').add({

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -364,6 +364,21 @@ exports.addPackageToService = functions.https.onCall(async (data, context) => {
       service.hoursUsed = svcHoursUsed;
       service.hoursRemaining = round2(service.totalHours - svcHoursUsed);
 
+      // ── Invariant guard: prevent drift between service.totalHours and Σ(packages.hours) ──
+      // Drift happened historically (pre-2026-02-19) when renewServiceHours updated totalHours
+      // but skipped pushing the new package. This guard catches any future regression.
+      const sumPkgHours = round2(
+        service.packages.reduce((sum, pkg) => sum + (pkg.hours || 0), 0)
+      );
+      const drift = round2(service.totalHours - sumPkgHours);
+      if (Math.abs(drift) > 0.05) {
+        throw new functions.https.HttpsError(
+          'failed-precondition',
+          `Invariant violation: service.totalHours (${service.totalHours}) ≠ Σ(packages.hours) (${sumPkgHours}). Drift=${drift}h. Refusing to write inconsistent state.`,
+          { serviceId: service.id, totalHours: service.totalHours, sumPkgHours, drift }
+        );
+      }
+
       // עדכון המערך
       services[serviceIndex] = service;
 

--- a/functions/tests/package-drift-invariant.test.js
+++ b/functions/tests/package-drift-invariant.test.js
@@ -1,0 +1,239 @@
+/**
+ * Tests for package-drift invariants — guard against the bug fixed in commit
+ * 974152d (renewServiceHours pre-2026-02-19 updated service.totalHours but
+ * skipped pushing the new package, causing service-level vs package-level drift).
+ *
+ * Coverage:
+ *   A. addPackageToService — invariant violation on drifted incoming state
+ *   B. dailyInvariantCheck — Check 5 (package_drift) detection logic
+ */
+
+// ─── Pure-logic copies (no firebase-admin import) ─────────────────────────
+
+function round2(n) { return Math.round(n * 100) / 100; }
+
+/**
+ * Mirrors the invariant guard added to functions/services/index.js
+ * (addPackageToService transaction body, after package push + aggregate update).
+ */
+function checkPackageInvariant(service) {
+  const sumPkgHours = round2(
+    (service.packages || []).reduce((sum, pkg) => sum + (pkg.hours || 0), 0)
+  );
+  const drift = round2((service.totalHours || 0) - sumPkgHours);
+  if (Math.abs(drift) > 0.05) {
+    return {
+      ok: false,
+      drift,
+      totalHours: service.totalHours,
+      sumPkgHours
+    };
+  }
+  return { ok: true, drift };
+}
+
+/**
+ * Mirrors Check 5 in functions/scheduled/index.js (dailyInvariantCheck).
+ */
+function detectPackageDrift(client, ST = { HOURS: 'hours' }) {
+  const PKG_DRIFT_TOLERANCE = 0.05;
+  const findings = [];
+  (client.services || []).forEach(svc => {
+    const isHours = svc.type === ST.HOURS || svc.serviceType === ST.HOURS;
+    if (!isHours) return;
+    const packages = Array.isArray(svc.packages) ? svc.packages : [];
+    if (packages.length === 0) return;
+    const sumPkgHours = packages.reduce((sum, p) => sum + (p.hours || 0), 0);
+    const totalHours = svc.totalHours || 0;
+    const drift = Math.abs(totalHours - sumPkgHours);
+    if (drift > PKG_DRIFT_TOLERANCE) {
+      findings.push({
+        serviceId: svc.id,
+        totalHours: parseFloat(totalHours.toFixed(2)),
+        sumPkgHours: parseFloat(sumPkgHours.toFixed(2)),
+        drift: parseFloat(drift.toFixed(2))
+      });
+    }
+  });
+  return findings;
+}
+
+// ─── A. addPackageToService invariant ─────────────────────────────────────
+
+describe('addPackageToService — invariant guard', () => {
+  test('PASSES on consistent state: totalHours == Σ(pkg.hours)', () => {
+    const service = {
+      id: 'srv_1',
+      type: 'hours',
+      totalHours: 50,
+      packages: [
+        { id: 'pkg_1', hours: 20 },
+        { id: 'pkg_2', hours: 30 }
+      ]
+    };
+    expect(checkPackageInvariant(service).ok).toBe(true);
+  });
+
+  test('FAILS when totalHours > Σ(pkg.hours) (pre-2026-02-19 bug pattern)', () => {
+    const service = {
+      id: 'srv_drifted',
+      type: 'hours',
+      totalHours: 50,
+      packages: [{ id: 'pkg_1', hours: 20 }] // missing renewal of 30h
+    };
+    const result = checkPackageInvariant(service);
+    expect(result.ok).toBe(false);
+    expect(result.drift).toBe(30);
+  });
+
+  test('FAILS when totalHours < Σ(pkg.hours) (reverse drift)', () => {
+    const service = {
+      id: 'srv_reverse',
+      type: 'hours',
+      totalHours: 20,
+      packages: [
+        { id: 'pkg_1', hours: 20 },
+        { id: 'pkg_2', hours: 30 }
+      ]
+    };
+    const result = checkPackageInvariant(service);
+    expect(result.ok).toBe(false);
+    expect(result.drift).toBe(-30);
+  });
+
+  test('TOLERATES rounding noise within 0.05h', () => {
+    const service = {
+      id: 'srv_round',
+      type: 'hours',
+      totalHours: 50.03,
+      packages: [
+        { id: 'pkg_1', hours: 20 },
+        { id: 'pkg_2', hours: 30 }
+      ]
+    };
+    expect(checkPackageInvariant(service).ok).toBe(true);
+  });
+
+  test('FAILS just above tolerance', () => {
+    const service = {
+      id: 'srv_edge',
+      type: 'hours',
+      totalHours: 50.06,
+      packages: [
+        { id: 'pkg_1', hours: 20 },
+        { id: 'pkg_2', hours: 30 }
+      ]
+    };
+    expect(checkPackageInvariant(service).ok).toBe(false);
+  });
+
+  test('PASSES on empty packages array (legacy case — separate concern)', () => {
+    const service = {
+      id: 'srv_empty',
+      type: 'hours',
+      totalHours: 0,
+      packages: []
+    };
+    expect(checkPackageInvariant(service).ok).toBe(true);
+  });
+});
+
+// ─── B. dailyInvariantCheck — Check 5 (package_drift) ─────────────────────
+
+describe('dailyInvariantCheck — package_drift detection', () => {
+  test('detects drift on hours service (the original 2025306 bug pattern)', () => {
+    const client = {
+      id: '2025306',
+      services: [{
+        id: 'srv_1766393421154',
+        type: 'hours',
+        totalHours: 50,
+        packages: [{ id: 'pkg_initial', hours: 20 }]
+      }]
+    };
+    const findings = detectPackageDrift(client);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].drift).toBe(30);
+    expect(findings[0].serviceId).toBe('srv_1766393421154');
+  });
+
+  test('returns empty for consistent client', () => {
+    const client = {
+      id: 'good',
+      services: [{
+        id: 'srv_1',
+        type: 'hours',
+        totalHours: 50,
+        packages: [
+          { id: 'pkg_1', hours: 20 },
+          { id: 'pkg_2', hours: 30 }
+        ]
+      }]
+    };
+    expect(detectPackageDrift(client)).toEqual([]);
+  });
+
+  test('skips legal_procedure services', () => {
+    const client = {
+      id: 'mixed',
+      services: [{
+        id: 'srv_legal',
+        type: 'legal_procedure',
+        totalHours: 100,
+        packages: [{ id: 'pkg_x', hours: 20 }] // would be drift if checked
+      }]
+    };
+    expect(detectPackageDrift(client)).toEqual([]);
+  });
+
+  test('skips services with empty packages (legacy/separate concern)', () => {
+    const client = {
+      id: 'no-packages',
+      services: [{
+        id: 'srv_empty',
+        type: 'hours',
+        totalHours: 50,
+        packages: []
+      }]
+    };
+    expect(detectPackageDrift(client)).toEqual([]);
+  });
+
+  test('handles client with multiple services — flags only drifted ones', () => {
+    const client = {
+      id: 'multi',
+      services: [
+        {
+          id: 'srv_good',
+          type: 'hours',
+          totalHours: 30,
+          packages: [{ id: 'pkg_a', hours: 30 }]
+        },
+        {
+          id: 'srv_drift',
+          type: 'hours',
+          totalHours: 50,
+          packages: [{ id: 'pkg_b', hours: 20 }]
+        }
+      ]
+    };
+    const findings = detectPackageDrift(client);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].serviceId).toBe('srv_drift');
+  });
+
+  test('respects 0.05 tolerance for rounding (within tolerance)', () => {
+    const client = {
+      id: 'rounding',
+      services: [{
+        id: 'srv_x',
+        type: 'hours',
+        totalHours: 22.30,
+        packages: [
+          { id: 'pkg_1', hours: 22.27 }
+        ]
+      }]
+    };
+    expect(detectPackageDrift(client)).toEqual([]);
+  });
+});

--- a/scripts/investigate-overdraft-2025306.js
+++ b/scripts/investigate-overdraft-2025306.js
@@ -1,0 +1,180 @@
+/**
+ * Investigation — case 2025306 (בן ניסן) — backend rejects hours despite admin showing available.
+ * READ ONLY. No writes.
+ *
+ * Goals:
+ * 1. Locate client doc by fileNumber/caseNumber.
+ * 2. Print every service: type, pricingType, packages[], stages[], overrideActive.
+ * 3. For each package: hoursRemaining, hoursUsed, status. Compute afterDeduction at -10h gate.
+ * 4. Show overrideActive status (controls bypass of -10h floor).
+ * 5. Cross-check: sum of timesheet_entries minutes vs hoursUsed in package.
+ * 6. Identify which path the backend takes for new hours entry (active package vs fallback).
+ */
+
+const admin = require('firebase-admin');
+const serviceAccount = require('../service-account-key.json');
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+const db = admin.firestore();
+
+const CASE = '2025306';
+
+function fmt(v) {
+  if (v === undefined) return '<undefined>';
+  if (v === null) return '<null>';
+  if (v && typeof v.toDate === 'function') return v.toDate().toISOString();
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+function pad(label, val, width = 22) {
+  return `${label.padEnd(width)} ${fmt(val)}`;
+}
+
+async function findClient() {
+  console.log('═'.repeat(80));
+  console.log(`🔍 Locating client for case ${CASE}`);
+  console.log('═'.repeat(80));
+
+  const queries = [
+    ['fileNumber', CASE],
+    ['fileNumber', Number(CASE)],
+    ['caseNumber', CASE],
+    ['caseNumber', Number(CASE)]
+  ];
+
+  for (const [field, val] of queries) {
+    const snap = await db.collection('clients').where(field, '==', val).get();
+    if (!snap.empty) {
+      console.log(`✅ Found via ${field}=${val}: ${snap.size} doc(s)`);
+      return snap.docs;
+    }
+  }
+
+  console.log('❌ Client not found');
+  return [];
+}
+
+function dumpPackage(pkg, idx, prefix = '    ') {
+  console.log(`${prefix}package[${idx}] (id=${pkg.id})`);
+  console.log(`${prefix}  ${pad('status:', pkg.status, 18)}`);
+  console.log(`${prefix}  ${pad('hoursTotal:', pkg.hoursTotal, 18)}`);
+  console.log(`${prefix}  ${pad('hoursUsed:', pkg.hoursUsed, 18)}`);
+  console.log(`${prefix}  ${pad('hoursRemaining:', pkg.hoursRemaining, 18)}`);
+  console.log(`${prefix}  ${pad('createdAt:', pkg.createdAt, 18)}`);
+  console.log(`${prefix}  ${pad('depleted/closed?', pkg.depleted ?? pkg.closed, 18)}`);
+}
+
+function dumpService(svc, idx) {
+  console.log(`\n  ───── service[${idx}] (id=${svc.id}) ─────`);
+  console.log(`  ${pad('type:', svc.type)}`);
+  console.log(`  ${pad('pricingType:', svc.pricingType)}`);
+  console.log(`  ${pad('serviceName:', svc.serviceName || svc.name)}`);
+  console.log(`  ${pad('overrideActive:', svc.overrideActive)}`);
+  console.log(`  ${pad('hoursTotal:', svc.hoursTotal)}`);
+  console.log(`  ${pad('hoursUsed:', svc.hoursUsed)}`);
+  console.log(`  ${pad('hoursRemaining:', svc.hoursRemaining)}`);
+  console.log(`  ${pad('currentStage:', svc.currentStage)}`);
+
+  // Service-level packages (hourly type)
+  if (Array.isArray(svc.packages) && svc.packages.length > 0) {
+    console.log(`\n  packages (service-level): ${svc.packages.length}`);
+    svc.packages.forEach((p, i) => dumpPackage(p, i));
+  }
+
+  // Stages (legal_procedure)
+  if (Array.isArray(svc.stages) && svc.stages.length > 0) {
+    console.log(`\n  stages: ${svc.stages.length}`);
+    svc.stages.forEach((stage, sidx) => {
+      console.log(`    ┌─── stage[${sidx}] id=${stage.id} ───`);
+      console.log(`    │ ${pad('name:', stage.name)}`);
+      console.log(`    │ ${pad('pricingType:', stage.pricingType)}`);
+      console.log(`    │ ${pad('hoursTotal:', stage.hoursTotal)}`);
+      console.log(`    │ ${pad('hoursUsed:', stage.hoursUsed)}`);
+      console.log(`    │ ${pad('hoursRemaining:', stage.hoursRemaining)}`);
+      if (Array.isArray(stage.packages) && stage.packages.length > 0) {
+        console.log(`    │ stage.packages: ${stage.packages.length}`);
+        stage.packages.forEach((p, pi) => dumpPackage(p, pi, '    │   '));
+      }
+      console.log(`    └───`);
+    });
+  }
+}
+
+function analyzeGuard(client) {
+  console.log('\n' + '═'.repeat(80));
+  console.log('🛡️  -10h GUARD ANALYSIS');
+  console.log('═'.repeat(80));
+  console.log('Backend logic (functions/timesheet/index.js):');
+  console.log('  1. activePackage = DeductionSystem.getActivePackage(service, true, hasOverride)');
+  console.log('  2. afterDeduction = activePackage.hoursRemaining - hoursWorked');
+  console.log('  3. if afterDeduction < -10 && !hasOverride → throw ERR-1001');
+  console.log('  4. else fallback: find first eligible package (hoursRemaining > -10)');
+  console.log('  5. if all packages exhausted → use last package, check -10 again → ERR-1002');
+  console.log('');
+
+  const services = Array.isArray(client.services) ? client.services : [];
+  if (services.length === 0) {
+    console.log('⚠️  No services array — entries get counted at service-level only');
+    return;
+  }
+
+  services.forEach((svc, idx) => {
+    console.log(`\n📊 service[${idx}] gate analysis:`);
+    console.log(`   overrideActive: ${svc.overrideActive ? 'TRUE — bypasses guard' : 'FALSE — guard ENFORCED'}`);
+
+    const pkgs = svc.packages || [];
+    const eligible = pkgs.filter(p => {
+      const status = p.status || 'active';
+      return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
+        && (svc.overrideActive || (p.hoursRemaining || 0) > -10);
+    });
+
+    console.log(`   eligible packages (>−10h or override): ${eligible.length}/${pkgs.length}`);
+    if (eligible.length === 0 && pkgs.length > 0) {
+      const last = pkgs[pkgs.length - 1];
+      console.log(`   ❌ ALL packages exhausted — last package: hoursRemaining=${last.hoursRemaining}`);
+      console.log(`      Backend will hit "fallback to last" branch → ERR-1002 if -10 floor still violated`);
+    } else if (eligible.length > 0) {
+      eligible.forEach((p, i) => {
+        console.log(`   ✅ eligible[${i}] id=${p.id} status=${p.status} remaining=${p.hoursRemaining}`);
+        const margin = (p.hoursRemaining || 0) + 10;
+        console.log(`      max hoursWorked allowed before ERR-1001: ${margin.toFixed(2)}h`);
+      });
+    }
+  });
+}
+
+async function main() {
+  const docs = await findClient();
+  if (docs.length === 0) {
+    process.exit(1);
+  }
+
+  for (const doc of docs) {
+    const client = doc.data();
+    console.log(`\n${'═'.repeat(80)}`);
+    console.log(`📋 CLIENT DOC: ${doc.id}`);
+    console.log(`${'═'.repeat(80)}`);
+    console.log(`  ${pad('fullName:', client.fullName)}`);
+    console.log(`  ${pad('clientName:', client.clientName)}`);
+    console.log(`  ${pad('fileNumber:', client.fileNumber)}`);
+    console.log(`  ${pad('caseNumber:', client.caseNumber)}`);
+    console.log(`  ${pad('status:', client.status)}`);
+    console.log(`  ${pad('type:', client.type)}`);
+    console.log(`  ${pad('hoursRemaining (top):', client.hoursRemaining)}`);
+    console.log(`  ${pad('overrideActive (top):', client.overrideActive)}`);
+
+    const services = Array.isArray(client.services) ? client.services : [];
+    console.log(`\n  services count: ${services.length}`);
+    services.forEach((svc, i) => dumpService(svc, i));
+
+    analyzeGuard({ services });
+  }
+
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/migrate-package-drift-v3-2026-05-01.js
+++ b/scripts/migrate-package-drift-v3-2026-05-01.js
@@ -1,0 +1,568 @@
+/**
+ * Migration v3: add missing renewal packages to 7 drifted services.
+ *
+ * Default DRY-RUN. Pass --execute to write.
+ * Optional --target=<caseNumber> to migrate single target.
+ *
+ * v3 changes from v2 (per devil's advocate + review-strict):
+ *   1. Date normalization with type guard (handles Date, Timestamp, string).
+ *   2. Sort packages by activity rank — overdraft/active first, depleted last.
+ *      Ensures getActivePackage picks the still-eligible package.
+ *   3. Tx-level concurrent write detection — assert packages.length unchanged.
+ *   4. Orphan post-renewal entries → LAST renewal (still active/overdraft),
+ *      not first (which may be depleted after cascade).
+ *   5. Tolerance bumped 0.02 → 0.05 for accumulated rounding error.
+ *   6. Snapshot mechanism — backup full client doc to migration_backup_2026_05_01.
+ *   7. Pre-check: refuse migration if client has non-fixed legal_procedure services
+ *      (to avoid breaking client aggregates).
+ *
+ * Excluded: 2026008 (91h additional drift beyond missing package).
+ */
+
+const admin = require('firebase-admin');
+const crypto = require('crypto');
+const serviceAccount = require('../service-account-key.json');
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+const db = admin.firestore();
+
+const { calcClientAggregates, round2 } = require('../functions/src/modules/aggregation');
+const { isFixedService } = require('../functions/shared/aggregates');
+
+const EXECUTE = process.argv.includes('--execute');
+const TARGET_FLAG = process.argv.find(a => a.startsWith('--target='));
+const SINGLE_TARGET = TARGET_FLAG ? TARGET_FLAG.split('=')[1] : null;
+
+const TOLERANCE = 0.05; // bumped from 0.02
+const SCRIPT_NAME = 'migrate-package-drift-v3-2026-05-01';
+const ACTOR = 'system-migration-2026-05-01';
+const BACKUP_COLLECTION = 'migration_backup_2026_05_01';
+
+const TARGETS = [
+  { caseNumber: '2025306', serviceId: 'srv_1766393421154', expectedDelta: 30 },
+  { caseNumber: '2025011', serviceId: 'srv_1766574628760', expectedDelta: 25 },
+  { caseNumber: '2025002', serviceId: 'srv_1764868231167', expectedDelta: 22.3 },
+  { caseNumber: '2025002', serviceId: 'srv_1766504727174', expectedDelta: 21 },
+  { caseNumber: '2025333', serviceId: 'srv_1766331553598', expectedDelta: 20 },
+  { caseNumber: '2026045', serviceId: 'srv_1771499755064', expectedDelta: 20 },
+  { caseNumber: '20251000', serviceId: 'srv_1766330741925', expectedDelta: 15 }
+];
+
+/* ─── helpers ─────────────────────────────────────────────────────────── */
+
+function makeMigrationId(caseNumber, serviceId, sourceRef, sourceDate) {
+  return crypto.createHash('sha1')
+    .update(`${SCRIPT_NAME}|${caseNumber}|${serviceId}|${sourceRef}|${sourceDate}`)
+    .digest('hex')
+    .substring(0, 16);
+}
+
+/**
+ * v3 fix #1: Date type guard.
+ * Coerces Firestore Timestamp, JS Date, or ISO string to ISO string.
+ * Returns null if not parseable.
+ */
+function toIsoString(val) {
+  if (val == null) return null;
+  if (typeof val === 'string') return val;
+  if (val instanceof Date) return val.toISOString();
+  if (typeof val.toDate === 'function') {
+    try {
+      return val.toDate().toISOString();
+    } catch (e) {
+      return null;
+    }
+  }
+  // Firestore Timestamp may be plain object { _seconds, _nanoseconds }
+  if (typeof val._seconds === 'number') {
+    return new Date(val._seconds * 1000 + (val._nanoseconds || 0) / 1e6).toISOString();
+  }
+  return null;
+}
+
+function deriveStatus(pkg) {
+  const cap = pkg.hours || 0;
+  const used = pkg.hoursUsed || 0;
+  if (used > cap) return 'overdraft';
+  if (used === cap && cap > 0) return 'depleted';
+  return 'active';
+}
+
+/**
+ * v3 fix #2: Activity rank for sort.
+ * Lower rank = earlier in array = picked first by getActivePackage.
+ *   0 = active with positive remaining (truly available)
+ *   1 = overdraft (still eligible per filter, hoursRemaining > -10)
+ *   2 = depleted (rem == 0)
+ *   3 = exhausted (rem <= -10, excluded by filter anyway)
+ */
+function packageActivityRank(pkg) {
+  const remaining = pkg.hoursRemaining || 0;
+  const status = pkg.status;
+  if (remaining > 0) return 0;
+  if (status === 'overdraft' || (remaining > -10 && remaining < 0)) return 1;
+  if (remaining === 0) return 2;
+  return 3;
+}
+
+function makeRenewalPackage({ caseNumber, serviceId, renewalRecord, idx }) {
+  const hours = renewalRecord.hours || 0;
+  const date = renewalRecord.date;
+  const sourceRef = `renewalHistory[${idx}]`;
+  const migrationId = makeMigrationId(caseNumber, serviceId, sourceRef, date);
+  return {
+    id: `pkg_mig_${migrationId}`,
+    type: 'renewal',
+    hours,
+    hoursUsed: 0,
+    hoursRemaining: hours,
+    status: 'active',
+    purchaseDate: date,
+    description: 'חידוש שעות',
+    source: SCRIPT_NAME,
+    sourceRef,
+    sourceDate: date,
+    migrationId,
+    addedBy: renewalRecord.addedBy || 'admin'
+  };
+}
+
+/* ─── core compute ────────────────────────────────────────────────────── */
+
+function computeNewPackages(svc, target) {
+  const oldPackages = Array.isArray(svc.packages) ? [...svc.packages] : [];
+  const renewalHistory = svc.renewalHistory || [];
+
+  // total overdraft from ALL old packages
+  const totalOverdraft = round2(oldPackages.reduce((s, p) => {
+    const cap = p.hours || 0;
+    const used = p.hoursUsed || 0;
+    return s + Math.max(0, used - cap);
+  }, 0));
+
+  // dedup by migrationId (stable hash)
+  const existingMigrationIds = new Set(
+    oldPackages.filter(p => p.migrationId).map(p => p.migrationId)
+  );
+  const renewalsToAdd = renewalHistory.filter((r, i) => {
+    const sourceRef = `renewalHistory[${i}]`;
+    const mid = makeMigrationId(target.caseNumber, target.serviceId, sourceRef, r.date);
+    return !existingMigrationIds.has(mid);
+  });
+
+  if (renewalsToAdd.length === 0) {
+    throw new Error('No renewal records to add — all already migrated');
+  }
+
+  // sort by date ascending
+  renewalsToAdd.sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+  const indexedRenewals = renewalsToAdd.map(r => ({ rec: r, origIdx: renewalHistory.indexOf(r) }));
+
+  let newRenewalPackages = indexedRenewals.map(({ rec, origIdx }) =>
+    makeRenewalPackage({
+      caseNumber: target.caseNumber,
+      serviceId: target.serviceId,
+      renewalRecord: rec,
+      idx: origIdx
+    })
+  );
+
+  // cascade overdraft chronologically
+  let remainingOverdraft = totalOverdraft;
+  newRenewalPackages = newRenewalPackages.map(pkg => {
+    if (remainingOverdraft <= 0) return pkg;
+    const cap = pkg.hours || 0;
+    const absorb = Math.min(cap, remainingOverdraft);
+    const newUsed = round2(absorb);
+    const newRemaining = round2(cap - newUsed);
+    remainingOverdraft = round2(remainingOverdraft - absorb);
+    const updated = { ...pkg, hoursUsed: newUsed, hoursRemaining: newRemaining };
+    updated.status = deriveStatus(updated);
+    return updated;
+  });
+
+  // tail: any leftover overdraft → last renewal
+  if (remainingOverdraft > 0) {
+    const last = newRenewalPackages[newRenewalPackages.length - 1];
+    last.hoursUsed = round2((last.hoursUsed || 0) + remainingOverdraft);
+    last.hoursRemaining = round2((last.hours || 0) - last.hoursUsed);
+    last.status = deriveStatus(last);
+  }
+
+  // normalize all old packages: hoursUsed = hours, depleted
+  const normalizedOldPackages = oldPackages.map(p => ({
+    ...p,
+    hoursUsed: round2(p.hours || 0),
+    hoursRemaining: 0,
+    status: 'depleted',
+    _migrationNote: `Normalized by ${SCRIPT_NAME}: original hoursUsed=${p.hoursUsed}, overdraft transferred to renewal`,
+    _migratedBy: SCRIPT_NAME,
+    _originalHoursUsed: p.hoursUsed // forensic preservation (per devil's review B)
+  }));
+
+  // v3 fix #2: sort final array by activity rank
+  // Result: still-eligible (overdraft/active with hours) first, depleted last.
+  // Ensures getActivePackage picks correctly even after cascade.
+  const allPackages = [...newRenewalPackages, ...normalizedOldPackages];
+  allPackages.sort((a, b) => packageActivityRank(a) - packageActivityRank(b));
+
+  // identify last active renewal for orphan backfill
+  const lastActiveRenewal = [...newRenewalPackages].reverse().find(
+    p => p.status === 'active' || p.status === 'overdraft'
+  ) || newRenewalPackages[newRenewalPackages.length - 1];
+
+  // invariant: sum hoursUsed == old service.hoursUsed
+  const newSumHoursUsed = round2(allPackages.reduce((s, p) => s + (p.hoursUsed || 0), 0));
+  const oldServiceHoursUsed = round2(svc.hoursUsed || 0);
+
+  return {
+    newPackages: allPackages,
+    totalOverdraft,
+    newRenewalPackages,
+    normalizedOldPackages,
+    lastActiveRenewal,
+    newSumHoursUsed,
+    oldServiceHoursUsed,
+    invariantHoldsHoursUsed: Math.abs(newSumHoursUsed - oldServiceHoursUsed) <= TOLERANCE
+  };
+}
+
+/* ─── per-target migration ────────────────────────────────────────────── */
+
+async function migrateOne(target) {
+  const log = (msg) => console.log(`  ${msg}`);
+  console.log(`\n${'═'.repeat(80)}`);
+  console.log(`▶  ${target.caseNumber} | service ${target.serviceId}`);
+  console.log('═'.repeat(80));
+
+  const cs = await db.collection('clients').where('caseNumber', '==', target.caseNumber).get();
+  if (cs.empty) return { ...target, status: 'STOP', reason: 'client not found' };
+  const clientRef = cs.docs[0].ref;
+  const clientId = cs.docs[0].id;
+
+  const beforeSnap = (await clientRef.get()).data();
+  const beforeServices = Array.isArray(beforeSnap.services) ? beforeSnap.services : [];
+
+  // v3 fix #7: pre-check — refuse if client has non-fixed legal_procedure
+  // (would change semantics of calcClientAggregates).
+  const nonFixedLegalProc = beforeServices.find(s =>
+    (s.type === 'legal_procedure' || s.serviceType === 'legal_procedure') && !isFixedService(s)
+  );
+  if (nonFixedLegalProc) {
+    return {
+      ...target,
+      status: 'STOP',
+      reason: `client has non-fixed legal_procedure service (${nonFixedLegalProc.id}) — migration excluded for safety`
+    };
+  }
+
+  const svcIndex = beforeServices.findIndex(s => s.id === target.serviceId);
+  if (svcIndex === -1) return { ...target, status: 'STOP', reason: 'service not found' };
+  const beforeSvc = beforeServices[svcIndex];
+
+  log(`client doc:           ${clientId} (${beforeSnap.fullName || beforeSnap.clientName})`);
+  log(`service before:`);
+  log(`  totalHours:         ${beforeSvc.totalHours}`);
+  log(`  hoursUsed:          ${beforeSvc.hoursUsed}`);
+  log(`  hoursRemaining:     ${beforeSvc.hoursRemaining}`);
+  log(`  packages count:     ${(beforeSvc.packages || []).length}`);
+
+  let computed;
+  try {
+    computed = computeNewPackages(beforeSvc, target);
+  } catch (e) {
+    return { ...target, status: 'STOP', reason: 'compute failed: ' + e.message };
+  }
+
+  log(`total overdraft transferred: ${computed.totalOverdraft}h`);
+  log(`renewal packages added: ${computed.newRenewalPackages.length}`);
+  computed.newRenewalPackages.forEach((p, i) => {
+    log(`  renewal[${i}]: id=${p.id} hours=${p.hours} used=${p.hoursUsed} rem=${p.hoursRemaining} status=${p.status}`);
+  });
+  log(`final array order (by activity rank):`);
+  computed.newPackages.forEach((p, i) => {
+    log(`  [${i}] ${p.id} type=${p.type} status=${p.status} rem=${p.hoursRemaining} (rank=${packageActivityRank(p)})`);
+  });
+  log(`last active renewal (orphan backfill target post-renewal): ${computed.lastActiveRenewal.id}`);
+  log(`packages invariant (sum hoursUsed = old service.hoursUsed): ${computed.invariantHoldsHoursUsed ? '✅' : '❌'}`);
+  log(`  new sum: ${computed.newSumHoursUsed}, old service: ${computed.oldServiceHoursUsed}`);
+
+  if (!computed.invariantHoldsHoursUsed) {
+    return { ...target, status: 'STOP', reason: 'invariant fail' };
+  }
+
+  const totalHoursVal = round2(beforeSvc.totalHours || 0);
+  const newSvcHoursUsed = computed.newSumHoursUsed;
+  const newSvcHoursRemaining = round2(totalHoursVal - newSvcHoursUsed);
+  const newSvc = {
+    ...beforeSvc,
+    packages: computed.newPackages,
+    hoursUsed: newSvcHoursUsed,
+    hoursRemaining: newSvcHoursRemaining
+  };
+  const newServices = beforeServices.slice();
+  newServices[svcIndex] = newSvc;
+
+  const clientTotalHours = round2(newServices.reduce((sum, s) => sum + (s.totalHours || 0), 0));
+  const newClientAgg = calcClientAggregates(newServices, clientTotalHours);
+
+  log(`service after: hoursUsed=${newSvc.hoursUsed} hoursRemaining=${newSvc.hoursRemaining} packages=${newSvc.packages.length}`);
+  log(`client aggregates: total=${clientTotalHours} used=${newClientAgg.hoursUsed} rem=${newClientAgg.hoursRemaining} blocked=${newClientAgg.isBlocked} critical=${newClientAgg.isCritical}`);
+
+  // orphan backfill assignment with v3 fixes (#1 date, #4 last renewal)
+  const renewalDates = (beforeSvc.renewalHistory || [])
+    .map(r => toIsoString(r.date))
+    .filter(Boolean)
+    .sort();
+  const earliestRenewalDate = renewalDates[0];
+
+  const initialPkg = computed.normalizedOldPackages.find(p => p.type === 'initial')
+    || computed.normalizedOldPackages[0];
+  const lastRenewal = computed.lastActiveRenewal;
+
+  const orphanQuery = await db.collection('timesheet_entries')
+    .where('clientId', '==', clientId)
+    .where('serviceId', '==', target.serviceId)
+    .get();
+  const orphanAssignments = [];
+  orphanQuery.forEach(d => {
+    const e = d.data();
+    if (e.packageId) return;
+    const entryDate = toIsoString(e.date) || toIsoString(e.createdAt);
+    let assignTo;
+    if (!entryDate || !earliestRenewalDate) {
+      assignTo = initialPkg.id;
+    } else if (entryDate < earliestRenewalDate) {
+      assignTo = initialPkg.id;
+    } else {
+      assignTo = lastRenewal.id; // v3 fix #4: last active renewal
+    }
+    orphanAssignments.push({ ref: d.ref, packageId: assignTo, entryDate });
+  });
+  const initialBackfillCount = orphanAssignments.filter(o => o.packageId === initialPkg.id).length;
+  const renewalBackfillCount = orphanAssignments.filter(o => o.packageId === lastRenewal.id).length;
+  log(`orphan entries to backfill: ${orphanAssignments.length}`);
+  log(`  → initial pkg (${initialPkg.id}): ${initialBackfillCount}`);
+  log(`  → last renewal (${lastRenewal.id}): ${renewalBackfillCount}`);
+
+  if (!EXECUTE) {
+    log('🟢 DRY-RUN — no writes performed.');
+    return {
+      ...target,
+      status: 'DRY_OK',
+      plan: {
+        addedPackageIds: computed.newRenewalPackages.map(p => p.id),
+        orphanCount: orphanAssignments.length,
+        finalArrayOrder: computed.newPackages.map(p => `${p.id}(${p.status})`)
+      }
+    };
+  }
+
+  // ─── EXECUTE ───
+  log('🔴 EXECUTE — writing...');
+
+  // v3 fix #6: snapshot full client doc to backup collection BEFORE any write
+  const backupRef = db.collection(BACKUP_COLLECTION).doc(`${target.caseNumber}_${target.serviceId}_${Date.now()}`);
+  await backupRef.set({
+    snapshotAt: admin.firestore.FieldValue.serverTimestamp(),
+    script: SCRIPT_NAME,
+    target,
+    fullClientDoc: beforeSnap,
+    note: 'Full client doc snapshot before migration. Use for rollback.'
+  });
+  log(`  📦 backup snapshot: ${BACKUP_COLLECTION}/${backupRef.id}`);
+
+  // INTENT audit
+  const intentRef = db.collection('audit_log').doc();
+  await intentRef.set({
+    action: 'MIGRATION_ADD_MISSING_PACKAGE_v3',
+    phase: 'INTENT',
+    userId: ACTOR,
+    username: ACTOR,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    details: {
+      caseNumber: target.caseNumber,
+      clientId,
+      serviceId: target.serviceId,
+      script: SCRIPT_NAME,
+      addedPackageIds: computed.newRenewalPackages.map(p => p.id),
+      totalOverdraftTransferred: computed.totalOverdraft,
+      orphanBackfillPlan: { initial: initialBackfillCount, renewal: renewalBackfillCount },
+      backupRef: backupRef.path,
+      finalArrayOrder: computed.newPackages.map(p => p.id)
+    }
+  });
+  log(`  audit INTENT: ${intentRef.id}`);
+
+  let txnError = null;
+  let inTxResult = null;
+  try {
+    inTxResult = await db.runTransaction(async txn => {
+      const fresh = await txn.get(clientRef);
+      const freshSvcs = (fresh.data().services || []);
+      const freshIdx = freshSvcs.findIndex(s => s.id === target.serviceId);
+      if (freshIdx === -1) throw new Error('service vanished');
+      const freshSvc = freshSvcs[freshIdx];
+
+      // v3 fix #3: concurrent write detection
+      const beforePkgCount = (beforeSvc.packages || []).length;
+      const freshPkgCount = (freshSvc.packages || []).length;
+      if (freshPkgCount !== beforePkgCount) {
+        throw new Error(`Concurrent change detected: packages.length changed from ${beforePkgCount} to ${freshPkgCount}`);
+      }
+      // also detect renewalHistory change
+      const beforeRenewalCount = (beforeSvc.renewalHistory || []).length;
+      const freshRenewalCount = (freshSvc.renewalHistory || []).length;
+      if (freshRenewalCount !== beforeRenewalCount) {
+        throw new Error(`Concurrent change: renewalHistory.length changed ${beforeRenewalCount}→${freshRenewalCount}`);
+      }
+
+      const recomputed = computeNewPackages(freshSvc, target);
+      if (!recomputed.invariantHoldsHoursUsed) {
+        throw new Error('invariant violated on fresh read');
+      }
+
+      const finalTotal = round2(freshSvc.totalHours || 0);
+      const finalSvcHoursUsed = recomputed.newSumHoursUsed;
+      const finalSvcHoursRemaining = round2(finalTotal - finalSvcHoursUsed);
+      const finalSvc = {
+        ...freshSvc,
+        packages: recomputed.newPackages,
+        hoursUsed: finalSvcHoursUsed,
+        hoursRemaining: finalSvcHoursRemaining
+      };
+      const finalSvcs = freshSvcs.slice();
+      finalSvcs[freshIdx] = finalSvc;
+
+      const finalClientTotal = round2(finalSvcs.reduce((sum, s) => sum + (s.totalHours || 0), 0));
+      const finalClientAgg = calcClientAggregates(finalSvcs, finalClientTotal);
+
+      txn.update(clientRef, {
+        services: finalSvcs,
+        totalHours: finalClientTotal,
+        hoursUsed: finalClientAgg.hoursUsed,
+        hoursRemaining: finalClientAgg.hoursRemaining,
+        minutesUsed: finalClientAgg.minutesUsed,
+        minutesRemaining: finalClientAgg.minutesRemaining,
+        isBlocked: finalClientAgg.isBlocked,
+        isCritical: finalClientAgg.isCritical,
+        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
+        lastModifiedBy: ACTOR,
+        lastActivity: admin.firestore.FieldValue.serverTimestamp()
+      });
+
+      return {
+        addedPackageIds: recomputed.newRenewalPackages.map(p => p.id),
+        totalOverdraftTransferred: recomputed.totalOverdraft,
+        finalSvcHoursUsed,
+        finalSvcHoursRemaining,
+        finalClientAgg
+      };
+    });
+    log(`  ✅ transaction committed`);
+  } catch (e) {
+    txnError = e;
+    log(`  ❌ transaction failed: ${e.message}`);
+  }
+
+  // orphan backfill (post-tx, batch)
+  let backfilledCount = 0;
+  if (!txnError && orphanAssignments.length > 0) {
+    for (let i = 0; i < orphanAssignments.length; i += 500) {
+      const chunk = orphanAssignments.slice(i, i + 500);
+      const batch = db.batch();
+      chunk.forEach(o => batch.update(o.ref, {
+        packageId: o.packageId,
+        _migratedBy: SCRIPT_NAME
+      }));
+      await batch.commit();
+      backfilledCount += chunk.length;
+    }
+    log(`  ✅ orphans backfilled: ${backfilledCount}`);
+  }
+
+  // RESULT audit (in-tx values, not intent values)
+  const resultRef = db.collection('audit_log').doc();
+  await resultRef.set({
+    action: 'MIGRATION_ADD_MISSING_PACKAGE_v3',
+    phase: 'RESULT',
+    userId: ACTOR,
+    username: ACTOR,
+    timestamp: admin.firestore.FieldValue.serverTimestamp(),
+    details: {
+      caseNumber: target.caseNumber,
+      clientId,
+      serviceId: target.serviceId,
+      script: SCRIPT_NAME,
+      success: !txnError,
+      error: txnError?.message || null,
+      intentAuditId: intentRef.id,
+      backupRef: backupRef.path,
+      orphanBackfilledCount: backfilledCount,
+      inTxResult: inTxResult || null
+    }
+  });
+  log(`  audit RESULT: ${resultRef.id}`);
+
+  return {
+    ...target,
+    status: txnError ? 'ERROR' : 'DONE',
+    error: txnError?.message,
+    intentAuditId: intentRef.id,
+    resultAuditId: resultRef.id,
+    backupPath: backupRef.path
+  };
+}
+
+async function main() {
+  console.log('═'.repeat(80));
+  console.log('🔧 PACKAGE-DRIFT MIGRATION v3');
+  console.log(`Mode:    ${EXECUTE ? '🔴 EXECUTE' : '🟢 DRY-RUN'}`);
+  console.log(`Target:  ${SINGLE_TARGET || 'ALL'}`);
+  console.log(`Script:  ${SCRIPT_NAME}`);
+  console.log('═'.repeat(80));
+
+  const targetsToRun = SINGLE_TARGET
+    ? TARGETS.filter(t => `${t.caseNumber}:${t.serviceId}` === SINGLE_TARGET || t.caseNumber === SINGLE_TARGET)
+    : TARGETS;
+
+  if (targetsToRun.length === 0) {
+    console.log(`❌ No matching target for "${SINGLE_TARGET}"`);
+    process.exit(1);
+  }
+
+  console.log(`Running ${targetsToRun.length} target(s)\n`);
+
+  const results = [];
+  for (const t of targetsToRun) {
+    const r = await migrateOne(t);
+    results.push(r);
+  }
+
+  console.log('\n' + '═'.repeat(80));
+  console.log('FINAL REPORT');
+  console.log('═'.repeat(80));
+
+  const counts = {};
+  results.forEach(r => {
+    counts[r.status] = (counts[r.status] || 0) + 1;
+    console.log(`  ${r.status.padEnd(8)} ${r.caseNumber} ${r.serviceId} ${r.error || r.reason || ''}`);
+  });
+
+  console.log('\nCounts:', counts);
+  if (!EXECUTE) {
+    console.log('\n🟢 DRY-RUN complete. Review final array orders carefully.');
+    console.log('   Then run: --target=<caseNum> --execute (single client first).');
+  } else {
+    if (counts.ERROR > 0) {
+      console.log('\n❌ Errors detected. Review audit_log + backup collection.');
+    } else {
+      console.log('\n✅ All targets migrated. Run validate-strict before declaring done.');
+    }
+  }
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error('FATAL', e);
+  process.exit(1);
+});

--- a/scripts/preflight-package-drift-2026-05-01.js
+++ b/scripts/preflight-package-drift-2026-05-01.js
@@ -1,0 +1,211 @@
+/**
+ * Pre-flight audit for package-drift migration.
+ *
+ * READ ONLY. No writes.
+ *
+ * For each of the 8 drifted (clientId, serviceId) pairs:
+ *   1. Re-verify drift: service.totalHours - Σ(packages[].hours) > 0.02
+ *   2. Verify renewalHistory integrity:
+ *      - delta == Σ(renewalHistory.hours) within tolerance
+ *      - dates parseable
+ *      - sum >0
+ *   3. Orphan timesheet_entries:
+ *      - WHERE clientId AND serviceId, packageId is null/missing
+ *      - report count + total minutes
+ *   4. Existing packages snapshot (for backup-aware migration).
+ *   5. Active package per current logic — confirms which pkg backend currently picks.
+ *
+ * Output:
+ *   - Per-client report
+ *   - GO/STOP verdict per client
+ *   - Aggregate: how many GO, how many STOP, what blocks the STOPs
+ */
+
+const admin = require('firebase-admin');
+const serviceAccount = require('../service-account-key.json');
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+const db = admin.firestore();
+
+const TOLERANCE = 0.02;
+
+// 8 drifted services from sweep
+const TARGETS = [
+  { caseNumber: '2025306', serviceId: 'srv_1766393421154', expectedDelta: 30 },
+  { caseNumber: '2025011', serviceId: 'srv_1766574628760', expectedDelta: 25 },
+  { caseNumber: '2025002', serviceId: 'srv_1764868231167', expectedDelta: 22.3 },
+  { caseNumber: '2025002', serviceId: 'srv_1766504727174', expectedDelta: 21 },
+  { caseNumber: '2025333', serviceId: 'srv_1766331553598', expectedDelta: 20 },
+  { caseNumber: '2026045', serviceId: 'srv_1771499755064', expectedDelta: 20 },
+  { caseNumber: '20251000', serviceId: 'srv_1766330741925', expectedDelta: 15 },
+  { caseNumber: '2026008', serviceId: 'srv_1767719279651', expectedDelta: 15 }
+];
+
+function round2(n) { return Math.round(n * 100) / 100; }
+
+function getActivePackageMimick(packages) {
+  // Mimics functions/src/modules/deduction/deduction-logic.js — first eligible
+  return packages.find(p => {
+    const status = p.status || 'active';
+    return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
+      && (p.hoursRemaining || 0) > -10;
+  });
+}
+
+async function auditTarget(t) {
+  const cs = await db.collection('clients').where('caseNumber', '==', t.caseNumber).get();
+  if (cs.empty) {
+    return { ...t, status: 'STOP', reason: 'client not found' };
+  }
+  const doc = cs.docs[0];
+  const c = doc.data();
+  const services = Array.isArray(c.services) ? c.services : [];
+  const svc = services.find(s => s.id === t.serviceId);
+  if (!svc) {
+    return { ...t, status: 'STOP', reason: 'service not found' };
+  }
+
+  // 1. Re-verify drift
+  const packages = svc.packages || [];
+  const sumPkgHours = round2(packages.reduce((s, p) => s + (p.hours || 0), 0));
+  const totalHours = round2(svc.totalHours || 0);
+  const actualDelta = round2(totalHours - sumPkgHours);
+
+  // 2. renewalHistory integrity
+  const renewalHistory = svc.renewalHistory || [];
+  const renewalSum = round2(renewalHistory.reduce((s, r) => s + (r.hours || 0), 0));
+
+  // 3. Orphan timesheet_entries
+  const tsSnap = await db.collection('timesheet_entries')
+    .where('clientId', '==', doc.id)
+    .where('serviceId', '==', t.serviceId)
+    .get();
+  const orphans = [];
+  let orphanMinutes = 0;
+  let totalEntries = 0;
+  let totalEntryMinutes = 0;
+  tsSnap.forEach(d => {
+    const e = d.data();
+    totalEntries++;
+    totalEntryMinutes += (e.minutes || 0);
+    if (!e.packageId) {
+      orphans.push({ id: d.id, minutes: e.minutes || 0, date: e.date, action: e.action });
+      orphanMinutes += (e.minutes || 0);
+    }
+  });
+
+  // 4. Active package mimick
+  const activePkg = getActivePackageMimick(packages);
+
+  // 5. Verdict
+  const issues = [];
+  if (Math.abs(actualDelta - t.expectedDelta) > TOLERANCE) {
+    issues.push(`drift mismatch: expected ${t.expectedDelta}, actual ${actualDelta}`);
+  }
+  if (Math.abs(actualDelta - renewalSum) > TOLERANCE) {
+    issues.push(`delta(${actualDelta}) != renewalHistorySum(${renewalSum})`);
+  }
+  if (renewalHistory.length === 0) {
+    issues.push('no renewalHistory records');
+  }
+  // Orphans are OK — we'll handle in migration. Just flag.
+
+  return {
+    ...t,
+    clientDocId: doc.id,
+    fullName: c.fullName || c.clientName,
+    actualDelta,
+    sumPkgHours,
+    totalHours,
+    packageCount: packages.length,
+    packages: packages.map(p => ({ id: p.id, type: p.type, hours: p.hours, hoursUsed: p.hoursUsed, hoursRemaining: p.hoursRemaining, status: p.status })),
+    renewalHistoryCount: renewalHistory.length,
+    renewalSum,
+    renewalDates: renewalHistory.map(r => r.date),
+    activePkgId: activePkg?.id,
+    activePkgStatus: activePkg?.status,
+    activePkgHoursRemaining: activePkg?.hoursRemaining,
+    totalEntries,
+    totalEntryMinutes,
+    totalEntryHours: round2(totalEntryMinutes / 60),
+    orphanCount: orphans.length,
+    orphanMinutes,
+    orphanHours: round2(orphanMinutes / 60),
+    sampleOrphans: orphans.slice(0, 3),
+    status: issues.length === 0 ? 'GO' : 'STOP',
+    issues,
+    serviceCreatedAt: svc.createdAt,
+    lastRenewalDate: svc.lastRenewalDate,
+    serviceLastActivity: svc.lastActivity
+  };
+}
+
+async function main() {
+  console.log('═'.repeat(80));
+  console.log('🔍 PRE-FLIGHT AUDIT — package drift migration');
+  console.log(`Targets: ${TARGETS.length}`);
+  console.log('═'.repeat(80));
+
+  const results = [];
+  for (const t of TARGETS) {
+    const r = await auditTarget(t);
+    results.push(r);
+  }
+
+  // Per-target report
+  results.forEach((r, i) => {
+    console.log(`\n${'─'.repeat(80)}`);
+    console.log(`[${i + 1}/${results.length}] ${r.caseNumber} — ${r.fullName || ''}`);
+    console.log(`${'─'.repeat(80)}`);
+    console.log(`  service:                    ${r.serviceId}`);
+    console.log(`  status:                     ${r.status === 'GO' ? '✅ GO' : '❌ STOP'}`);
+    if (r.issues && r.issues.length > 0) {
+      r.issues.forEach(iss => console.log(`    ⚠️  ${iss}`));
+    }
+    console.log(`  drift (delta):              ${r.actualDelta}h (expected ${r.expectedDelta})`);
+    console.log(`  totalHours:                 ${r.totalHours}`);
+    console.log(`  Σ packages.hours:           ${r.sumPkgHours}`);
+    console.log(`  package count:              ${r.packageCount}`);
+    if (r.packages) {
+      r.packages.forEach((p, idx) => {
+        console.log(`    pkg[${idx}] ${p.id} | type=${p.type} | hours=${p.hours} | used=${p.hoursUsed} | remaining=${p.hoursRemaining} | status=${p.status}`);
+      });
+    }
+    console.log(`  renewalHistory count:       ${r.renewalHistoryCount}, sum=${r.renewalSum}h`);
+    console.log(`  renewal dates:              ${(r.renewalDates || []).join(', ')}`);
+    console.log(`  active pkg (current logic): ${r.activePkgId} status=${r.activePkgStatus} remaining=${r.activePkgHoursRemaining}`);
+    console.log(`  timesheet entries total:    ${r.totalEntries} (${r.totalEntryHours}h)`);
+    console.log(`  orphan entries (no pkgId):  ${r.orphanCount} (${r.orphanHours}h)`);
+    if (r.sampleOrphans && r.sampleOrphans.length > 0) {
+      r.sampleOrphans.forEach(o => console.log(`    sample orphan: ${o.id} | ${o.minutes}min | date=${o.date}`));
+    }
+  });
+
+  // Aggregate
+  const goCount = results.filter(r => r.status === 'GO').length;
+  const stopCount = results.filter(r => r.status === 'STOP').length;
+  const totalOrphans = results.reduce((s, r) => s + (r.orphanCount || 0), 0);
+  const totalOrphanHours = round2(results.reduce((s, r) => s + (r.orphanHours || 0), 0));
+
+  console.log('\n' + '═'.repeat(80));
+  console.log('AGGREGATE');
+  console.log('═'.repeat(80));
+  console.log(`GO:   ${goCount}/${results.length}`);
+  console.log(`STOP: ${stopCount}/${results.length}`);
+  console.log(`Total orphan entries across all targets: ${totalOrphans} (${totalOrphanHours}h)`);
+
+  if (totalOrphans > 0) {
+    console.log('\n⚠️  Orphans detected — must be backfilled during migration.');
+    console.log('   Recommendation: assign orphans to the EXISTING (initial/depleted) package,');
+    console.log('   since those entries consumed hours BEFORE the missing renewal would have applied.');
+  }
+
+  if (stopCount > 0) {
+    console.log('\n❌ Some targets STOP — investigate before migration.');
+  } else {
+    console.log('\n✅ All targets GO. Migration script can be designed against this data.');
+  }
+
+  process.exit(0);
+}
+
+main().catch(e => { console.error('FATAL', e); process.exit(1); });

--- a/scripts/sweep-package-drift-2026-04-30.js
+++ b/scripts/sweep-package-drift-2026-04-30.js
@@ -1,0 +1,141 @@
+/**
+ * Sweep — package drift detection (READ ONLY).
+ *
+ * Detects clients where:
+ *   service.totalHours > Σ(service.packages[].hours)
+ *
+ * Indicates: renewServiceHours bug pre-2026-02-19 (commit 974152d) — totalHours
+ * was incremented but the renewal package was not created.
+ *
+ * Reports per service:
+ *   - service.totalHours
+ *   - sum of package.hours
+ *   - delta (missing hours)
+ *   - renewalHistory entries (if any) — confirms attempted renewals
+ *
+ * READ ONLY. NO writes.
+ */
+
+const admin = require('firebase-admin');
+const serviceAccount = require('../service-account-key.json');
+admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
+const db = admin.firestore();
+
+const TOLERANCE = 0.02; // hours
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+async function main() {
+  console.log('═'.repeat(80));
+  console.log('🔍 PACKAGE DRIFT SWEEP — service.totalHours vs Σ(package.hours)');
+  console.log('═'.repeat(80));
+
+  const snap = await db.collection('clients').get();
+  console.log(`Total clients scanned: ${snap.size}\n`);
+
+  const drifted = [];
+  let scannedServices = 0;
+
+  snap.forEach(doc => {
+    const c = doc.data();
+    const services = Array.isArray(c.services) ? c.services : [];
+
+    services.forEach((svc, sIdx) => {
+      // Only hours-type services with packages
+      const isHours = svc.type === 'hours' || svc.serviceType === 'hours';
+      if (!isHours) return;
+
+      scannedServices++;
+
+      const packages = Array.isArray(svc.packages) ? svc.packages : [];
+      const sumPkgHours = round2(packages.reduce((s, p) => s + (p.hours || 0), 0));
+      const totalHours = round2(svc.totalHours || 0);
+      const delta = round2(totalHours - sumPkgHours);
+
+      if (delta > TOLERANCE) {
+        const renewalHistory = svc.renewalHistory || [];
+        const renewalHoursSum = round2(renewalHistory.reduce((s, r) => s + (r.hours || 0), 0));
+
+        drifted.push({
+          clientId: doc.id,
+          fullName: c.fullName || c.clientName || '<no-name>',
+          status: c.status,
+          serviceId: svc.id,
+          serviceName: svc.name || svc.serviceName,
+          totalHours,
+          sumPkgHours,
+          delta,
+          packageCount: packages.length,
+          renewalHistoryCount: renewalHistory.length,
+          renewalHistorySum: renewalHoursSum,
+          renewalDates: renewalHistory.map(r => r.date?.substring(0, 10)).join(', '),
+          lastRenewalDate: svc.lastRenewalDate?.substring(0, 10),
+          serviceCreatedAt: svc.createdAt?.substring(0, 10),
+          clientUpdatedAt: c.updatedAt?.substring?.(0, 10) || c.updatedAt?.toDate?.()?.toISOString().substring(0, 10),
+          lastModifiedBy: c.lastModifiedBy
+        });
+      }
+    });
+  });
+
+  console.log(`Scanned services: ${scannedServices}`);
+  console.log(`Drifted services: ${drifted.length}\n`);
+
+  if (drifted.length === 0) {
+    console.log('✅ No drift detected — all hours services have package.hours summing to totalHours.');
+    process.exit(0);
+  }
+
+  // Sort by delta desc
+  drifted.sort((a, b) => b.delta - a.delta);
+
+  console.log('═'.repeat(80));
+  console.log('DRIFTED SERVICES (sorted by missing hours)');
+  console.log('═'.repeat(80));
+
+  drifted.forEach((d, i) => {
+    console.log(`\n[${i + 1}] ${d.clientId} | ${d.fullName}`);
+    console.log(`    service:           ${d.serviceId} (${d.serviceName})`);
+    console.log(`    totalHours:        ${d.totalHours}`);
+    console.log(`    Σ package.hours:   ${d.sumPkgHours}`);
+    console.log(`    🔴 missing hours:  ${d.delta}`);
+    console.log(`    package count:     ${d.packageCount}`);
+    console.log(`    renewal records:   ${d.renewalHistoryCount} (sum=${d.renewalHistorySum}h)`);
+    if (d.renewalHistoryCount > 0) {
+      console.log(`    renewal dates:     ${d.renewalDates}`);
+    }
+    console.log(`    lastRenewalDate:   ${d.lastRenewalDate || '-'}`);
+    console.log(`    service createdAt: ${d.serviceCreatedAt}`);
+    console.log(`    lastModifiedBy:    ${d.lastModifiedBy || '-'}`);
+  });
+
+  // Summary
+  const totalMissing = round2(drifted.reduce((s, d) => s + d.delta, 0));
+  console.log('\n' + '═'.repeat(80));
+  console.log('SUMMARY');
+  console.log('═'.repeat(80));
+  console.log(`Total drifted services:    ${drifted.length}`);
+  console.log(`Total missing hours (sum): ${totalMissing}`);
+  console.log(`Services with renewal records: ${drifted.filter(d => d.renewalHistoryCount > 0).length}`);
+  console.log(`Services touched by reconcile-full: ${drifted.filter(d => d.lastModifiedBy === 'reconcile-full-2026-03-29').length}`);
+
+  // Match check: for services with renewalHistory, does delta == renewalHistorySum?
+  console.log('\n' + '═'.repeat(80));
+  console.log('CONFIRMATION CHECK — does delta match renewalHistorySum?');
+  console.log('═'.repeat(80));
+  const withHistory = drifted.filter(d => d.renewalHistoryCount > 0);
+  withHistory.forEach(d => {
+    const match = Math.abs(d.delta - d.renewalHistorySum) <= TOLERANCE;
+    console.log(`  ${match ? '✅' : '⚠️'} ${d.clientId} | delta=${d.delta} | history=${d.renewalHistorySum} | match=${match}`);
+  });
+
+  console.log('\nDone. READ ONLY — no writes performed.');
+  process.exit(0);
+}
+
+main().catch(e => {
+  console.error('FATAL', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes data drift on 7 client services where `renewServiceHours` (Admin Panel, pre-2026-02-19) bumped `service.totalHours` and `renewalHistory` but failed to push the renewal package to `packages[]`. Backend `getActivePackage` saw only the depleted initial package — blocked new timesheet entries while Admin Panel showed available hours.

The bug was fixed in commit `974152d` (2026-02-19), but 9 clients had already drifted. This PR migrates the 7 that match the `renewServiceHours` pattern exactly. 2 clients with different drift patterns are deferred (2026008 — 91h additional drift; 2025724 — empty packages array).

## What changed

### Migration (executed against PROD before this PR)
- 7 client services migrated via `scripts/migrate-package-drift-v3-2026-05-01.js`.
- Verified post-migration: sweep clean for all 7. Smoke test on 2025306 (בן ניסן) — timesheet entry succeeded.
- Audit trail: 7 INTENT + 7 RESULT entries in `audit_log`. Backup snapshots in `migration_backup_2026_05_01` collection.

### Code hardening (deployed before this PR)
- `functions/services/index.js` — `addPackageToService` validates `service.totalHours === Σ(packages.hours)` before commit. Throws `failed-precondition` on drift > 0.05h. Prevents future regressions.
- `functions/scheduled/index.js` — `dailyInvariantCheck` adds Check 5 (`package_drift`) detection across all hours services. Daily early-warning.
- `functions/tests/package-drift-invariant.test.js` — 12 unit tests covering invariant guard + Check 5 detection logic.

### Migration scripts
- `scripts/sweep-package-drift-2026-04-30.js` — Read-only drift detection across all clients.
- `scripts/preflight-package-drift-2026-05-01.js` — Per-target verification + orphan audit.
- `scripts/migrate-package-drift-v3-2026-05-01.js` — Migration with: cascade overdraft, sort by activity rank, concurrent write detection, snapshot backup, INTENT+RESULT audit.
- `scripts/investigate-overdraft-2025306.js` — Original investigation tool for the bug discovery.

### Other
- `eslint.config.js` — Add `scripts/**` to ignore list (ad-hoc scripts use console output).

## Migration script policy decisions (approved by Tommy)
1. **Initial package normalization**: `hoursUsed = hours, hoursRemaining = 0, status = depleted`.
2. **Cascade overdraft chronologically** across renewals (not all-on-first).
3. **Sort packages by activity rank** — overdraft/active first, depleted last. Ensures `getActivePackage` picks the still-eligible package.
4. **Orphan timesheet_entries** — `entryDate < earliestRenewalDate ? initial : lastActiveRenewal`.
5. **Tolerance 0.05h** for accumulated rounding error.

## Risks reviewed
3 rounds of devil's advocate + review-strict. Top risks mitigated:
- Date type guard (Firestore Timestamp / JS Date / ISO string / plain object).
- Concurrent write detection in transaction.
- Backup snapshot before any write (recovery available).
- Pre-check refuses migration if client has non-fixed legal_procedure.

## Out of scope (backlog)
- **2026008 (חזי מאנע)** — 91h drift beyond missing package. Separate trigger investigation needed.
- **2025724 (מאפיית הכפר)** — service with empty packages array. Different root cause.

## Test plan
- [ ] Verify deployed `addPackageToService` rejects writes with drift > 0.05h.
- [ ] Verify deployed `dailyInvariantCheck` (next 6:00 IL) reports Check 5 with no findings.
- [ ] Re-run `node scripts/sweep-package-drift-2026-04-30.js` — should show only 2 deferred cases (2025724, 2026008).
- [ ] Spot-check Admin Panel for migrated client (2025002) — package list shows new renewal + initial depleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)