### PR TITLE
fix(user-app): cache-bust ESM imports of budget-tasks/timesheet-constants

### DIFF
--- a/apps/user-app/js/main.js
+++ b/apps/user-app/js/main.js
@@ -65,8 +65,8 @@ import * as ClientHours from './modules/client-hours.js';
 import * as Forms from './modules/forms.js';
 
 // Budget Tasks Module (v5.2.4 - rings fix with 100%+ support)
-import * as BudgetTasks from './modules/budget-tasks.js?v=5.2.4';
-import { BUDGET_TASKS_LOAD_LIMIT } from './modules/budget-tasks.js';
+import * as BudgetTasks from './modules/budget-tasks.js?v=esc5fix';
+import { BUDGET_TASKS_LOAD_LIMIT } from './modules/budget-tasks.js?v=esc5fix';
 
 // Timesheet Module
 import * as Timesheet from './modules/timesheet.js';

--- a/apps/user-app/js/modules/budget-tasks.js
+++ b/apps/user-app/js/modules/budget-tasks.js
@@ -32,7 +32,7 @@ import {
   createServiceBadge,
   createCombinedInfoBadge,
   createStatusBadge
-} from './timesheet-constants.js';
+} from './timesheet-constants.js?v=esc5fix';
 import { buildErrorFromResult } from './error-utils.js';
 
 import DescriptionTooltips from './description-tooltips.js';

--- a/apps/user-app/js/modules/firebase-operations.js
+++ b/apps/user-app/js/modules/firebase-operations.js
@@ -30,7 +30,7 @@
    =========================== */
 
 // ✅ Import budget tasks functions from dedicated module (DRY principle)
-import { loadBudgetTasksFromFirebase } from './budget-tasks.js';
+import { loadBudgetTasksFromFirebase } from './budget-tasks.js?v=esc5fix';
 import { buildErrorFromResult } from './error-utils.js';
 
 /* === Firebase Functions Wrapper === */

--- a/apps/user-app/js/modules/real-time-listeners.js
+++ b/apps/user-app/js/modules/real-time-listeners.js
@@ -44,7 +44,7 @@
  */
 
 // Import budget tasks load limit constant
-import { BUDGET_TASKS_LOAD_LIMIT } from './budget-tasks.js';
+import { BUDGET_TASKS_LOAD_LIMIT } from './budget-tasks.js?v=esc5fix';
 
 /**
  * Manager for real-time listeners

--- a/apps/user-app/js/modules/timesheet.js
+++ b/apps/user-app/js/modules/timesheet.js
@@ -53,7 +53,7 @@ import {
   createServiceBadge,
   createServiceInfoHeader,
   createCombinedInfoBadge
-} from './timesheet-constants.js';
+} from './timesheet-constants.js?v=esc5fix';
 
 import DescriptionTooltips from './description-tooltips.js';
 


### PR DESCRIPTION
## Summary

Follow-up to PR #254. The escapeHtml fix is on the server but browsers keep loading the stale `timesheet-constants.js` because the ESM imports that pull it in (directly or via `budget-tasks.js`) have no version query.

Bumps 5 ESM import paths to `?v=esc5fix` so the browser re-fetches the fixed module.

## Files

- `main.js`: `BudgetTasks` + `BUDGET_TASKS_LOAD_LIMIT` (was `?v=5.2.4` / no version)
- `budget-tasks.js`: `timesheet-constants`
- `timesheet.js`: `timesheet-constants`
- `firebase-operations.js`: `budget-tasks`
- `real-time-listeners.js`: `budget-tasks`

## Why this is a patch

User App has no unified ESM cache-bust strategy. Dozens of `import './X.js'` (no version) exist across modules, so every fix to a deeply-imported module will keep hitting this trap until either:
- A build pipeline (Vite) generates content-hashed filenames automatically
- A lint rule enforces `?v=` on every relative ESM import + a deploy script bumps it

Filed for follow-up.

## Test plan

- [ ] After merge, hard reload DEV (https://main--gh-law-office-system.netlify.app)
- [ ] Open case חליבה (2025549), task `QzKo0ZqWBULz072mGSUB` (service "שלב ב' הליך משפטי - מחוזי")
- [ ] Click briefcase / folder icon → popup opens with case + service info
- [ ] Console clean (no SyntaxError on click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)