### PR TITLE
feat(admin-table): show mixed (hours+fixed) client type + replace legacy default

### DIFF
--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -434,8 +434,10 @@
     <script src="js/ui/Navigation.js?v=20251125"></script>
 
     <!-- Data Managers (Required for Fluent Components) -->
-    <script src="js/managers/ClientsDataManager.js?v=20251125"></script>
-    <script src="js/ui/ClientsTable.js?v=20251125"></script>
+    <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager -->
+    <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
+    <script src="js/managers/ClientsDataManager.js?v=20260514-mixed"></script>
+    <script src="js/ui/ClientsTable.js?v=20260514-mixed"></script>
     <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
 

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -574,12 +574,14 @@
     <script src="js/ui/AnnouncementEditor.js"></script>
 
     <!-- ===== Clients Management Scripts ===== -->
-    <script src="js/managers/ClientsDataManager.js?v=20251205-DATE-FIX"></script>
+    <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager (used by .loadClients) -->
+    <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
+    <script src="js/managers/ClientsDataManager.js?v=20260514-mixed"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
     <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
     <script src="js/ui/ClientManagementModal.js?v=20251127-FINAL"></script>
-    <script src="js/ui/ClientsTable.js?v=20251215-PAGINATION"></script>
+    <script src="js/ui/ClientsTable.js?v=20260514-mixed"></script>
 
     <!-- ===== Shared Components ===== -->
     <script src="js/ui/Notifications.js?v=20251123v1"></script>

