### PR TITLE
hardening(functions): trigger fallback warning + extract+test FIXED deduction

### DIFF
--- a/functions/addTimeToTask_v2.js
+++ b/functions/addTimeToTask_v2.js
@@ -189,6 +189,31 @@ function sanitizeString(str) {
   return str.trim().replace(/[<>]/g, '');
 }
 
+/**
+ * Pure: increment work tracking on a fixed-type service.
+ *
+ * Returns deductionResult shape { updatedServices, isOverage, overageMinutes } or null
+ * if the target service is not found. Caller uses non-null result to set
+ * deductedInTransaction=true on the entry, which causes timesheet-trigger to skip the
+ * fallback CREATE path (preventing double-count of task.actualMinutes).
+ *
+ * Extracted in PR #259 (Level 2 hardening) so the FIXED branch is unit-testable in
+ * isolation without spinning up a Firestore transaction.
+ */
+function computeFixedDeduction(services, lookupServiceId, minutesDelta) {
+  if (!Array.isArray(services)) return null;
+  const svcIndex = services.findIndex(s => s && s.id === lookupServiceId);
+  if (svcIndex === -1) return null;
+  const updatedSvc = { ...services[svcIndex] };
+  const work = { ...(updatedSvc.work || { totalMinutesWorked: 0, entriesCount: 0 }) };
+  work.totalMinutesWorked = round2((work.totalMinutesWorked || 0) + minutesDelta);
+  work.entriesCount = (work.entriesCount || 0) + 1;
+  updatedSvc.work = work;
+  const updatedArr = [...services];
+  updatedArr[svcIndex] = updatedSvc;
+  return { updatedServices: updatedArr, isOverage: false, overageMinutes: 0 };
+}
+
 function lookupServiceIds(clientData, taskData) {
   const result = { stageId: null, packageId: null };
 
@@ -484,17 +509,7 @@ async function addTimeToTaskWithTransaction(db, data, user) {
                 }
               }
             } else if (serviceType === ST.FIXED) {
-              const svcIndex = services.findIndex(s => s.id === lookupServiceId);
-              if (svcIndex !== -1) {
-                const updatedSvc = { ...services[svcIndex] };
-                const work = { ...(updatedSvc.work || { totalMinutesWorked: 0, entriesCount: 0 }) };
-                work.totalMinutesWorked = round2((work.totalMinutesWorked || 0) + minutesDelta);
-                work.entriesCount = (work.entriesCount || 0) + 1;
-                updatedSvc.work = work;
-                const updatedArr = [...services];
-                updatedArr[svcIndex] = updatedSvc;
-                deductionResult = { updatedServices: updatedArr, isOverage: false, overageMinutes: 0 };
-              }
+              deductionResult = computeFixedDeduction(services, lookupServiceId, minutesDelta);
             }
           }
         }
@@ -639,4 +654,7 @@ async function addTimeToTaskWithTransaction(db, data, user) {
   );
 }
 
-module.exports = { addTimeToTaskWithTransaction };
+module.exports = {
+  addTimeToTaskWithTransaction,
+  _test: { computeFixedDeduction }
+};

