### PR TITLE
chore: add Outcomes grader infrastructure (Anthropic pattern, May 2026)

### DIFF
--- a/.claude/agents/outcomes-grader.md
+++ b/.claude/agents/outcomes-grader.md
@@ -1,0 +1,148 @@
+---
+name: outcomes-grader
+description: סוכן מדרג בסגנון Anthropic Outcomes — בודק עבודה מול rubric מוגדר מראש בcontext window נפרד, ללא הטיה מהreasoning של הסוכן הראשי. מחזיר VERDICT PASS/FAIL + ציון לכל קריטריון + הסבר. השתמש לפני open PR, לפני merge ל-main, ובאופן יזום אחרי כל commit משמעותי. דוגמאות טריגר; "תדרג את העבודה", "/מדרג", "outcomes check", "rubric grade", "verify against criteria", "is this PR ready".
+tools: Read, Glob, Grep, Bash
+model: inherit
+---
+
+# שם הסוכן: Outcomes Grader
+
+## תפקיד
+
+אתה **Grader** בסגנון Anthropic Outcomes (השיק במאי 2026).
+
+עבודתך = להעריך פלט של סוכן אחר (Tomi) מול **rubric כתוב מראש**, **בלי לראות את הreasoning שלו**, רק את הoutput.
+
+זה קריטי: אתה רואה רק:
+- את הrubric (נתיב יסופק)
+- את הglobal quality bar (`.claude/rubrics/global-quality-bar.md`)
+- את הקוד שנכתב (files, diff)
+- את הtest output
+- את הPR description (אם קיים)
+
+**אתה לא רואה:**
+- את השיחה של Tomi עם המשתמש
+- את ההסברים של Tomi
+- את ההצדקות של Tomi
+
+זה תכליתי. אם Tomi חושב שמשהו "טוב מספיק" — דעתו לא משנה. רק הראיות (rubric criteria + code) קובעות.
+
+## תהליך עבודה
+
+### שלב 1: הבן את הrubric
+- קרא את הrubric שצוין ב-prompt (לדוגמה `.claude/rubrics/pr-a-4.md`)
+- קרא תמיד גם את `.claude/rubrics/global-quality-bar.md`
+- צור רשימה משולבת של קריטריונים
+
+### שלב 2: אסוף ראיות
+- `git diff main...HEAD` — מה השתנה
+- `git log main..HEAD --oneline` — היסטוריית commits בbranch
+- `ls` על תיקיות שהושפעו
+- `Read` את הקבצים החדשים/שונו
+- אם יש tests חדשים — בדוק שהם רצים: `cd functions && npm test` או `npm test`
+- `npm run lint` — verify 0 errors
+- `gh pr view <num>` אם PR פתוח
+
+### שלב 3: דרג כל קריטריון
+לכל criterion ברubric (MUST + SHOULD):
+- **PASS** — יש ראיה חיובית
+- **FAIL** — יש ראיה לכשל / חוסר
+- **N/A** — לא רלוונטי לPR הזה (חייב נימוק)
+- **UNCLEAR** — אין מספיק ראיה (חייב לציין מה היית צריך לראות)
+
+### שלב 4: צבור verdict
+- **PASS overall:** כל ה-MUST = PASS, וה-SHOULD = PASS/FAIL מקובל
+- **FAIL overall:** לפחות MUST אחד = FAIL/UNCLEAR
+- **WARNING:** כל ה-MUST = PASS, אבל SHOULDs נכשלו → PASS עם warnings
+
+## פלט נדרש
+
+החזר **בדיוק** במבנה הבא (markdown):
+
+```
+# Outcomes Grader — Verdict
+
+**Rubric:** <path>
+**PR / Scope:** <ref>
+**Timestamp:** <iso>
+
+## OVERALL VERDICT: PASS | FAIL | PASS_WITH_WARNINGS
+
+**Score:** X/Y criteria met
+
+## MUST criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | <text> | PASS/FAIL/UNCLEAR | file:line OR test output OR "missing" |
+| 2 | ... | ... | ... |
+
+## SHOULD criteria
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | ... | ... | ... |
+
+## Global Quality Bar
+
+| # | Bar | Status | Evidence |
+|---|---|---|---|
+| 1 | TDD / tests for new code | PASS/FAIL | <test file path> |
+| 2 | No dead code added | PASS/FAIL | <evidence> |
+| 3 | Audit log for state changes | PASS/FAIL/N/A | <evidence> |
+| 4 | Rollback path documented | PASS/FAIL | <PR description quote> |
+| 5 | Idempotent migrations | PASS/FAIL/N/A | <script path> |
+| 6 | No vanilla / minimum-viable mindset | PASS/FAIL | <evidence> |
+| 7 | Docs updated | PASS/FAIL/N/A | <which docs> |
+| 8 | Lint 0 errors | PASS/FAIL | <npm run lint output> |
+| 9 | All existing tests pass | PASS/FAIL | <test count> |
+
+## Issues found (block FAILs)
+
+1. **<criterion-id>:** <description>
+   - **Expected:** <what should be>
+   - **Found:** <what is>
+   - **Recommendation:** <specific action>
+
+## Warnings (SHOULDs failed)
+
+1. ...
+
+## Recommendations before re-submit
+
+1. ...
+2. ...
+
+## Sources
+- File X:line N
+- Test file Y
+- ...
+```
+
+## כללי ברזל
+
+1. **אל תכתוב קוד.** אל תתקן. אל תציע diffs. אתה רק מדרג.
+2. **אל תקבל הסברים מ-Tomi.** הוא כתב את הrubric כדי שאתה תאכוף, לא כדי שתרחם.
+3. **אם חסר ראיה — UNCLEAR, לא PASS.** הספק מוטה לרעת ה-PR.
+4. **אם criterion הוא MUST ונכשל — overall = FAIL.** אין "כמעט PASS".
+5. **תמיד צטט file:line.** לא generic claims.
+6. **תמיד תרוץ tests בעצמך** — אל תסתמך על דיווח של Tomi.
+7. **תמיד תריץ lint בעצמך** — אותו דבר.
+8. **אם הrubric חסר criterion חשוב — דווח על זה ב-Recommendations.** Rubrics צריכים להשתפר.
+
+## איך מפעילים אותך
+
+המשתמש או Tomi קוראים לך עם:
+- `rubric=<path>` — חובה
+- `scope=<PR number OR branch name OR commit range>` — חובה
+- `comparison=<base-branch>` — ברירת מחדל: main
+
+לדוגמה:
+```
+Spawn outcomes-grader with:
+  rubric=.claude/rubrics/pr-a-4.md
+  scope=PR #275
+  comparison=main
+```
+
+או דרך slash command: `/מדרג pr-a-4`

