### PR TITLE
fix(ci): install functions/node_modules before firebase deploy to PROD

### DIFF
--- a/.github/workflows/ci-cd-production.yml
+++ b/.github/workflows/ci-cd-production.yml
@@ -439,6 +439,13 @@ jobs:
       - name: 📦 Install Firebase Tools
         run: npm install -g firebase-tools@latest
 
+      # Functions deploy requires functions/node_modules present (firebase
+      # CLI needs to find firebase-functions package). Build artifacts only
+      # include user-app static files, so install Functions deps here.
+      - name: 📦 Install Functions Dependencies
+        working-directory: ./functions
+        run: npm ci --prefer-offline --no-audit
+
       - name: 🚀 Deploy to Firebase Production
         run: |
           echo "🚀 Deploying to Production..."


### PR DESCRIPTION
## Bug

After #269 unblocked the deploy gate, the very next main push exposed a latent CI bug:

```
⚠ functions: Couldn't find firebase-functions package in your source code.
Have you run 'npm install'?
Error: An unexpected error has occurred.
```

`deploy-production` exited with code 2.

## Root cause

`build-artifacts` only contains `apps/user-app/{dist,js,css,images}` + `index.html` + `firebase.json`. Functions source comes from the `actions/checkout@v4` step, but `functions/node_modules` is never installed in the deploy-production job. Firebase CLI requires those deps to discover and deploy functions.

## Why it was latent

CI `deploy-production` was skipped on every main push since 2026-05-03 (E2E cancellation gate, fixed in #269). Before that timespan, this code path was rarely exercised. `deploy-staging` works because it deploys `--only hosting` (no functions).

## Fix

Add `npm ci` step in `functions/` working-directory before firebase deploy. One step inserted, no other changes.

```yaml
- name: 📦 Install Functions Dependencies
  working-directory: ./functions
  run: npm ci --prefer-offline --no-audit
```

Uses `--prefer-offline --no-audit` to match the build job's npm install pattern.

## Test plan
- [ ] CI green on this PR
- [ ] Merge to main → verify `deploy-production` succeeds (not failure)
- [ ] Verify Firebase Functions PROD shows new revision (calcClientAggregates fix from #266)
- [ ] Verify firestore:rules + hosting deploy with functions
- [ ] Smoke test PROD admin panel — type display + isBlocked still rendering correctly

## Impact when merged

12 days of stuck Functions fixes (#254, #257, #260, #263, #264, #266, #267) will finally reach Firebase Functions PROD. Most importantly: #266 calcClientAggregates root cause fix.