--- a/functions/addTimeToTask_v2.test.js
+++ b/functions/addTimeToTask_v2.test.js
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for addTimeToTask_v2 pure functions.
+ *
+ * Currently covers computeFixedDeduction (extracted in PR #259 / Level 2 hardening).
+ * Regression guard for PR #257 — the FIXED branch was missing entirely, which led to
+ * deductionResult=null → deductedInTransaction=false → trigger ran fallback CREATE
+ * path → actualMinutes double-counted on 7 tasks.
+ *
+ * Invariant: for any supported serviceType, the deduction function MUST return a
+ * non-null deductionResult when the service exists. Returning null would re-introduce
+ * the double-count class of bug.
+ */
+
+// Mock firebase-admin and functions before requiring the module
+jest.mock('firebase-admin', () => ({
+  firestore: () => ({}),
+  initializeApp: jest.fn()
+}));
+jest.mock('firebase-functions', () => ({
+  https: { onCall: jest.fn(() => jest.fn()), HttpsError: class extends Error {} },
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+jest.mock('firebase-functions/v2/https', () => ({
+  onCall: jest.fn(() => jest.fn())
+}));
+
+const { _test: { computeFixedDeduction } } = require('./addTimeToTask_v2');
+
+describe('computeFixedDeduction', () => {
+  function makeFixedService(id, work = null) {
+    return { id, type: 'fixed', ...(work !== null && { work }) };
+  }
+
+  test('returns non-null with incremented work tracking when service exists', () => {
+    const services = [
+      makeFixedService('svc_other'),
+      makeFixedService('svc_target', { totalMinutesWorked: 120, entriesCount: 4 }),
+      makeFixedService('svc_third')
+    ];
+
+    const result = computeFixedDeduction(services, 'svc_target', 30);
+
+    expect(result).not.toBeNull();
+    expect(result.isOverage).toBe(false);
+    expect(result.overageMinutes).toBe(0);
+    const updated = result.updatedServices.find(s => s.id === 'svc_target');
+    expect(updated.work.totalMinutesWorked).toBe(150);
+    expect(updated.work.entriesCount).toBe(5);
+  });
+
+  test('initialises work object when missing on the service', () => {
+    const services = [makeFixedService('svc_target')];
+    const result = computeFixedDeduction(services, 'svc_target', 45);
+
+    expect(result).not.toBeNull();
+    const updated = result.updatedServices[0];
+    expect(updated.work.totalMinutesWorked).toBe(45);
+    expect(updated.work.entriesCount).toBe(1);
+  });
+
+  test('treats undefined totalMinutesWorked / entriesCount as zero', () => {
+    const services = [makeFixedService('svc_target', {})];
+    const result = computeFixedDeduction(services, 'svc_target', 60);
+
+    expect(result.updatedServices[0].work.totalMinutesWorked).toBe(60);
+    expect(result.updatedServices[0].work.entriesCount).toBe(1);
+  });
+
+  test('does NOT mutate the original services array or service object', () => {
+    const original = [makeFixedService('svc_target', { totalMinutesWorked: 100, entriesCount: 2 })];
+    const snapshot = JSON.parse(JSON.stringify(original));
+
+    computeFixedDeduction(original, 'svc_target', 10);
+
+    expect(original).toEqual(snapshot);
+    expect(original[0].work.totalMinutesWorked).toBe(100);
+    expect(original[0].work.entriesCount).toBe(2);
+  });
+
+  test('returns null when target service id is missing — caller must handle', () => {
+    const services = [makeFixedService('svc_a'), makeFixedService('svc_b')];
+    expect(computeFixedDeduction(services, 'svc_missing', 30)).toBeNull();
+  });
+
+  test('returns null when services is not an array', () => {
+    expect(computeFixedDeduction(null, 'svc_target', 30)).toBeNull();
+    expect(computeFixedDeduction(undefined, 'svc_target', 30)).toBeNull();
+    expect(computeFixedDeduction({}, 'svc_target', 30)).toBeNull();
+  });
+
+  test('handles negative delta (DELETE / correction) without going below zero count', () => {
+    const services = [makeFixedService('svc_target', { totalMinutesWorked: 50, entriesCount: 2 })];
+    const result = computeFixedDeduction(services, 'svc_target', -20);
+
+    expect(result.updatedServices[0].work.totalMinutesWorked).toBe(30);
+    // entriesCount increments regardless — caller decides when to use this function
+    expect(result.updatedServices[0].work.entriesCount).toBe(3);
+  });
+
+  test('rounds totalMinutesWorked to 2 decimals', () => {
+    const services = [makeFixedService('svc_target', { totalMinutesWorked: 0.1, entriesCount: 0 })];
+    const result = computeFixedDeduction(services, 'svc_target', 0.2);
+
+    expect(result.updatedServices[0].work.totalMinutesWorked).toBe(0.3);
+  });
+
+  test('CRITICAL REGRESSION GUARD: never returns null when target service exists', () => {
+    // If this test ever fails, the ST.FIXED double-count bug from PR #257 has returned.
+    const services = [makeFixedService('svc_target')];
+    const result = computeFixedDeduction(services, 'svc_target', 1);
+    expect(result).not.toBeNull();
+    expect(result.updatedServices).toBeDefined();
+    expect(result.updatedServices.length).toBe(services.length);
+  });
+});

--- a/functions/triggers/timesheet-trigger.js
+++ b/functions/triggers/timesheet-trigger.js
@@ -224,6 +224,28 @@ const onTimesheetEntryChanged = onDocumentWritten({
     return null;
   }
 
+  // ── Observability: detect callables that wrote a taskId entry without setting the flag ──
+  // Background: addTimeToTask had a missing ST.FIXED branch (PR #257) that returned
+  // deductionResult=null → deductedInTransaction stayed false → trigger ran the fallback
+  // CREATE path → actualMinutes was incremented twice (callable + trigger). 7 tasks drifted
+  // for 6 days before user noticed. This warning surfaces the same class of regression
+  // immediately in logs instead of waiting for drift audit.
+  // NOT a behavioral change — trigger fallback still runs as before.
+  if (eventType === 'CREATE' && entry.taskId && entry.deductedInTransaction !== true) {
+    console.warn(JSON.stringify({
+      severity: 'WARNING',
+      event: 'TRIGGER_FALLBACK_WITH_TASK',
+      message: 'Trigger CREATE fallback ran for an entry that has a taskId — possible callable bug (missing deductedInTransaction). If callable already incremented task.actualMinutes, this will double-count.',
+      entryId,
+      taskId: entry.taskId,
+      serviceId: entry.serviceId || null,
+      serviceType: entry.serviceType || null,
+      minutes: entry.minutes || 0,
+      createdBy: entry.createdBy || null,
+      action: entry.action || null,
+    }));
+  }
+
   // ── Guard: clientId required ──
   const clientId = entry.clientId;
   if (!clientId) {


### PR DESCRIPTION
Level 2 hardening for the callable+trigger double-write architecture. Closes part of #259.

## Context
PR #257 fixed a specific bug (missing ST.FIXED branch in `addTimeToTask`). The bug went undetected for 6 days, drifted 7 tasks (1275min total), and was only discovered when a user manually noticed 360min on a 180min entry.

The class of bug is broader than one missing branch: any callable that writes a `timesheet_entry` with a `taskId` but doesn't set `deductedInTransaction=true` will silently double-count via the trigger fallback CREATE path.

## Changes

### 1. Trigger observability (`functions/triggers/timesheet-trigger.js`)
After the existing skip-on-`deductedInTransaction` guard, add a structured `console.warn` when:
- `eventType === 'CREATE'`
- `entry.taskId` exists
- `entry.deductedInTransaction !== true`

This is exactly the signature of the PR #257 bug. Future regressions surface in logs immediately instead of waiting for drift audits.

**NOT a behavioral change.** The trigger fallback CREATE path runs as before; the warning only adds visibility.

### 2. Extract `computeFixedDeduction` + tests (`functions/addTimeToTask_v2.js`)
Extract the inline FIXED branch (12 lines) into a pure function exported via `_test`, mirroring the pattern in `triggers/timesheet-trigger.test.js`.

9 unit tests including a CRITICAL REGRESSION GUARD that fails if the function ever returns null when the target service exists.

**Invariant under test:** for any supported `serviceType`, the deduction function MUST return non-null `deductionResult` when the service exists. Returning null re-introduces the double-count class of bug.

## Validation
- `npx jest addTimeToTask_v2.test.js` → 9/9 PASS
- `npx jest` (full suite) → 217/217 PASS
- `node --check` on both modified files → OK

## Out of scope (deferred to follow-up issue)
**Alerting on existing system_health_checks.** Daily invariant check already runs Check 3 (`task.actualMinutes vs Σ(entries)`), Check 4, Check 5 — but discrepancies are only written to `system_health_checks` collection. Nobody actively reads them. This was the real reason the FIXED bug stayed live for 6 days.

Requires a channel decision (email / Firestore notification / Cloud Monitoring) before implementation.

## Test plan
- [ ] Merge to main
- [ ] Deploy `addTimeToTask` + trigger to PROD via merge to production-stable
- [ ] Verify `TRIGGER_FALLBACK_WITH_TASK` does NOT appear in PROD logs (confirms callable always sets the flag for taskId entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)