### PR TITLE
fix(admin-report): match legal_procedure stage entries

### DIFF
--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -436,8 +436,8 @@
     <!-- Data Managers (Required for Fluent Components) -->
     <script src="js/managers/ClientsDataManager.js?v=20251125"></script>
     <script src="js/ui/ClientsTable.js?v=20251125"></script>
-    <script src="js/ui/ClientReportModal.js?v=20251125"></script>
-    <script src="js/managers/ReportGenerator.js?v=20251125"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260507-stage"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
 
     <!-- Fluent Design Components -->
     <script src="js/fluent/FluentDataGrid.js?v=20251125"></script>

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -575,9 +575,9 @@
 
     <!-- ===== Clients Management Scripts ===== -->
     <script src="js/managers/ClientsDataManager.js?v=20251205-DATE-FIX"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260129-EDIT-PREVIEW"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260129-EVIDENCE"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260507-stage"></script>
     <script src="js/ui/ClientManagementModal.js?v=20251127-FINAL"></script>
     <script src="js/ui/ClientsTable.js?v=20251215-PAGINATION"></script>
 

--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -229,7 +229,7 @@
     <script src="js/ui/Notifications.js?v=e02c45c"></script>
     <script src="js/ui/UserForm.js?v=e02c45c"></script>
     <script src="js/ui/UserDetailsModal.js?v=e02c45c"></script>
-    <script src="js/managers/ReportGenerator.js?v=e02c45c"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
     <script src="js/ui/DeleteDataSidePanel.js?v=e02c45c"></script>
     <script src="js/managers/UsersActions.js?v=e02c45c"></script>
 

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -93,6 +93,14 @@ return true;
                     if (formData.serviceId && entry.service === formData.serviceId) {
 return true;
 }
+                    // legal_procedure stages: entries store stage id (e.g. "stage_a") in serviceId,
+                    // while card holds parent service id. Match by stage when present.
+                    if (formData.stage && entry.serviceId === formData.stage) {
+return true;
+}
+                    if (formData.stage && entry.stage === formData.stage) {
+return true;
+}
                     if (entry.service === formData.service) {
 return true;
 }

--- a/apps/admin-panel/js/ui/ClientReportModal.js
+++ b/apps/admin-panel/js/ui/ClientReportModal.js
@@ -766,6 +766,7 @@ card.classList.add('resolved');
             // Data attributes for selection
             card.dataset.serviceName = serviceInfo.displayName;
             card.dataset.serviceId = serviceInfo.serviceId || serviceInfo.stage || '';
+            card.dataset.stage = serviceInfo.stage || '';
             card.dataset.serviceIndex = index;
             card.dataset.serviceType = serviceInfo.type;
 
@@ -1002,8 +1003,9 @@ card.classList.add('resolved');
             // Update hidden input with sanitized value
             this.selectedServiceInput.value = this.sanitizeInput(serviceName);
             this.selectedServiceInput.dataset.serviceId = card.dataset.serviceId || '';
+            this.selectedServiceInput.dataset.stage = card.dataset.stage || '';
 
-            console.log('✅ Selected service:', serviceName, '| serviceId:', card.dataset.serviceId);
+            console.log('✅ Selected service:', serviceName, '| serviceId:', card.dataset.serviceId, '| stage:', card.dataset.stage);
         }
 
         /**
@@ -1121,6 +1123,7 @@ return '';
                 endDate: this.endDateInput?.value,
                 service: this.selectedServiceInput?.value || '',
                 serviceId: this.selectedServiceInput?.dataset.serviceId || '',
+                stage: this.selectedServiceInput?.dataset.stage || '',
                 reportType,
                 reportFormat
             };


### PR DESCRIPTION
## Summary
- דוח ללקוח על service מסוג `legal_procedure` (לדוגמה ביה\"ד עבודה / שלב א') החזיר ריק
- `card.dataset.serviceId` החזיק את parent service id (`srv_xxx`), אבל ה-entries שמורים עם stage id (`stage_a`) ב-`entry.serviceId`
- מוסיף `stage` ל-card dataset ולמסלול הסינון ב-`matchService`

## Root cause
[ClientReportModal.js:768](apps/admin-panel/js/ui/ClientReportModal.js#L768):
```js
card.dataset.serviceId = serviceInfo.serviceId || serviceInfo.stage || '';
// parent קיים → לוקח אותו, stage לעולם לא נבחר
```
ה-22 entries של ביה\"ד עבודה אצל לקוח 2025549 (חליבה) שמורים עם `serviceId: \"stage_a\"`. הסינון השווה `\"srv_1772921939885\" === \"stage_a\"` → false → דוח ריק.

## Changes
- `ClientReportModal.js`:
  - `card.dataset.stage` חדש
  - `selectedServiceInput.dataset.stage` ב-`selectServiceCard`
  - `getFormData` מחזיר `stage`
- `ReportGenerator.js` — `matchService` משווה גם `formData.stage === entry.serviceId` ו-`entry.stage`
- `clients.html` / `clients-fluent.html` / `index.html` — cache-bust `v=20260507-stage`

## Verification (DEV)
- [ ] לקוח חליבה (2025549), בחר \"שלב א'\" של ביה\"ד עבודה, טווח 2026-04-30 .. 2026-05-07
- [ ] מצופה: 3 entries של עוזי, 1.67h
- [ ] regression: services רגילים (תוכנית שעות #1, סיום הליך שלב א, מחוזי שלב ב) ממשיכים לעבוד

## Notes
- אין שינוי data
- אין שינוי schema
- backwards-compatible: matchService רק מוסיף תנאים, לא מסיר

🤖 Generated with [Claude Code](https://claude.com/claude-code)