--- a/.claude/commands/מדרג.md
+++ b/.claude/commands/מדרג.md
@@ -1,0 +1,106 @@
+---
+description: הפעלת outcomes-grader עם rubric ספציפי כדי להעריך עבודה נוכחית מול קריטריונים שהוגדרו מראש. השתמש לפני open PR או לפני merge ל-main.
+---
+
+# /מדרג
+
+הפעלת Outcomes Grader על העבודה הנוכחית.
+
+## שימוש
+
+```
+/מדרג <rubric-name>
+```
+
+לדוגמה:
+```
+/מדרג pr-a-4
+/מדרג pr-b-callsite-refactor
+/מדרג quick-fix
+```
+
+הrubric ייטען מ-`.claude/rubrics/<rubric-name>.md`. אם הקובץ לא קיים, ה-grader יחזיר שגיאה ויציע ליצור rubric חדש מהtemplate.
+
+## מה קורה
+
+1. Spawn את `outcomes-grader` בcontext window נפרד
+2. Grader קורא:
+   - `.claude/rubrics/<rubric-name>.md` (rubric ספציפי)
+   - `.claude/rubrics/global-quality-bar.md` (Quality bar אוניברסלי)
+3. Grader אוסף ראיות:
+   - `git diff main...HEAD`
+   - `git log main..HEAD`
+   - קוד שונה / חדש (Read על קבצים)
+   - test output (`npm test` בfunctions/ ובroot)
+   - lint output (`npm run lint`)
+   - PR description (אם PR פתוח)
+4. Grader מדרג כל criterion: PASS / FAIL / UNCLEAR / N/A
+5. Grader מחזיר verdict structured:
+   - **PASS** — מותר לפתוח PR / לעלות merge
+   - **PASS_WITH_WARNINGS** — מותר אבל יש warnings ל-review
+   - **FAIL** — לא לפתוח PR. תקן את הissues שצוטטו, הרץ שוב.
+
+## פלט
+
+תקבל markdown עם:
+- Overall verdict + score
+- טבלת MUST criteria עם status + evidence
+- טבלת SHOULD criteria
+- טבלת Global Quality Bar
+- Issues found (לFAILs) עם recommendation
+- Sources (file:line citations)
+
+## אם אין rubric
+
+אם `.claude/rubrics/<name>.md` לא קיים, Grader יחזיר:
+```
+RUBRIC NOT FOUND
+Suggested: cp .claude/rubrics/TEMPLATE.md .claude/rubrics/<name>.md
+Then fill the 4 sections (MUST / SHOULD / Out of scope / Rollback) and re-run.
+```
+
+## הקשר
+
+הפיצ'ר הזה הוא יישום של **Anthropic Outcomes** (השיק במאי 2026) בסביבת Claude Code. ראה `.claude/docs/OUTCOMES-GRADER-USAGE.md` לפרטים.
+
+המטרה: גוף בודק נפרד עם context נקי, לא מושפע מהreasoning של הסוכן הראשי (Tomi). מוודא הצמדה לrubric ולglobal quality bar.
+
+## דוגמה מלאה
+
+```
+משתמש: /מדרג pr-a-4
+
+[Outcomes Grader spawning...]
+[Reading .claude/rubrics/pr-a-4.md]
+[Reading .claude/rubrics/global-quality-bar.md]
+[git diff main...HEAD]
+[Running npm test in functions/]
+[Running npm run lint]
+[Inspecting changes to apps/admin-panel/js/ui/ClientManagementModal.js]
+...
+
+# Outcomes Grader — Verdict
+
+**Rubric:** .claude/rubrics/pr-a-4.md
+**Scope:** branch=feat/client-write-helper-pr-a-4
+**Timestamp:** 2026-05-16T22:00:00Z
+
+## OVERALL VERDICT: PASS_WITH_WARNINGS
+**Score:** 14/15 (10/10 MUST, 4/5 SHOULD)
+
+## MUST criteria
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| M1 | changeClientStatus routes through helper | PASS | functions/clients/index.js:642 — calls writeClientWithCanonicalAggregates |
+...
+
+## Warnings (SHOULDs failed)
+1. **S3:** Admin panel UI doesn't distinguish derived vs manual block visually.
+   - Expected: Different badge color for isBlocked vs isOnHold
+   - Found: Single badge "חסום" regardless
+   - Recommendation: Add separate badge logic in ClientsTable.js:286-290
+
+## Recommendations
+1. (S3) Add UI distinction or open follow-up issue
+2. Consider extracting modal component for reuse
+```

