### PR TITLE
fix(admin-report): scope summary totals to selected stage

### DIFF
--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -436,8 +436,8 @@
     <!-- Data Managers (Required for Fluent Components) -->
     <script src="js/managers/ClientsDataManager.js?v=20251125"></script>
     <script src="js/ui/ClientsTable.js?v=20251125"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260507-stage"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
 
     <!-- Fluent Design Components -->
     <script src="js/fluent/FluentDataGrid.js?v=20251125"></script>

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -575,9 +575,9 @@
 
     <!-- ===== Clients Management Scripts ===== -->
     <script src="js/managers/ClientsDataManager.js?v=20251205-DATE-FIX"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260507-stage"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
     <script src="js/ui/ClientManagementModal.js?v=20251127-FINAL"></script>
     <script src="js/ui/ClientsTable.js?v=20251215-PAGINATION"></script>
 

--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -229,7 +229,7 @@
     <script src="js/ui/Notifications.js?v=e02c45c"></script>
     <script src="js/ui/UserForm.js?v=e02c45c"></script>
     <script src="js/ui/UserDetailsModal.js?v=e02c45c"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/DeleteDataSidePanel.js?v=e02c45c"></script>
     <script src="js/managers/UsersActions.js?v=e02c45c"></script>
 

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -925,33 +925,58 @@ return true;
                     serviceRemainingHours = client.hoursRemaining || 0;
                 }
             } else {
-                const selectedService = client.services?.find(s => {
-                    if (s.name === formData.service) {
-return true;
-}
-                    if (s.serviceName === formData.service) {
-return true;
-}
-                    if (s.displayName === formData.service) {
-return true;
-}
-                    if (s.stage && formData.service.includes(s.stage)) {
-return true;
-}
-                    if (s.displayName && s.displayName.includes(formData.service)) {
-return true;
-}
-                    return false;
-                });
+                // First try: legal_procedure stage (formData.stage holds e.g. "stage_a")
+                let selectedStage = null;
+                if (formData.stage && Array.isArray(client.services)) {
+                    for (const s of client.services) {
+                        if (Array.isArray(s.stages)) {
+                            const match = s.stages.find(st => st.id === formData.stage);
+                            if (match) {
+                                selectedStage = match;
+                                break;
+                            }
+                        }
+                    }
+                }
 
-                if (selectedService) {
-                    serviceTotalHours = selectedService.totalHours || selectedService.hours || selectedService.allocatedHours || selectedService.stageHours || 0;
-                    serviceRemainingHours = selectedService.hoursRemaining || selectedService.remainingHours || 0;
-                    serviceUsedHours = serviceTotalHours - serviceRemainingHours;
+                if (selectedStage) {
+                    serviceTotalHours = selectedStage.totalHours || selectedStage.hours || 0;
+                    serviceRemainingHours = (selectedStage.hoursRemaining !== undefined)
+                        ? selectedStage.hoursRemaining
+                        : (serviceTotalHours - (selectedStage.hoursUsed || 0));
+                    serviceUsedHours = selectedStage.hoursUsed !== undefined
+                        ? selectedStage.hoursUsed
+                        : (serviceTotalHours - serviceRemainingHours);
                 } else {
-                    serviceTotalHours = client.totalHours || 0;
-                    serviceUsedHours = (client.totalHours || 0) - (client.hoursRemaining || 0);
-                    serviceRemainingHours = client.hoursRemaining || 0;
+                    const selectedService = client.services?.find(s => {
+                        if (s.name === formData.service) {
+return true;
+}
+                        if (s.serviceName === formData.service) {
+return true;
+}
+                        if (s.displayName === formData.service) {
+return true;
+}
+                        if (s.stage && formData.service.includes(s.stage)) {
+return true;
+}
+                        if (s.displayName && s.displayName.includes(formData.service)) {
+return true;
+}
+                        return false;
+                    });
+
+                    if (selectedService) {
+                        serviceTotalHours = selectedService.totalHours || selectedService.hours || selectedService.allocatedHours || selectedService.stageHours || 0;
+                        serviceRemainingHours = selectedService.hoursRemaining || selectedService.remainingHours || 0;
+                        serviceUsedHours = serviceTotalHours - serviceRemainingHours;
+                    } else {
+                        // Last resort: derive from filtered timesheetEntries (already service-scoped)
+                        serviceUsedHours = timesheetEntries.reduce((sum, e) => sum + ((e.minutes || 0) / 60), 0);
+                        serviceTotalHours = 0;
+                        serviceRemainingHours = -serviceUsedHours;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- שורת \"סיכום: תקציב X | בוצעו Y | יתרה Z\" הציגה **סך כל הלקוח** במקום ה-stage שנבחר
- אצל לקוח חליבה (2025549), בחירת \"שלב א'\" של ביה\"ד עבודה הראתה 224.5h תקציב (סך כל ה-services של הלקוח) במקום 79.5h של ה-stage עצמו
- מצופה לאחר fix: 79.5h תקציב | 32.42h בוצעו | 47.08h יתרה

## Root cause
[ReportGenerator.js:928-955](apps/admin-panel/js/managers/ReportGenerator.js#L928-L955) חיפש ב-`client.services.find()` לפי `s.name === formData.service`. ל-stage formData.service = \"שלב א'\" אבל ה-parent service נקרא \"ביה\"ד לעבודה\". `selectedService` undefined → fallback ל-`client.totalHours` (סך כל הלקוח).

## Fix
- מסלול ראשון חדש: אם `formData.stage` קיים, חיפוש בתוך `service.stages[]` לפי `stage.id === formData.stage`
- שימוש ב-`stage.totalHours` / `stage.hoursUsed` / `stage.hoursRemaining` (קיימים בDB, אומת ב-script)
- fallback אחרון: סכימת `timesheetEntries` (כבר scoped ל-service) במקום `client.totalHours`

## Verification (DEV)
- [ ] לקוח חליבה (2025549), בחר \"שלב א'\" של ביה\"ד עבודה
- [ ] טווח שבוע (30.04 .. 07.05) או חודש
- [ ] סיכום מצופה: **תקציב 79.5h | בוצעו 32.42h | יתרה 47.08h**
- [ ] regression: \"תוכנית שעות #1\" (39 entries), \"מחוזי שלב ב'\" (8 entries) — סיכומים לא משתנים

## Notes
- אין שינוי data
- אין schema migration
- backwards-compatible: רק fallback אחרון השתנה (היה whole-client → עכשיו entries-derived); אם ה-service נמצא דרך .find() — אין שינוי

🤖 Generated with [Claude Code](https://claude.com/claude-code)