### PR TITLE
fix(functions): prevent double-count of actualMinutes on fixed-service tasks

### DIFF
--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -483,6 +483,18 @@ async function addTimeToTaskWithTransaction(db, data, user) {
                   }
                 }
               }
+            } else if (serviceType === ST.FIXED) {
+              const svcIndex = services.findIndex(s => s.id === lookupServiceId);
+              if (svcIndex !== -1) {
+                const updatedSvc = { ...services[svcIndex] };
+                const work = { ...(updatedSvc.work || { totalMinutesWorked: 0, entriesCount: 0 }) };
+                work.totalMinutesWorked = round2((work.totalMinutesWorked || 0) + minutesDelta);
+                work.entriesCount = (work.entriesCount || 0) + 1;
+                updatedSvc.work = work;
+                const updatedArr = [...services];
+                updatedArr[svcIndex] = updatedSvc;
+                deductionResult = { updatedServices: updatedArr, isOverage: false, overageMinutes: 0 };
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Tasks attached to a service of type=`fixed` get `actualMinutes` doubled on every time entry. Add the missing FIXED branch in `addTimeToTask_v2` so the deduction happens inside the callable transaction and the timesheet trigger skips CREATE.

## Bug

`addTimeToTask_v2` had branches for `ST.HOURS` and `ST.LEGAL_PROCEDURE` only. For `ST.FIXED`:
- `deductionResult` stayed null
- `deductedInTransaction` stayed false
- the callable still incremented `task.actualMinutes` (line 557)
- the `onTimesheetEntryChanged` trigger checks `deductedInTransaction === true` to skip CREATE — it didn't skip and ran a second `increment(minutes)` on the same task

Result: `task.actualMinutes` = 2 × actual minutes from `timesheet_entries`.

## Audit

Scanned 504 `budget_tasks` (timesheet_entries Σ vs task.actualMinutes):

| Drift > 1min | Service type | Pattern |
| --- | --- | --- |
| 7 tasks | all `fixed` | 6 of 7 are exactly 2× ratio |

Total ghost minutes: **1275min (21.25h)**. Affected clients: דניאל הגנזאר (2026060), זיאת שמוליק (2026043).

## Fix

Add a FIXED branch that mirrors the working pattern in `createTimesheetEntry_v2` (timesheet/index.js:783-795) and the trigger fallback (triggers/timesheet-trigger.js:388-404):

```js
} else if (serviceType === ST.FIXED) {
  const svcIndex = services.findIndex(s => s.id === lookupServiceId);
  if (svcIndex !== -1) {
    const updatedSvc = { ...services[svcIndex] };
    const work = { ...(updatedSvc.work || { totalMinutesWorked: 0, entriesCount: 0 }) };
    work.totalMinutesWorked = round2((work.totalMinutesWorked || 0) + minutesDelta);
    work.entriesCount = (work.entriesCount || 0) + 1;
    updatedSvc.work = work;
    const updatedArr = [...services];
    updatedArr[svcIndex] = updatedSvc;
    deductionResult = { updatedServices: updatedArr, isOverage: false, overageMinutes: 0 };
  }
}
```

Sets `deductionResult` non-null → existing `deductedInTransaction = true` line (493) fires → trigger skips CREATE per existing guard at trigger:222 → no double increment.

No changes to HOURS, LEGAL_PROCEDURE, the trigger, or aggregation modules.

## Data fix

Separate script will reconcile the 7 existing affected tasks (`actualMinutes` set to Σ entries, `actualHours` recomputed, `completion.actualMinutes` and `gapMinutes` recomputed for the 4 completed ones). Not in this PR.

## Test plan

- [ ] firebase deploy --only functions:addTimeToTask_v2
- [ ] In DEV: create a task on a `fixed` service, log e.g. 60min, verify `task.actualMinutes === 60` (not 120)
- [ ] Regression: create a task on `hours` service, log time → still 1× (no change to that path)
- [ ] Regression: create a task on `legal_procedure` service → unchanged
- [ ] Confirm `service.work.totalMinutesWorked` increments correctly (was already updated by the trigger; should still be correct after the trigger skips)

## References

- Memory: `project_known_issues.md` issue #3 — this is the manifest of that bug
- Related architecture: `feedback_aggregates_trigger_double_count.md` — same class of bug (trigger + manual update racing)