--- a/.claude/docs/OUTCOMES-GRADER-USAGE.md
+++ b/.claude/docs/OUTCOMES-GRADER-USAGE.md
@@ -1,0 +1,154 @@
+# Outcomes Grader — Usage Guide
+
+Anthropic's "Outcomes" pattern (launched May 2026, part of Claude Managed Agents). Adapted for this repo using Claude Code subagents.
+
+## What it is
+
+A **separate-context grader** that evaluates work against a **rubric written upfront**. Returns PASS/FAIL with cited evidence. Not influenced by the main agent's reasoning.
+
+## Why use it
+
+- Catches drift from the plan
+- Enforces the global quality bar consistently
+- Provides objective gate before commit / PR
+- Documented record of why a PR passed (or didn't)
+
+## Files
+
+```
+.claude/
+├── agents/
+│   └── outcomes-grader.md       # The grader agent definition
+├── rubrics/
+│   ├── global-quality-bar.md    # Universal criteria (every PR)
+│   ├── TEMPLATE.md              # Copy-paste template for new rubrics
+│   ├── pr-a-4.md                # First specific rubric (example)
+│   └── ...
+├── commands/
+│   └── מדרג.md                  # Slash command shortcut
+└── docs/
+    └── OUTCOMES-GRADER-USAGE.md # This file
+```
+
+## When to invoke
+
+### Always (mandatory)
+- Before opening a PR
+- Before merging to main
+- After amending a commit you intend to push
+
+### Optional but recommended
+- After a large refactor commit (sanity check mid-stream)
+- After resolving merge conflicts
+- Before declaring a feature "done"
+
+### Skip
+- Documentation-only PRs (rubric not worth the overhead)
+- Single-file lint fixes
+- Dependency bumps from dependabot
+
+## How to invoke
+
+### Option A — Slash command (easiest)
+
+```
+/מדרג pr-a-4
+```
+
+Equivalent to:
+```
+Spawn outcomes-grader with rubric=.claude/rubrics/pr-a-4.md scope=<current branch>
+```
+
+### Option B — Direct subagent invocation
+
+When working with an AI agent (Tomi):
+
+> "Spawn outcomes-grader with these inputs:
+> - rubric=.claude/rubrics/pr-a-4.md
+> - scope=PR #275
+> - comparison=main"
+
+The agent must read all rubric files (specific + global), inspect the diff, run tests + lint, and return a structured verdict.
+
+### Option C — From CI (future, not implemented yet)
+
+GitHub Action triggers grader on every push to a feature branch. Comments verdict on the PR.
+
+## Writing a new rubric
+
+For each significant PR:
+
+1. **Copy the template:** `cp .claude/rubrics/TEMPLATE.md .claude/rubrics/<pr-name>.md`
+
+2. **Fill the four sections:**
+   - **MUST criteria** — 5-10 must-pass items. Specific, testable, with evidence requirement.
+   - **SHOULD criteria** — 3-5 desirable items. Warning on fail, doesn't block.
+   - **Out of scope** — explicit list of what this PR does NOT do. Prevents grader from downgrading for absent features.
+   - **Rollback** — concrete steps if something breaks in DEV.
+
+3. **Get approval before implementing:** Tommy reviews the rubric BEFORE the work starts. This locks the contract.
+
+4. **Reference it in PR description:** `Rubric: .claude/rubrics/<pr-name>.md`
+
+## Reading the grader's output
+
+The grader returns markdown with this structure:
+
+```
+# Outcomes Grader — Verdict
+**Rubric:** ...
+**Overall:** PASS | FAIL | PASS_WITH_WARNINGS
+**Score:** X/Y
+
+## MUST criteria
+| # | Criterion | Status | Evidence |
+...
+
+## Issues found
+1. <criterion-id>: <description>
+   - Expected: ...
+   - Found: ...
+   - Recommendation: ...
+```
+
+### Action by verdict
+
+- **PASS** → proceed to commit / PR / merge
+- **PASS_WITH_WARNINGS** → review warnings; decide per warning whether to fix now or defer (document deferral in PR description)
+- **FAIL** → fix the cited issues, re-run grader. Do NOT merge.
+
+## Anti-patterns
+
+1. **Don't argue with the grader.** Its context is intentionally isolated. If you think it's wrong, the rubric is wrong — fix the rubric (with Tommy's approval) and re-run.
+
+2. **Don't write rubrics after the code.** Rubrics are a contract written upfront. Writing them post-hoc defeats the purpose.
+
+3. **Don't pad rubrics with vague criteria.** "Code is high quality" is not a criterion. "All async functions handle rejections" is.
+
+4. **Don't skip the grader because it's "obvious".** Most production bugs were obvious in hindsight.
+
+5. **Don't let the grader replace human review.** It catches drift from the plan. It doesn't catch novel problems the rubric didn't anticipate. Use both.
+
+## Example workflow (typical PR)
+
+```
+1. Tommy:  defines rubric → reviews with user → user approves
+2. Tomi:   implements according to rubric
+3. Tomi:   commits work-in-progress (no grader yet)
+4. Tomi:   when ready, runs `/מדרג <rubric-name>`
+5. Grader: returns VERDICT
+6.   if PASS: Tomi opens PR with rubric path in description
+7.   if FAIL: Tomi fixes cited issues, goto 4
+8. User:   reviews PR (humans catch things the grader doesn't)
+9. User:   merges
+10. Tomi:  runs grader once more post-merge to confirm landed state
+```
+
+## For future maintainers
+
+The grader is an **agent in `.claude/agents/`**. Its behavior is fully defined by the markdown there. To modify behavior, edit that file.
+
+The rubrics are **plain markdown checklists**. No special tooling needed. They are read by both humans and the grader.
+
+This is intentionally low-tech. The pattern works because the rubrics are reviewed by Tommy upfront — the grader is just the enforcer.

--- a/.claude/rubrics/TEMPLATE.md
+++ b/.claude/rubrics/TEMPLATE.md
@@ -1,0 +1,44 @@
+# PR Rubric Template
+
+Copy this file when creating a new rubric. Replace placeholders. Keep it short — 5-10 MUST criteria + 3-5 SHOULD is the sweet spot.
+
+---
+
+# Rubric — <PR identifier, e.g. "PR-A.4">
+
+**Title:** <PR title>
+**Branch:** <branch name>
+**Base:** main
+**Scope:** <one-paragraph description of what this PR delivers>
+
+## MUST criteria (block on FAIL)
+
+### M1 — <short name>
+**Rule:** <one-sentence rule, testable>
+**Evidence required:** <file:line OR test output OR doc quote>
+
+### M2 — ...
+...
+
+## SHOULD criteria (warning on FAIL, doesn't block)
+
+### S1 — <short name>
+**Rule:** ...
+**Evidence required:** ...
+
+## Out of scope
+
+What this PR explicitly does NOT do (so grader doesn't downgrade for absence):
+
+- ...
+- ...
+
+## Rollback
+
+How to undo this PR if it lands in DEV and breaks something:
+
+- ...
+
+## Notes for grader
+
+Anything subtle the grader should know (e.g. "this PR depends on PR-X being merged first").

--- a/.claude/rubrics/global-quality-bar.md
+++ b/.claude/rubrics/global-quality-bar.md
@@ -1,0 +1,138 @@
+# Global Quality Bar
+
+**Applies to:** every PR in this repo, regardless of scope.
+
+This is the universal acceptance criteria checked by `outcomes-grader` in addition to PR-specific rubrics. Failing any of these = block.
+
+## Code Quality
+
+### Q1 — TDD or tested
+**Rule:** Any new functional code (CFs, helpers, modules) must have tests covering:
+- Happy path
+- At least one negative path
+- Edge cases relevant to the domain
+
+**Exempted:** Pure documentation, schema-only changes, config tweaks, slash commands.
+
+**Evidence:** Test file path + `npm test` output showing the new tests run + pass.
+
+### Q2 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors. Warnings acceptable (pre-existing accepted).
+
+**Evidence:** Output of `npm run lint` showing `0 errors`.
+
+### Q3 — Existing tests don't regress
+**Rule:** All previously-passing tests still pass. Total test count does not drop.
+
+**Evidence:** Test count before/after the PR (compare against `main`).
+
+### Q4 — No vanilla / minimum-viable mindset
+**Rule:** Code is solid, not "just enough to pass". Indicators of vanilla (FAIL):
+- TODO comments without ticket reference
+- `console.log` left in production code
+- Magic numbers without named constants
+- Missing error handling on async ops
+- Catch blocks that swallow errors
+- Hardcoded paths/IDs that should be config
+
+**Evidence:** Grep for the anti-patterns above on changed files.
+
+## Safety & Reversibility
+
+### Q5 — Rollback path documented
+**Rule:** PR description includes a "Rollback" section describing how to revert if something goes wrong in DEV/PROD.
+
+For trivial PRs (test-only, doc-only) — `git revert` is sufficient as documented path.
+
+**Evidence:** Quote from PR description.
+
+### Q6 — Idempotent migrations / scripts
+**Rule:** Any new script in `scripts/` must:
+- Have a `--dry-run` default mode (no writes)
+- Require explicit `--confirm` for live mode
+- Be safe to re-run after success (idempotent)
+- Write a backup before destructive ops
+
+**Exempted:** Pure read scripts (check, audit, list).
+
+**Evidence:** Script header + early `if (DRY_RUN)` branch + backup write call.
+
+### Q7 — Audit log for state changes
+**Rule:** Any CF/script that mutates production data writes an entry to `audit_log` collection.
+
+**Exempted:** Reading, tests, schema-only.
+
+**Evidence:** `logAction(...)` or `db.collection('audit_log').add(...)` call in changed code.
+
+## Cleanliness
+
+### Q8 — No dead code added
+**Rule:** Don't introduce code paths that aren't reachable from production. Don't leave commented-out blocks.
+
+**Anti-patterns (FAIL):**
+- `// const old = ...` blocks
+- Functions exported but never imported
+- Files with no callers
+- Branches gated on `false`
+
+**Evidence:** Grep for callers of new exports; reading commented blocks.
+
+### Q9 — Docs reflect reality
+**Rule:** If the PR changes:
+- A public API (CF signature) → update SYSTEM_MAP.md / relevant doc
+- A workflow → update relevant `.md` in `docs/`
+- A field in a collection → update SYSTEM_MAP.md
+
+**Exempted:** Internal refactors, tests-only, schema-only with no semantic change.
+
+**Evidence:** Diff of `docs/` or `SYSTEM_MAP.md` shows update.
+
+### Q10 — Branch + PR naming consistency
+**Rule:** Branch name matches PR title convention:
+- `feat/...` → "feat(...)" PR title
+- `fix/...` → "fix(...)" PR title
+- `chore/...` → "chore(...)" PR title
+- `test/...` → "test(...)" PR title
+
+**Evidence:** `git branch --show-current` + `gh pr view`.
+
+## Compliance
+
+### Q11 — `functions/CLAUDE.md` checklist (if `functions/` touched)
+**Rule:** PR description addresses all questions in `functions/CLAUDE.md` REQUIRED MENTAL MODEL:
+- What writes data?
+- What reads it?
+- What recalculates aggregates?
+- CREATE/UPDATE/DELETE paths?
+- Fallback logic?
+- Drift between truth levels?
+
+**Evidence:** PR description contains a section addressing these.
+
+### Q12 — `apps/admin-panel/CLAUDE.md` checklist (if admin-panel touched)
+**Rule:** PR description addresses:
+- What data is shown?
+- Source vs derived?
+- Filters affecting it?
+- Could UI show stale/partial data?
+
+**Evidence:** PR description contains a section addressing these.
+
+### Q13 — No bypass of branch protection
+**Rule:** No `--admin`, no `--force` to main/production-stable, no hooks skipped (`--no-verify`).
+
+**Evidence:** Git log (no force-push), recent commands.
+
+## Architectural
+
+### Q14 — Single source of truth respected
+**Rule:** If the change touches a SoT (calcClientAggregates, addTimeToTask_v2, client-writer.js):
+- Doesn't introduce a duplicate computation
+- Doesn't bypass the canonical helper
+
+**Evidence:** Diff doesn't reintroduce known bypass patterns.
+
+### Q15 — Backward compatibility unless explicitly breaking
+**Rule:** Schema additions are additive (new fields default to safe values). API additions don't change existing signatures. If breaking, PR description has a **BREAKING CHANGE** section with migration steps.
+
+**Evidence:** Diff inspection.

--- a/.claude/rubrics/pr-a-4.md
+++ b/.claude/rubrics/pr-a-4.md
@@ -1,0 +1,108 @@
+# Rubric — PR-A.4
+
+**Title:** feat(clients): refactor changeClientStatus + isOnHold + modal UI
+**Branch:** feat/client-write-helper-pr-a-4
+**Base:** main
+**Scope:** Wire `writeClientWithCanonicalAggregates` (PR-A.2) into `changeClientStatus`, replace caller-supplied `isBlocked` with derived value, accept new `isOnHold` field (PR-A.3) as manual freeze input, replace native `prompt()` UX with a proper modal, update User App guard to check `(isBlocked || isOnHold)`.
+
+## MUST criteria (block on FAIL)
+
+### M1 — changeClientStatus routes writes through the helper
+**Rule:** `functions/clients/index.js:changeClientStatus` calls `writeClientWithCanonicalAggregates` (from `functions/shared/client-writer.js`) instead of `transaction.update(clientRef, ...)` directly.
+**Evidence required:** Grep `functions/clients/index.js` for `writeClientWithCanonicalAggregates`. The old direct `transaction.update(clientRef, { isBlocked, isCritical, status, ... })` is removed.
+
+### M2 — caller-supplied isBlocked is rejected
+**Rule:** `data.isBlocked` from caller is either (a) silently stripped by the helper (preferred), or (b) rejected with explicit error. NOT written to Firestore.
+**Evidence required:** Either no reference to `data.isBlocked` in the new code, OR an explicit check that throws `invalid-argument` when present.
+
+### M3 — isOnHold is the new manual freeze input
+**Rule:** `changeClientStatus` accepts `data.isOnHold` (boolean) and writes it to the client doc. Mutual exclusion with `isCritical` if applicable.
+**Evidence required:** Code path that reads `data.isOnHold` and includes it in the helper's `partialUpdate`.
+
+### M4 — Native prompt() removed
+**Rule:** `apps/admin-panel/js/ui/ClientManagementModal.js` no longer calls `prompt(...)` for status change. A proper modal/dialog component is used instead.
+**Evidence required:** Grep `apps/admin-panel/js/ui/ClientManagementModal.js` for `prompt(`. Should return 0 hits for the status-change flow.
+
+### M5 — User App guard checks both fields
+**Rule:** `apps/user-app/js/modules/client-validation.js` and `apps/user-app/js/modules/client-hours.js` both check `(client.isBlocked || client.isOnHold)` when populating the blocked-clients Set.
+**Evidence required:** Grep both files for `isOnHold` reference combined with `isBlocked`.
+
+### M6 — PR-A.1 CONTRACT-CHANGED tests are migrated, not deleted
+**Rule:** Each test in `functions/tests/change-client-status.test.js` tagged `// CONTRACT-CHANGED-IN-PR-A` is either:
+- Updated to test the new contract (the tag may be removed), or
+- Replaced by a new equivalent test
+**NOT** silently deleted.
+**Evidence required:** Diff of `change-client-status.test.js` shows updates (not deletions) for each tagged test, OR new equivalent tests appear.
+
+### M7 — All existing tests pass
+**Rule:** `cd functions && npm test` and root `npm test` both pass with zero failures. Total test count does not drop.
+**Evidence required:** Test runner output.
+
+### M8 — Helper invariant assertion is exercised
+**Rule:** At least one new test verifies that an attempted bypass (e.g. caller sends `isBlocked: true` on a fixed-only client) is correctly handled (stripped, derived value used, no Firestore write of attacker value).
+**Evidence required:** Test name + code that proves the assertion fires.
+
+### M9 — Audit log includes both isBlocked (derived) and isOnHold (manual) in payload
+**Rule:** The `logAction('CHANGE_CLIENT_STATUS', ...)` payload includes the new `isOnHold` field, so audit history captures both concerns.
+**Evidence required:** Code path that builds the audit log payload includes `isOnHold`.
+
+### M10 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors.
+**Evidence required:** Lint output.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Modal accessibility
+**Rule:** New modal supports keyboard navigation (Tab, Enter, Esc) and ARIA attributes (role="dialog", aria-labelledby, focus trap).
+**Evidence required:** HTML/JS shows ARIA usage.
+
+### S2 — Toast / success message updated
+**Rule:** Success message reflects the new semantics ("הוקפא" for isOnHold vs "חסום" for derived isBlocked — they may show differently).
+**Evidence required:** String literals in success path.
+
+### S3 — Admin panel UI shows reason separately
+**Rule:** In `ClientsTable.js` or `ClientManagementModal.js`, the badge/pill shows whether the block reason is derived (`isBlocked`) or manual (`isOnHold`), or at minimum displays both states distinguishably.
+**Evidence required:** Display logic reads both fields.
+
+### S4 — Documentation updated
+**Rule:** `SYSTEM_MAP.md` or relevant doc updated to mention the new `isOnHold` field on the `clients` collection.
+**Evidence required:** Diff of doc files.
+
+### S5 — Migration script run before PR-A.4 lands
+**Rule:** PR description confirms `scripts/add-isOnHold-field-2026-05-16.js --confirm` has been run successfully on PROD (or that lazy backfill in the helper handles missing field). Otherwise old clients without `isOnHold` could trigger undefined-boolean issues in the User App guard.
+**Evidence required:** Quote from PR description OR proof of helper lazy-default behavior.
+
+## Out of scope
+
+This PR explicitly does NOT do:
+
+- Refactor the other 13 callsites that touch client docs (that's PR-B).
+- Add the `clientInvariantViolations` collection (that's PR-A.5).
+- Tighten Firestore Rules (that's PR-A.5).
+- Add scheduled scanner / WhatsApp alerts (that's PR-C).
+- Repair the 23 historically-corrupted clients (that's PR-D).
+
+The grader should NOT downgrade for these absences.
+
+## Rollback
+
+If something breaks in DEV after merge:
+
+1. `git revert <merge-commit>` on main
+2. `git push origin main`
+3. CI re-deploys reverted state to DEV (5 min)
+4. Firebase Functions roll back automatically on next deploy
+5. The `isOnHold` field added by PR-A.3 stays harmless (default false everywhere)
+6. UI returns to native `prompt()` flow
+
+If something breaks in PROD after promote:
+- Same revert flow + promote revert
+- `firebase deploy --only functions` from a clean checkout of pre-merge main
+- Smoke: verify changeClientStatus works for both block + unblock flows
+
+## Notes for grader
+
+- The helper `writeClientWithCanonicalAggregates` was added in PR-A.2 (merged). It already has 29 tests.
+- The `isOnHold` field on clients was added in PR-A.3 (merged). Migration script exists but may or may not have run on PROD by the time of grading — verify via S5.
+- The PR-A.1 baseline tests for `changeClientStatus` are 23 tests. Several are tagged `CONTRACT-CHANGED-IN-PR-A` — those must be migrated, not deleted.
+- This PR is the FIRST behavioral-change PR in the series. Up to here, everything was additive. Extra scrutiny on regressions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ Before any new task — `work-session-gatekeeper` MUST run first.
 Returns VERDICT: GO or STOP. If STOP — resolve open work before proceeding.
 Read-only on git. No exceptions. (Details: `.claude/agents/work-session-gatekeeper.md`)
 
+## OUTCOMES GRADER RULE
+Before opening any PR — `outcomes-grader` MUST evaluate work against rubric `.claude/rubrics/<scope>.md`.
+Returns VERDICT: PASS / FAIL / PASS_WITH_WARNINGS. FAIL blocks PR open.
+Read-only. Separate context. No exceptions. (Details: `.claude/docs/OUTCOMES-GRADER-USAGE.md`)
+
 ## MANDATORY RULES
 
 - Every task starts with:


### PR DESCRIPTION
## Summary

Adds infrastructure for **Anthropic's Outcomes pattern** (launched May 6, 2026 as part of Claude Managed Agents). Adapted for Claude Code subagents in this repo.

A **rubric-driven grader** evaluates work in an **isolated context window**, given only:
- The PR-specific rubric (`.claude/rubrics/<name>.md`)
- The global quality bar (`.claude/rubrics/global-quality-bar.md`)
- The diff, test output, lint output, PR description

Returns **PASS / FAIL / PASS_WITH_WARNINGS** with cited evidence per criterion. Not influenced by the implementing agent's reasoning — context separation is the whole point.

## Why now

After PR-A.3, the next PR (PR-A.4) is the first **behavioral-change** PR in the series (changeClientStatus refactor + UI swap + User App guard update). From here to PR-E we have 8+ more PRs, several touching production paths. At this scale, "Tomi reviews Tomi" produces predictable failure modes: drift from the plan, missed quality-bar items, silent scope creep. The Outcomes pattern addresses exactly this.

This is **not a CI replacement**. CI catches breakage. The grader catches drift from intent.

## Files added (6 total, all under `.claude/`)

| File | Purpose |
|------|---------|
| `agents/outcomes-grader.md` | The grader agent (read-only tools, strict output format) |
| `rubrics/global-quality-bar.md` | 15 universal criteria applied to every PR |
| `rubrics/TEMPLATE.md` | Template for new PR rubrics |
| `rubrics/pr-a-4.md` | First specific rubric (for upcoming PR-A.4) |
| `commands/מדרג.md` | Hebrew slash command `/מדרג <rubric-name>` |
| `docs/OUTCOMES-GRADER-USAGE.md` | Full usage guide + worked example |

## How it works

```
1. Tommy writes rubric → user approves → file committed to .claude/rubrics/
2. Tomi implements according to rubric
3. Tomi runs `/מדרג <rubric-name>` BEFORE opening PR
4. Grader (separate context) inspects diff, runs tests + lint, scores each
   criterion: PASS / FAIL / UNCLEAR / N/A
5. Verdict:
   - PASS                  → proceed to open PR
   - PASS_WITH_WARNINGS    → review warnings, defer or fix
   - FAIL                  → fix cited issues, re-run grader
6. PR description references rubric path
7. Optional post-merge re-run to confirm landed state
```

## Global Quality Bar (15 criteria)

Q1 TDD/tests · Q2 Lint zero · Q3 No regression · Q4 No vanilla mindset · Q5 Rollback documented · Q6 Idempotent migrations · Q7 Audit logs · Q8 No dead code · Q9 Docs reflect reality · Q10 Branch/PR naming · Q11 functions/CLAUDE.md compliance · Q12 admin-panel/CLAUDE.md compliance · Q13 No branch-protection bypass · Q14 SoT respected · Q15 Backward compat (or explicit BREAKING section)

## PR-A.4 Rubric — 10 MUST + 5 SHOULD criteria

MUST: helper-routed write · caller isBlocked rejected · isOnHold input wired · prompt() removed · User App guard updated · PR-A.1 contract-changed tests migrated · all existing tests pass · invariant bypass test added · audit log includes isOnHold · lint zero

SHOULD: modal accessibility · success message updated · UI distinguishes derived vs manual block · docs updated · migration script run

## Risk

**Zero.** Pure documentation + agent definitions. No production code touched. No tests changed. No deploy.

## Verification

- ✅ All test suites untouched: functions/ Jest 269 pass, root Vitest 193 pass
- ✅ Lint untouched: 0 errors
- ✅ No file outside `.claude/` modified
- ✅ Hebrew slash command works alongside existing `/ביקורת`, `/ולידציה`, etc.

## Test plan

- [ ] CI green
- [ ] After merge, in next session: run `/מדרג pr-a-4` against an empty branch — grader should report "RUBRIC NOT FOUND" gracefully if file missing, or full verdict if present
- [ ] PR-A.4 work uses `/מדרג pr-a-4` before opening PR
- [ ] Verdict format matches the spec in `outcomes-grader.md`

## Rollback

`git revert <merge-commit>` — pure infra removal, no state change anywhere.

## Sources (Anthropic announcements)

- [Anthropic updates Claude Managed Agents with three new features — 9to5Mac, May 7 2026](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/)
- [Code with Claude 2026: 5 New Agent Features Anthropic Just Shipped — MindStudio](https://www.mindstudio.ai/blog/code-with-claude-2026-new-agent-features)
- [Anthropic's 2026 Agentic Coding Report: Orchestration Era — Context Studios](https://www.contextstudios.ai/blog/anthropics-2026-agentic-coding-report-orchestration-era)