--- a/apps/admin-panel/js/core/client-type-display.js
+++ b/apps/admin-panel/js/core/client-type-display.js
@@ -1,0 +1,205 @@
+/**
+ * Client Type Display — composes "what kind of client is this?" from services[].
+ *
+ * Replaces the legacy logic that read a non-existent `client.type` field
+ * and defaulted it to 'hours' in ClientsDataManager, causing every fixed
+ * client to appear as 'שעות' in the admin table.
+ *
+ * Source of truth: client.services[] — the array of service objects.
+ * Each service has:
+ *   - type: 'hours' | 'fixed' | 'legal_procedure'
+ *   - pricingType: 'hourly' | 'fixed'  (legal_procedure only)
+ *   - status: 'active' | 'completed'   (active = currently used)
+ *
+ * Output: a stable `typeDisplay` object the UI can render without further logic.
+ *
+ * Created: 2026-05-14 as part of feature/admin-table-mixed-type-display.
+ */
+
+(function () {
+    'use strict';
+
+    /**
+     * Canonical fixed-service check.
+     * Mirrors functions/shared/aggregates.js:isFixedService — keep in sync.
+     *
+     * @param {Object} svc - service object
+     * @returns {boolean}
+     */
+    function isFixedService(svc) {
+        if (!svc) {
+            return false;
+        }
+        return svc.type === 'fixed' ||
+            (svc.type === 'legal_procedure' && svc.pricingType === 'fixed');
+    }
+
+    /**
+     * Service status check. Treats missing status as 'active' for backward
+     * compatibility with old data (services pre-dating the status field).
+     *
+     * @param {Object} svc - service object
+     * @returns {boolean}
+     */
+    function isServiceActive(svc) {
+        if (!svc) {
+            return false;
+        }
+        // Missing status = legacy data = treat as active
+        if (!svc.status) {
+            return true;
+        }
+        return svc.status === 'active';
+    }
+
+    /**
+     * Compute the "type display" for a client based on active services.
+     *
+     * Returns an object the UI can render directly. Includes a `breakdown`
+     * array suitable for tooltips listing every service (active + completed).
+     *
+     * @param {Array<Object>} services - client.services array
+     * @returns {{
+     *   kind: 'none' | 'hours' | 'fixed' | 'mixed',
+     *   label: string,    // Hebrew label
+     *   icon: string,     // FontAwesome class
+     *   breakdown: Array<{name: string, type: string, status: string, isFixed: boolean, isActive: boolean}>
+     * }}
+     */
+    function computeClientTypeDisplay(services) {
+        const list = Array.isArray(services) ? services : [];
+
+        // Breakdown: every service with classification flags for tooltips/exports.
+        const breakdown = list.map(svc => ({
+            name: svc.name || '(ללא שם)',
+            type: svc.type || 'unknown',
+            pricingType: svc.pricingType || null,
+            status: svc.status || 'active',
+            isFixed: isFixedService(svc),
+            isActive: isServiceActive(svc)
+        }));
+
+        const active = breakdown.filter(b => b.isActive);
+        const hasHours = active.some(b => !b.isFixed);
+        const hasFixed = active.some(b => b.isFixed);
+
+        let kind, label, icon;
+        if (active.length === 0) {
+            kind = 'none';
+            label = 'ללא';
+            icon = 'fa-question-circle';
+        } else if (hasHours && hasFixed) {
+            kind = 'mixed';
+            label = 'מעורב';
+            icon = 'fa-layer-group';
+        } else if (hasHours) {
+            kind = 'hours';
+            label = 'שעות';
+            icon = 'fa-clock';
+        } else {
+            kind = 'fixed';
+            label = 'פיקס';
+            icon = 'fa-file-invoice-dollar';
+        }
+
+        return { kind, label, icon, breakdown };
+    }
+
+    /**
+     * Render an HTML tooltip body listing every service with status.
+     * Safe — escapes service names against XSS.
+     *
+     * @param {Array} breakdown - the `.breakdown` from computeClientTypeDisplay
+     * @returns {string} HTML string
+     */
+    function renderTypeTooltip(breakdown) {
+        if (!Array.isArray(breakdown) || breakdown.length === 0) {
+            return '<div class="type-tooltip"><em>אין שירותים</em></div>';
+        }
+
+        const escapeHtml = (str) => String(str || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+
+        const activeRows = breakdown.filter(b => b.isActive).map(b => {
+            const typeLabel = b.isFixed ? 'פיקס' : 'שעות';
+            const icon = b.isFixed ? 'fa-file-invoice-dollar' : 'fa-clock';
+            return `<div class="tooltip-row active">
+                <i class="fas ${icon}"></i>
+                <span class="svc-name">${escapeHtml(b.name)}</span>
+                <span class="svc-type">${typeLabel}</span>
+            </div>`;
+        }).join('');
+
+        const completedRows = breakdown.filter(b => !b.isActive).map(b => {
+            const typeLabel = b.isFixed ? 'פיקס' : 'שעות';
+            return `<div class="tooltip-row completed">
+                <i class="fas fa-check-circle"></i>
+                <span class="svc-name">${escapeHtml(b.name)}</span>
+                <span class="svc-type">${typeLabel} (סגור)</span>
+            </div>`;
+        }).join('');
+
+        return `<div class="type-tooltip">
+            ${activeRows ? `<div class="tooltip-section">
+                <div class="tooltip-header">פעילים:</div>
+                ${activeRows}
+            </div>` : ''}
+            ${completedRows ? `<div class="tooltip-section">
+                <div class="tooltip-header">סגורים:</div>
+                ${completedRows}
+            </div>` : ''}
+        </div>`;
+    }
+
+    /**
+     * Render an inline CSV-friendly composition string (for exports).
+     * Example: "שעות + פיקס" / "שעות" / "פיקס" / "ללא"
+     *
+     * @param {Array} breakdown
+     * @returns {string}
+     */
+    function renderTypeForCsv(breakdown) {
+        if (!Array.isArray(breakdown)) {
+            return '';
+        }
+        const active = breakdown.filter(b => b.isActive);
+        const hasHours = active.some(b => !b.isFixed);
+        const hasFixed = active.some(b => b.isFixed);
+        if (active.length === 0) {
+            return 'ללא';
+        }
+        if (hasHours && hasFixed) {
+            return 'שעות + פיקס';
+        }
+        if (hasHours) {
+            return 'שעות';
+        }
+        return 'פיקס';
+    }
+
+    // Expose to window — admin-panel pattern
+    if (typeof window !== 'undefined') {
+        window.ClientTypeDisplay = {
+            computeClientTypeDisplay,
+            renderTypeTooltip,
+            renderTypeForCsv,
+            isFixedService,    // exported for tests + future reuse
+            isServiceActive    // same
+        };
+    }
+
+    // CommonJS export — for vitest tests under Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            computeClientTypeDisplay,
+            renderTypeTooltip,
+            renderTypeForCsv,
+            isFixedService,
+            isServiceActive
+        };
+    }
+})();

