### PR TITLE
fix(ci): remove e2e dependency from deploy-production (unblock 12 days of stuck fixes)

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -412,7 +412,12 @@ jobs:
   deploy-production:
     name: 🚀 Deploy to Production
     runs-on: ubuntu-latest
-    needs: [deploy-staging, e2e]
+    # E2E removed from needs: it has continue-on-error:true (broken UI selectors,
+    # tracked Phase 4) but GitHub Actions skips dependents when a needed job is
+    # cancelled by timeout — not failed. This caused 12 days of fixes (incl. #266
+    # calcClientAggregates) to not reach Firebase Functions PROD. Restore the gate
+    # only after E2E specs are rewritten.
+    needs: [deploy-staging]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     timeout-minutes: 20
 


### PR DESCRIPTION
## Bug

`deploy-production` job has `needs: [deploy-staging, e2e]`.

E2E specs reference old UI selectors (broken since #252). E2E job marked `continue-on-error: true` so failures don't block. BUT Playwright runs hit 20-min `timeout-minutes`, GitHub Actions marks the job **cancelled**, not failed. GitHub Actions **skips dependents on cancellation regardless of `continue-on-error`**.

## Impact

Every push to `main` since 2026-05-03 → `deploy-production` = **skipped**.

12 days of fixes have NOT reached Firebase Functions PROD:

| PR | Fix |
|----|-----|
| #254 | XSS escape in HTML escaping |
| #257 | ST.FIXED double-count in addTimeToTask_v2 |
| #260 | Trigger fallback warning + FIXED deduction tests |
| #263 | admin-report match legal_procedure stage entries |
| #264 | admin-report scope summary totals to stage |
| **#266** | **Unify calcClientAggregates + remove parallel write paths for isBlocked (root cause of historical blocked-client incidents)** |
| #267 | Admin table mixed type display |

Critical because the buggy duplicate `calcClientAggregates` is still live on PROD Cloud Functions. Running data reconciliation now would be re-corrupted by next admin write.

## Fix

Remove `e2e` from `needs:`. Keep `deploy-staging` as the gate — build, tests, lint, types, security all still block PROD deploy.

E2E gate to be restored once specs are rewritten (Phase 4).

## Test plan
- [ ] CI green on this PR
- [ ] Merge to main → verify `deploy-production` job runs (not skipped)
- [ ] Verify Firebase Functions PROD deploys successfully
- [ ] Verify hosting + firestore:rules deploy
- [ ] Smoke test PROD admin panel