--- a/apps/admin-panel/js/fluent/FluentDataGrid.js
+++ b/apps/admin-panel/js/fluent/FluentDataGrid.js
@@ -360,11 +360,15 @@ return;
         row.appendChild(caseCell);
 
         // Service type
+        // Refactored 2026-05-14: was comparing client.type to a Hebrew string
+        // ('הליך משפטי') that never matches (type stores English IDs). Now uses
+        // typeDisplay computed by ClientsDataManager from services[].
         const typeCell = document.createElement('td');
+        const td = client.typeDisplay || { kind: client.type || 'none', label: client.type || 'ללא', icon: 'fa-briefcase' };
         typeCell.innerHTML = `
-            <span class="service-type-badge" data-type="${client.type}">
-                ${client.type === 'הליך משפטי' ? '<i class="fas fa-balance-scale"></i>' : '<i class="fas fa-briefcase"></i>'}
-                ${this.escapeHtml(client.type)}
+            <span class="service-type-badge" data-type="${this.escapeHtml(td.kind)}">
+                <i class="fas ${td.icon}"></i>
+                ${this.escapeHtml(td.label)}
             </span>
         `;
         row.appendChild(typeCell);

--- a/apps/admin-panel/js/managers/ClientsDataManager.js
+++ b/apps/admin-panel/js/managers/ClientsDataManager.js
@@ -193,13 +193,23 @@
                 this.clients = snapshot.docs
                     .map(doc => {
                         const clientData = doc.data();
+
+                        // ✅ Compute type display from services[] (canonical source of truth).
+                        // Replaces legacy `type: clientData.type || 'hours'` default which
+                        // wrongly defaulted every fixed client to 'hours' display.
+                        // See apps/admin-panel/js/core/client-type-display.js.
+                        const typeDisplay = window.ClientTypeDisplay
+                            ? window.ClientTypeDisplay.computeClientTypeDisplay(clientData.services)
+                            : { kind: 'none', label: 'ללא', icon: 'fa-question-circle', breakdown: [] };
+
                         const client = {
                             id: doc.id,
                             ...clientData,
                             // Ensure we have the correct field names
                             fullName: clientData.fullName || clientData.clientName || '',
                             caseNumber: clientData.caseNumber || '',
-                            type: clientData.type || 'hours',
+                            type: typeDisplay.kind,  // ← computed: 'hours'/'fixed'/'mixed'/'none' (was: legacy default 'hours')
+                            typeDisplay: typeDisplay,  // ← full object with label/icon/breakdown for UI
                             isBlocked: clientData.isBlocked || false,
                             isCritical: clientData.isCritical || false,
                             status: clientData.status || 'active',

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -312,15 +312,34 @@ return;
         /**
          * Get type badge
          * קבלת תג סוג
+         *
+         * Reads from client.typeDisplay (computed by ClientsDataManager from
+         * services[] — the canonical source of truth). Supports mixed clients
+         * (both hours + fixed active services) and renders a tooltip with
+         * per-service breakdown.
+         *
+         * Refactored 2026-05-14 from binary `client.type === 'hours' ? ...`
+         * which was wrong for fixed clients (DataManager defaulted them to
+         * 'hours') and unable to represent mixed clients.
          */
         getTypeBadge(client) {
-            const typeText = client.type === 'hours' ? 'שעות' : 'קבוע';
-            const icon = client.type === 'hours' ? 'fa-clock' : 'fa-file-invoice-dollar';
+            const td = client.typeDisplay || {
+                kind: 'none', label: 'ללא', icon: 'fa-question-circle', breakdown: []
+            };
+
+            const tooltipHtml = (window.ClientTypeDisplay && window.ClientTypeDisplay.renderTypeTooltip)
+                ? window.ClientTypeDisplay.renderTypeTooltip(td.breakdown)
+                : '';
+
+            // Escape tooltip HTML for safe embedding in data attribute
+            const tooltipAttr = tooltipHtml
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;');
 
             return `
-                <span class="type-badge">
-                    <i class="fas ${icon}"></i>
-                    ${typeText}
+                <span class="type-badge type-badge-${td.kind}" data-tooltip-html="${tooltipAttr}">
+                    <i class="fas ${td.icon}"></i>
+                    ${td.label}
                 </span>
             `;
         }
@@ -328,9 +347,15 @@ return;
         /**
          * Get hours display
          * קבלת תצוגת שעות
+         *
+         * Shows hours info for any client with an active billable service
+         * (hours or legal_procedure+hourly). Pure-fixed clients return '-'.
          */
         getHoursDisplay(client) {
-            if (client.type !== 'hours') {
+            const td = client.typeDisplay;
+            // Show hours for hours-only OR mixed clients (both have billable hours)
+            const hasBillableHours = td && (td.kind === 'hours' || td.kind === 'mixed');
+            if (!hasBillableHours) {
                 return '<span>-</span>';
             }
 
@@ -363,6 +388,12 @@ return;
         /**
          * Get hours warning icon
          * קבלת אייקון התראה לשעות
+         *
+         * Triggers for clients with active billable services low on hours.
+         *
+         * Refactored 2026-05-14 to read from services[] (canonical source)
+         * instead of legacy `client.procedureType` + `client.pricingType`
+         * which weren't reliably maintained for multi-service clients.
          */
         getHoursWarningIcon(client) {
             // Only check active, non-blocked clients
@@ -370,40 +401,36 @@ return;
                 return '';
             }
 
+            const td = client.typeDisplay;
+            // No warning for fixed-only or no-services clients
+            if (!td || td.kind === 'fixed' || td.kind === 'none') {
+                return '';
+            }
+
             const hoursRemaining = client.hoursRemaining || 0;
             const totalHours = client.totalHours || 0;
 
-            // Regular hourly client
-            if (client.procedureType === 'hours') {
-                if (hoursRemaining < 5 || (totalHours > 0 && (hoursRemaining / totalHours) < 0.05)) {
-                    return '<span class="hours-warning-icon critical" title="פחות מ-5 שעות">🔴</span>';
-                }
-                if (hoursRemaining < 10 || (totalHours > 0 && (hoursRemaining / totalHours) < 0.1)) {
-                    return '<span class="hours-warning-icon warning" title="5-10 שעות">🟡</span>';
-                }
+            // Client-level hours warning (covers 'hours' and 'mixed' kinds)
+            if (hoursRemaining < 5 || (totalHours > 0 && (hoursRemaining / totalHours) < 0.05)) {
+                return '<span class="hours-warning-icon critical" title="פחות מ-5 שעות">🔴</span>';
+            }
+            if (hoursRemaining < 10 || (totalHours > 0 && (hoursRemaining / totalHours) < 0.1)) {
+                return '<span class="hours-warning-icon warning" title="5-10 שעות">🟡</span>';
             }
 
-            // Legal procedure - hourly pricing
-            if (client.procedureType === 'legal_procedure' && client.pricingType === 'hourly') {
-                // Check total hours remaining
-                if (hoursRemaining < 5) {
-                    return '<span class="hours-warning-icon critical" title="פחות מ-5 שעות נותרו בהליך">🔴</span>';
-                }
-                if (hoursRemaining < 10) {
-                    return '<span class="hours-warning-icon warning" title="5-10 שעות נותרו בהליך">🟡</span>';
-                }
-
-                // Check current stage hours remaining
-                if (client.services && client.services.length > 0) {
-                    const legalService = client.services.find(s => s.type === 'legal_procedure');
-                    if (legalService && legalService.stages) {
-                        const currentStage = legalService.stages.find(s => s.status === 'active');
-                        if (currentStage) {
-                            const stageRemaining = currentStage.hoursRemaining || 0;
-                            if (stageRemaining < 5) {
-                                return '<span class="hours-warning-icon critical" title="פחות מ-5 שעות בשלב הנוכחי">🔴</span>';
-                            }
-                        }
+            // Additional stage-level warning for active legal_procedure-hourly service
+            const services = Array.isArray(client.services) ? client.services : [];
+            const legalHourlyService = services.find(s =>
+                s.type === 'legal_procedure' &&
+                s.pricingType === 'hourly' &&
+                (!s.status || s.status === 'active')
+            );
+            if (legalHourlyService && Array.isArray(legalHourlyService.stages)) {
+                const currentStage = legalHourlyService.stages.find(s => s.status === 'active');
+                if (currentStage) {
+                    const stageRemaining = currentStage.hoursRemaining || 0;
+                    if (stageRemaining < 5) {
+                        return '<span class="hours-warning-icon critical" title="פחות מ-5 שעות בשלב הנוכחי">🔴</span>';
                     }
                 }
             }
@@ -643,12 +670,14 @@ return '-';
 
             // For now, just show an alert with basic info
             // TODO: Create a proper ClientDetailsModal
+            const td = client.typeDisplay || { kind: 'none', label: 'ללא' };
+            const hasBillableHours = td.kind === 'hours' || td.kind === 'mixed';
             alert(`
 פרטי לקוח:
 שם: ${client.fullName}
 מספר תיק: ${client.caseNumber || '-'}
-סוג: ${client.type === 'hours' ? 'שעות' : 'קבוע'}
-${client.type === 'hours' ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''}
+סוג: ${td.label}
+${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''}
 סטטוס: ${client.status}
             `.trim());
         }
@@ -671,15 +700,22 @@ ${client.type === 'hours' ? `שעות נותרות: ${client.hoursRemaining || 0
 
             // Convert to CSV
             const headers = ['שם הלקוח', 'מספר תיק', 'סוג', 'שעות נותרות', 'סטטוס', 'צוות', 'כניסה אחרונה'];
-            const rows = clients.map(client => [
-                client.fullName,
-                client.caseNumber || '',
-                client.type === 'hours' ? 'שעות' : 'קבוע',
-                client.type === 'hours' ? client.hoursRemaining || 0 : '-',
-                client.isBlocked ? 'חסום' : client.isCritical ? 'קריטי' : client.status,
-                client.assignedTo ? client.assignedTo.join(', ') : '',
-                this.getTeamLastLogin(client)
-            ]);
+            const rows = clients.map(client => {
+                const td = client.typeDisplay || { kind: 'none', breakdown: [] };
+                const typeLabel = (window.ClientTypeDisplay && window.ClientTypeDisplay.renderTypeForCsv)
+                    ? window.ClientTypeDisplay.renderTypeForCsv(td.breakdown)
+                    : (td.label || 'ללא');
+                const hasBillableHours = td.kind === 'hours' || td.kind === 'mixed';
+                return [
+                    client.fullName,
+                    client.caseNumber || '',
+                    typeLabel,
+                    hasBillableHours ? (client.hoursRemaining || 0) : '-',
+                    client.isBlocked ? 'חסום' : client.isCritical ? 'קריטי' : client.status,
+                    client.assignedTo ? client.assignedTo.join(', ') : '',
+                    this.getTeamLastLogin(client)
+                ];
+            });
 
             let csv = headers.join(',') + '\n';
             csv += rows.map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');

--- a/tests/unit/admin-panel/client-type-display.test.ts
+++ b/tests/unit/admin-panel/client-type-display.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit Tests — ClientTypeDisplay
+ *
+ * Tests the new computeClientTypeDisplay() function that replaces the
+ * legacy `client.type || 'hours'` default which was causing every fixed
+ * client to display as 'שעות' in the admin clients table.
+ *
+ * Created: 2026-05-14 as part of feature/admin-table-mixed-type-display.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore — CommonJS require from TypeScript ESM test
+import {
+  computeClientTypeDisplay,
+  renderTypeTooltip,
+  renderTypeForCsv,
+  isFixedService,
+  isServiceActive
+} from '../../../apps/admin-panel/js/core/client-type-display.js';
+
+describe('isFixedService — canonical fixed-service check', () => {
+  it('returns true for type=fixed', () => {
+    expect(isFixedService({ type: 'fixed' })).toBe(true);
+  });
+
+  it('returns true for legal_procedure + pricingType=fixed', () => {
+    expect(isFixedService({ type: 'legal_procedure', pricingType: 'fixed' })).toBe(true);
+  });
+
+  it('returns false for type=hours', () => {
+    expect(isFixedService({ type: 'hours' })).toBe(false);
+  });
+
+  it('returns false for legal_procedure + pricingType=hourly', () => {
+    expect(isFixedService({ type: 'legal_procedure', pricingType: 'hourly' })).toBe(false);
+  });
+
+  it('returns false for null/undefined input', () => {
+    expect(isFixedService(null)).toBe(false);
+    expect(isFixedService(undefined)).toBe(false);
+  });
+});
+
+describe('isServiceActive — service status check', () => {
+  it('returns true for status=active', () => {
+    expect(isServiceActive({ status: 'active' })).toBe(true);
+  });
+
+  it('returns false for status=completed', () => {
+    expect(isServiceActive({ status: 'completed' })).toBe(false);
+  });
+
+  it('returns true for missing status (backward compat with legacy data)', () => {
+    expect(isServiceActive({ type: 'hours' })).toBe(true);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isServiceActive(null)).toBe(false);
+    expect(isServiceActive(undefined)).toBe(false);
+  });
+});
+
+describe('computeClientTypeDisplay — kind/label/icon', () => {
+  it('returns "none" for empty services array', () => {
+    const result = computeClientTypeDisplay([]);
+    expect(result.kind).toBe('none');
+    expect(result.label).toBe('ללא');
+    expect(result.icon).toBe('fa-question-circle');
+  });
+
+  it('returns "none" for undefined services', () => {
+    const result = computeClientTypeDisplay(undefined);
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns "none" for non-array input', () => {
+    const result = computeClientTypeDisplay('not an array' as any);
+    expect(result.kind).toBe('none');
+  });
+
+  it('returns "hours" for client with only hours services', () => {
+    const services = [
+      { type: 'hours', name: 'תוכנית 1', status: 'active' },
+      { type: 'hours', name: 'תוכנית 2', status: 'active' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.kind).toBe('hours');
+    expect(result.label).toBe('שעות');
+    expect(result.icon).toBe('fa-clock');
+  });
+
+  it('returns "fixed" for client with only fixed services', () => {
+    const services = [
+      { type: 'fixed', name: 'הסכם 1', status: 'active' },
+      { type: 'legal_procedure', pricingType: 'fixed', name: 'הליך', status: 'active' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.kind).toBe('fixed');
+    expect(result.label).toBe('פיקס');
+    expect(result.icon).toBe('fa-file-invoice-dollar');
+  });
+
+  it('returns "mixed" for client with both hours AND fixed active services (Binyamingold)', () => {
+    const services = [
+      { type: 'legal_procedure', pricingType: 'fixed', name: 'הליך מחוזי', status: 'active' },
+      { type: 'hours', name: 'הליך ביהמש עליון', status: 'active', totalHours: 70 }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.kind).toBe('mixed');
+    expect(result.label).toBe('מעורב');
+    expect(result.icon).toBe('fa-layer-group');
+  });
+
+  it('treats legal_procedure + pricingType=hourly as hours (billable)', () => {
+    const services = [
+      { type: 'legal_procedure', pricingType: 'hourly', name: 'הליך שעתי', status: 'active' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.kind).toBe('hours');
+  });
+});
+
+describe('computeClientTypeDisplay — active-only logic', () => {
+  it('ignores completed services when computing kind', () => {
+    const services = [
+      { type: 'hours', name: 'שעות סגור', status: 'completed' },
+      { type: 'fixed', name: 'פיקס פעיל', status: 'active' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    // Only fixed is active → kind=fixed (not mixed)
+    expect(result.kind).toBe('fixed');
+  });
+
+  it('returns "none" when all services are completed', () => {
+    const services = [
+      { type: 'hours', name: 'שעות סגור', status: 'completed' },
+      { type: 'fixed', name: 'פיקס סגור', status: 'completed' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.kind).toBe('none');
+  });
+
+  it('breakdown includes ALL services regardless of active status', () => {
+    const services = [
+      { type: 'hours', name: 'A', status: 'active' },
+      { type: 'fixed', name: 'B', status: 'completed' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.breakdown.length).toBe(2);
+    expect(result.breakdown[0].isActive).toBe(true);
+    expect(result.breakdown[1].isActive).toBe(false);
+  });
+});
+
+describe('computeClientTypeDisplay — breakdown structure', () => {
+  it('marks isFixed correctly per service', () => {
+    const services = [
+      { type: 'hours', name: 'h', status: 'active' },
+      { type: 'fixed', name: 'f', status: 'active' },
+      { type: 'legal_procedure', pricingType: 'fixed', name: 'lpf', status: 'active' },
+      { type: 'legal_procedure', pricingType: 'hourly', name: 'lph', status: 'active' }
+    ];
+    const result = computeClientTypeDisplay(services);
+    expect(result.breakdown[0].isFixed).toBe(false);  // hours
+    expect(result.breakdown[1].isFixed).toBe(true);   // fixed
+    expect(result.breakdown[2].isFixed).toBe(true);   // legal+fixed
+    expect(result.breakdown[3].isFixed).toBe(false);  // legal+hourly
+  });
+
+  it('handles service with missing name (fallback to ללא שם)', () => {
+    const services = [{ type: 'hours', status: 'active' }];
+    const result = computeClientTypeDisplay(services);
+    expect(result.breakdown[0].name).toBe('(ללא שם)');
+  });
+});
+
+describe('renderTypeTooltip — HTML output', () => {
+  it('returns "אין שירותים" for empty breakdown', () => {
+    expect(renderTypeTooltip([])).toContain('אין שירותים');
+  });
+
+  it('lists active services under פעילים', () => {
+    const breakdown = [
+      { name: 'הליך מחוזי', isActive: true, isFixed: true }
+    ];
+    const html = renderTypeTooltip(breakdown);
+    expect(html).toContain('פעילים:');
+    expect(html).toContain('הליך מחוזי');
+    expect(html).toContain('פיקס');
+  });
+
+  it('lists completed services separately under סגורים', () => {
+    const breakdown = [
+      { name: 'שעות סגור', isActive: false, isFixed: false }
+    ];
+    const html = renderTypeTooltip(breakdown);
+    expect(html).toContain('סגורים:');
+    expect(html).toContain('שעות (סגור)');
+  });
+
+  it('escapes HTML in service names (XSS prevention)', () => {
+    const breakdown = [
+      { name: '<script>alert(1)</script>', isActive: true, isFixed: false }
+    ];
+    const html = renderTypeTooltip(breakdown);
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('renderTypeForCsv — CSV-safe label', () => {
+  it('returns "ללא" for empty', () => {
+    expect(renderTypeForCsv([])).toBe('ללא');
+  });
+
+  it('returns "שעות + פיקס" for mixed', () => {
+    const breakdown = [
+      { isActive: true, isFixed: false },
+      { isActive: true, isFixed: true }
+    ];
+    expect(renderTypeForCsv(breakdown)).toBe('שעות + פיקס');
+  });
+
+  it('returns "שעות" for hours-only', () => {
+    expect(renderTypeForCsv([{ isActive: true, isFixed: false }])).toBe('שעות');
+  });
+
+  it('returns "פיקס" for fixed-only', () => {
+    expect(renderTypeForCsv([{ isActive: true, isFixed: true }])).toBe('פיקס');
+  });
+
+  it('ignores completed when computing CSV label', () => {
+    const breakdown = [
+      { isActive: false, isFixed: false },  // completed hours
+      { isActive: true, isFixed: true }     // active fixed
+    ];
+    expect(renderTypeForCsv(breakdown)).toBe('פיקס');
+  });
+});


### PR DESCRIPTION
## Summary

The admin clients table's "סוג" (type) column displayed every client as either "שעות" or "קבוע", driven by a non-existent `client.type` field that ClientsDataManager defaulted to `'hours'`. This was wrong for two cases:

1. **Pure-fixed clients** — showed "שעות" by default. Confusing for admins.
2. **Hybrid clients** (both hours AND fixed services, e.g. Binyamingold 2025996) — no way to represent the actual composition; the table picked one type silently.

This PR computes the type display from the canonical `services[]` array.

## Root cause

`apps/admin-panel/js/managers/ClientsDataManager.js:202`:

```js
type: clientData.type || 'hours',  // ❌ clientData.type never exists in Firestore
```

No backend code writes `client.type`. The fallback to `'hours'` made every loaded client appear hours-typed in the table, the details modal, and the CSV export.

## Solution

New module `apps/admin-panel/js/core/client-type-display.js`:

- **`computeClientTypeDisplay(services)`** → derives `{kind, label, icon, breakdown}` from `services[]`. Kinds: `hours` | `fixed` | `mixed` | `none`.
- **`renderTypeTooltip(breakdown)`** → HTML for per-service breakdown tooltip (active vs. completed sections, XSS-safe).
- **`renderTypeForCsv(breakdown)`** → flat string `"שעות + פיקס"` / `"שעות"` / `"פיקס"` / `"ללא"` for exports.

Mirrors `functions/shared/aggregates.js:isFixedService` so admin and backend agree on what counts as fixed.

## Files

| File | Change |
|---|---|
| `apps/admin-panel/js/core/client-type-display.js` | **NEW** (210 LOC) |
| `tests/unit/admin-panel/client-type-display.test.ts` | **NEW** (30 tests) |
| `apps/admin-panel/js/managers/ClientsDataManager.js` | Line 202 — compute from `services[]` instead of defaulting `'hours'` |
| `apps/admin-panel/js/ui/ClientsTable.js` | `getTypeBadge`, `getHoursDisplay`, `getHoursWarningIcon`, details modal, CSV export — read `typeDisplay` instead of binary `client.type` check |
| `apps/admin-panel/js/fluent/FluentDataGrid.js` | Fixed pre-existing Hebrew-string-comparison bug (compared `client.type` to `'הליך משפטי'` which the field never contains) |
| `apps/admin-panel/clients.html` | Load `client-type-display.js` before `ClientsDataManager.js` + cache-bust |
| `apps/admin-panel/clients-fluent.html` | Same |

## Behavioral changes

> ⚠️ Per `apps/admin-panel/CLAUDE.md`: this is a behavioral change, not a UI tweak.

| Scenario | Before | After |
|---|---|---|
| Pure-fixed client | "שעות" (wrong) | "פיקס" |
| Hours-only client | "שעות" | "שעות" (same) |
| Mixed hours+fixed client (Binyamingold) | "שעות" | "מעורב" |
| All-completed services client | "שעות" | "ללא" |
| Type badge tooltip | Plain badge | Hover reveals per-service breakdown |
| CSV export mixed client | "שעות" | "שעות + פיקס" |
| Hours warning icon | hours clients only | hours + mixed clients |

## Verification

```
Test Files  9 passed (9)
Tests       193 passed | 2 skipped (195 total)
```

- 30 new unit tests for `ClientTypeDisplay`.
- All edge cases covered: empty services, completed-only, hours-only, fixed-only, mixed, legal_procedure variants, XSS in service names.
- `typeFilter` logic unchanged — old filter values (`'hours'`, `'fixed'`) still match the new computed `kind`.

## Test plan

- [x] Unit tests pass (`npm test`) — 195 total
- [x] Husky pre-commit hook passes (eslint + lint-staged)
- [ ] Manual DEV verification on https://main--admin-gh-law-office-system.netlify.app:
  - [ ] Binyamingold (2025996) shows "מעורב"
  - [ ] שלומי חי לחיאני (2026069) shows "פיקס"
  - [ ] Any hours-only client shows "שעות"
  - [ ] Hover over badge — tooltip lists services correctly
  - [ ] CSV export shows correct labels including "שעות + פיקס"
  - [ ] Type filter dropdown still works (existing values match new `kind`)
- [ ] Cache-bust verified in DEV (`?v=20260514-mixed` query strings)
- [ ] After DEV pass: merge to `production-stable` per CLAUDE.md flow
- [ ] PROD smoke test post-deploy

## Out of scope (follow-up PRs)

- `apps/admin-panel/js/managers/ReportGenerator.js` and `js/ui/ClientReportModal.js` still use legacy `client.type === 'hours' || ... || client.procedureType === ...` logic in several places.
- The legacy `client.procedureType` / `client.pricingType` fields are still written by the backend on creation; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)