### PR TITLE
feat(clients): wire writeClientWithCanonicalAggregates + isOnHold end-to-end (PR-A.4)

### DIFF
--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -436,8 +436,8 @@
     <!-- Data Managers (Required for Fluent Components) -->
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager -->
     <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
-    <script src="js/managers/ClientsDataManager.js?v=20260514-mixed"></script>
-    <script src="js/ui/ClientsTable.js?v=20260514-mixed"></script>
+    <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
+    <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
 

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -576,12 +576,12 @@
     <!-- ===== Clients Management Scripts ===== -->
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager (used by .loadClients) -->
     <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
-    <script src="js/managers/ClientsDataManager.js?v=20260514-mixed"></script>
+    <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
     <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
-    <script src="js/ui/ClientManagementModal.js?v=20251127-FINAL"></script>
-    <script src="js/ui/ClientsTable.js?v=20260514-mixed"></script>
+    <script src="js/ui/ClientManagementModal.js?v=20260516-isOnHold"></script>
+    <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
 
     <!-- ===== Shared Components ===== -->
     <script src="js/ui/Notifications.js?v=20251123v1"></script>

--- a/apps/admin-panel/js/managers/ClientsDataManager.js
+++ b/apps/admin-panel/js/managers/ClientsDataManager.js
@@ -212,6 +212,9 @@
                             typeDisplay: typeDisplay,  // ← full object with label/icon/breakdown for UI
                             isBlocked: clientData.isBlocked || false,
                             isCritical: clientData.isCritical || false,
+                            // PR-A.4 (2026-05-16): manual freeze flag, orthogonal to derived isBlocked.
+                            // === true coerces missing field (pre-migration clients) to false safely.
+                            isOnHold: clientData.isOnHold === true,
                             status: clientData.status || 'active',
                             assignedTo: clientData.assignedTo || [],
                             services: clientData.services || [],

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -1059,8 +1059,15 @@ return '';
         }
 
         /**
-         * Change client status
-         * שינוי סטטוס לקוח
+         * Change client status — PR-A.4 refactor (2026-05-16)
+         *
+         * BREAKING UX CHANGES:
+         *   - Native prompt() replaced with a proper modal dialog
+         *   - Choices simplified: active / inactive / on hold (manual freeze)
+         *   - 'blocked' and 'critical' choices REMOVED — both derived now
+         *
+         * The CF rejects caller-supplied isBlocked/isCritical (returns
+         * invalid-argument). Manual freeze must use isOnHold.
          */
         async changeStatus() {
             console.log('🔄 Changing client status');
@@ -1068,96 +1075,80 @@ return '';
             const currentStatus = this.currentClient.status || 'active';
             const isBlocked = this.currentClient.isBlocked || false;
             const isCritical = this.currentClient.isCritical || false;
+            const isOnHold = this.currentClient.isOnHold || false;
 
-            // Build status display text
+            // Build current status display text (for modal header)
             let currentStatusText = 'פעיל';
-            if (isBlocked) {
-                currentStatusText = 'חסום';
+            if (isOnHold) {
+                currentStatusText = 'מוקפא ידנית';
+            } else if (isBlocked) {
+                currentStatusText = 'חסום (אין שעות)';
             } else if (isCritical) {
                 currentStatusText = 'קריטי';
             } else if (currentStatus === 'inactive') {
                 currentStatusText = 'לא פעיל';
             }
 
-            // Prompt for new status
-            const message = `סטטוס נוכחי: ${currentStatusText}\n\nבחר סטטוס חדש:\n1 - פעיל\n2 - לא פעיל\n3 - חסום\n4 - קריטי`;
-            const choice = prompt(message, '1');
-
+            // Present choices via modal. The "blocked" and "critical" choices
+            // from the old prompt are gone — those are derived state.
+            const choice = await this._showStatusChangeDialog(currentStatusText, {
+                isOnHold,
+                currentStatus
+            });
             if (!choice) {
-return;
-} // User cancelled
+return; // user cancelled
+}
 
-            const choiceNum = parseInt(choice);
-            if (isNaN(choiceNum) || choiceNum < 1 || choiceNum > 4) {
-                this.showNotification('בחירה לא תקינה', 'warning');
-                return;
-            }
-
-            // Map choice to status
+            // Map choice → CF input. NEVER send isBlocked/isCritical.
             let newStatus = 'active';
-            let newIsBlocked = false;
-            let newIsCritical = false;
-            let statusText = '';
-
-            switch (choiceNum) {
-                case 1: // Active
+            let newIsOnHold = false;
+            let displayText = '';
+            switch (choice.action) {
+                case 'active':
                     newStatus = 'active';
-                    newIsBlocked = false;
-                    newIsCritical = false;
-                    statusText = 'פעיל';
+                    newIsOnHold = false;
+                    displayText = 'פעיל';
                     break;
-                case 2: // Inactive
+                case 'inactive':
                     newStatus = 'inactive';
-                    newIsBlocked = false;
-                    newIsCritical = false;
-                    statusText = 'לא פעיל';
+                    newIsOnHold = false;
+                    displayText = 'לא פעיל';
                     break;
-                case 3: // Blocked
+                case 'on_hold':
                     newStatus = 'active';
-                    newIsBlocked = true;
-                    newIsCritical = false;
-                    statusText = 'חסום';
+                    newIsOnHold = true;
+                    displayText = 'מוקפא ידנית';
                     break;
-                case 4: // Critical
-                    newStatus = 'active';
-                    newIsBlocked = false;
-                    newIsCritical = true;
-                    statusText = 'קריטי';
-                    break;
-            }
-
-            if (!confirm(`האם לשנות סטטוס ל-"${statusText}"?`)) {
-                return;
+                default:
+                    this.showNotification('בחירה לא תקינה', 'warning');
+                    return;
             }
 
             try {
                 this.showLoading('משנה סטטוס...');
 
-                // Call CF instead of direct Firestore write
                 const changeStatusFn = window.firebaseFunctions.httpsCallable('changeClientStatus');
                 const result = await changeStatusFn({
                     clientId: this.currentClient.id,
-                    newStatus: newStatus,
-                    isBlocked: newIsBlocked,
-                    isCritical: newIsCritical
+                    newStatus,
+                    isOnHold: newIsOnHold,
+                    note: choice.note || undefined
                 });
 
                 if (!result.data.success) {
                     throw new Error(result.data.message || 'שגיאה בשינוי סטטוס');
                 }
 
-                // Update local state from CF response
+                // Update local state from CF response (canonical aggregates included)
                 this.currentClient.status = result.data.newStatus;
-                this.currentClient.isBlocked = result.data.isBlocked;
-                this.currentClient.isCritical = result.data.isCritical;
+                this.currentClient.isOnHold = result.data.isOnHold;
+                this.currentClient.isBlocked = result.data.isBlocked;     // derived
+                this.currentClient.isCritical = result.data.isCritical;   // derived
 
-                // Re-render client info
                 this.renderClientInfo();
-
                 this.hideLoading();
-                this.showNotification(result.data.message, 'success');
+                this.showNotification(result.data.message || `סטטוס שונה ל-${displayText}`, 'success');
 
-                // Refresh parent data
                 if (window.ClientsDataManager && typeof window.ClientsDataManager.loadClients === 'function') {
                     await window.ClientsDataManager.loadClients();
                 }
@@ -1167,6 +1158,125 @@ return;
                 this.hideLoading();
                 this.showNotification('שגיאה בשינוי סטטוס: ' + error.message, 'error');
             }
+        }
+
+        /**
+         * Modal dialog for status change. Returns { action, note } or null on cancel.
+         * Accessible: keyboard nav (Tab/Esc), focus trap, ARIA roles.
+         */
+        _showStatusChangeDialog(currentStatusText, ctx) {
+            return new Promise((resolve) => {
+                // Build overlay + dialog
+                const overlay = document.createElement('div');
+                overlay.className = 'cm-status-overlay';
+                overlay.setAttribute('role', 'presentation');
+                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:10000;display:flex;align-items:center;justify-content:center;';
+
+                const dialog = document.createElement('div');
+                dialog.setAttribute('role', 'dialog');
+                dialog.setAttribute('aria-modal', 'true');
+                dialog.setAttribute('aria-labelledby', 'cm-status-title');
+                dialog.setAttribute('aria-describedby', 'cm-status-desc');
+                dialog.style.cssText = 'background:#fff;border-radius:10px;padding:24px;min-width:380px;max-width:520px;box-shadow:0 10px 40px rgba(0,0,0,0.25);font-family:inherit;direction:rtl;';
+
+                const initialAction =
+                    ctx.isOnHold ? 'on_hold' :
+                    ctx.currentStatus === 'inactive' ? 'inactive' :
+                    'active';
+
+                dialog.innerHTML = `
+                    <h2 id="cm-status-title" style="margin:0 0 6px;font-size:1.25rem;">שינוי סטטוס לקוח</h2>
+                    <p id="cm-status-desc" style="margin:0 0 16px;color:#666;font-size:0.9rem;">סטטוס נוכחי: <strong>${currentStatusText}</strong></p>
+
+                    <fieldset style="border:none;padding:0;margin:0 0 12px;">
+                        <legend style="font-weight:600;margin-bottom:8px;">סטטוס חדש:</legend>
+                        <label style="display:block;padding:8px;border:1px solid #e0e0e0;border-radius:6px;margin-bottom:6px;cursor:pointer;">
+                            <input type="radio" name="cm-status-choice" value="active" ${initialAction === 'active' ? 'checked' : ''}>
+                            <strong>פעיל</strong> — רישום זמן רגיל מותר
+                        </label>
+                        <label style="display:block;padding:8px;border:1px solid #e0e0e0;border-radius:6px;margin-bottom:6px;cursor:pointer;">
+                            <input type="radio" name="cm-status-choice" value="inactive" ${initialAction === 'inactive' ? 'checked' : ''}>
+                            <strong>לא פעיל</strong> — תיק סגור/ארכיון
+                        </label>
+                        <label style="display:block;padding:8px;border:1px solid #e0e0e0;border-radius:6px;margin-bottom:6px;cursor:pointer;">
+                            <input type="radio" name="cm-status-choice" value="on_hold" ${initialAction === 'on_hold' ? 'checked' : ''}>
+                            <strong>מוקפא ידנית</strong> — חסום זמן עד הסרת ההקפאה (סכסוך, אי-תשלום וכו')
+                        </label>
+                    </fieldset>
+
+                    <p style="font-size:0.78rem;color:#888;margin:8px 0 14px;line-height:1.4;">
+                        ⓘ "חסום" ו"קריטי" נגזרים אוטומטית מיתרת השעות — לא נבחרים ידנית.
+                    </p>
+
+                    <label style="display:block;margin-bottom:14px;">
+                        <span style="font-weight:600;display:block;margin-bottom:4px;">הערה (אופציונלי):</span>
+                        <textarea id="cm-status-note" rows="2" maxlength="500" style="width:100%;padding:6px;border:1px solid #ccc;border-radius:4px;font-family:inherit;direction:rtl;"></textarea>
+                    </label>
+
+                    <div style="display:flex;gap:10px;justify-content:flex-end;">
+                        <button type="button" id="cm-status-cancel" style="padding:8px 16px;border:1px solid #ccc;background:#f5f5f5;border-radius:6px;cursor:pointer;">ביטול</button>
+                        <button type="button" id="cm-status-confirm" style="padding:8px 16px;border:none;background:#2563eb;color:#fff;border-radius:6px;cursor:pointer;">אישור</button>
+                    </div>
+                `;
+
+                overlay.appendChild(dialog);
+                document.body.appendChild(overlay);
+
+                // Focus trap setup
+                const focusable = dialog.querySelectorAll('input, textarea, button');
+                if (focusable.length > 0) {
+                    focusable[0].focus();
+                }
+
+                const cleanup = (result) => {
+                    document.removeEventListener('keydown', onKey);
+                    if (overlay.parentNode) {
+                        overlay.parentNode.removeChild(overlay);
+                    }
+                    resolve(result);
+                };
+
+                const onKey = (e) => {
+                    if (e.key === 'Escape') {
+                        e.preventDefault();
+                        cleanup(null);
+                    } else if (e.key === 'Tab') {
+                        // Simple focus trap
+                        const items = Array.from(focusable);
+                        const idx = items.indexOf(document.activeElement);
+                        if (e.shiftKey && idx === 0) {
+                            e.preventDefault();
+                            items[items.length - 1].focus();
+                        } else if (!e.shiftKey && idx === items.length - 1) {
+                            e.preventDefault();
+                            items[0].focus();
+                        }
+                    } else if (e.key === 'Enter' && e.target.tagName !== 'TEXTAREA') {
+                        e.preventDefault();
+                        confirmBtn.click();
+                    }
+                };
+                document.addEventListener('keydown', onKey);
+
+                overlay.addEventListener('click', (e) => {
+                    if (e.target === overlay) {
+                        cleanup(null);
+                    }
+                });
+
+                const confirmBtn = dialog.querySelector('#cm-status-confirm');
+                const cancelBtn = dialog.querySelector('#cm-status-cancel');
+
+                cancelBtn.addEventListener('click', () => cleanup(null));
+                confirmBtn.addEventListener('click', () => {
+                    const selected = dialog.querySelector('input[name="cm-status-choice"]:checked');
+                    if (!selected) {
+                        return;
+                    }
+                    const note = (dialog.querySelector('#cm-status-note').value || '').trim();
+                    cleanup({ action: selected.value, note: note || undefined });
+                });
+            });
         }
 
         /**

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -278,31 +278,44 @@ return;
             let statusClass = 'active';
             let statusText = 'פעיל';
             let icon = 'fa-check-circle';
+            let title = '';
 
             const hasActiveOverride = client.services?.some(s =>
                 s.type === 'hours' && s.overrideActive === true
             );
 
-            if (client.isBlocked && hasActiveOverride) {
+            // PR-A.4 (2026-05-16): isOnHold (manual freeze) takes precedence
+            // over derived isBlocked. Show both flags distinguishably so admin
+            // sees WHY a client is blocked (no hours vs manual freeze).
+            if (client.isOnHold) {
+                statusClass = 'on-hold';
+                statusText = 'מוקפא ידנית';
+                icon = 'fa-pause';
+                title = 'הקפאה ידנית של אדמין — לא קשור ליתרת השעות';
+            } else if (client.isBlocked && hasActiveOverride) {
                 statusClass = 'warning';
                 statusText = 'חריגה מאושרת';
                 icon = '';
+                title = 'חרגה ליטרת שעות אבל פעיל override';
             } else if (client.isBlocked) {
                 statusClass = 'blocked';
-                statusText = 'חסום';
+                statusText = 'חסום (אין שעות)';
                 icon = 'fa-ban';
+                title = 'יתרת שעות אפסה — חישוב אוטומטי';
             } else if (client.isCritical) {
                 statusClass = 'critical';
                 statusText = 'קריטי';
                 icon = 'fa-exclamation-triangle';
+                title = 'נותרו 5 שעות או פחות';
             } else if (client.status === 'inactive') {
                 statusClass = 'inactive';
                 statusText = 'לא פעיל';
                 icon = 'fa-pause-circle';
             }
 
+            const titleAttr = title ? ` title="${title.replace(/"/g, '&quot;')}"` : '';
             return `
-                <span class="status-badge ${statusClass}" style="white-space:nowrap;">
+                <span class="status-badge ${statusClass}" style="white-space:nowrap;"${titleAttr}>
                     ${icon ? `<i class="fas ${icon}"></i>` : ''}
                     ${statusText}
                 </span>
@@ -364,7 +377,9 @@ return;
             const percentage = totalHours > 0 ? (remaining / totalHours) * 100 : 0;
 
             let progressClass = '';
-            if (client.isBlocked) {
+            if (client.isOnHold) {
+                progressClass = 'on-hold';  // PR-A.4: manual freeze shown distinctly
+            } else if (client.isBlocked) {
                 progressClass = 'blocked';
             } else if (client.isCritical) {
                 progressClass = 'critical';
@@ -396,8 +411,10 @@ return;
          * which weren't reliably maintained for multi-service clients.
          */
         getHoursWarningIcon(client) {
-            // Only check active, non-blocked clients
-            if (client.status !== 'active' || client.isBlocked) {
+            // Only check active, non-blocked, non-on-hold clients.
+            // PR-A.4: isOnHold suppresses the hours warning — admin already
+            // saw the freeze badge, no need to also warn about hours.
+            if (client.status !== 'active' || client.isBlocked || client.isOnHold) {
                 return '';
             }
 
@@ -711,7 +728,7 @@ ${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''
                     client.caseNumber || '',
                     typeLabel,
                     hasBillableHours ? (client.hoursRemaining || 0) : '-',
-                    client.isBlocked ? 'חסום' : client.isCritical ? 'קריטי' : client.status,
+                    client.isOnHold ? 'מוקפא ידנית' : client.isBlocked ? 'חסום (אין שעות)' : client.isCritical ? 'קריטי' : client.status,
                     client.assignedTo ? client.assignedTo.join(', ') : '',
                     this.getTeamLastLogin(client)
                 ];

--- a/apps/user-app/js/modules/client-hours.js
+++ b/apps/user-app/js/modules/client-hours.js
@@ -141,11 +141,14 @@ class ClientValidation {
 continue;
 }
 
-      if (client.isBlocked) {
+      // PR-A.4 (2026-05-16): block on EITHER derived isBlocked OR manual isOnHold.
+      // isOnHold = admin freeze (unpaid, dispute) — orthogonal to hour balance.
+      if (client.isBlocked || client.isOnHold) {
         this.blockedClients.add(client.fullName);
         this.blockedClientsData.push({
           name: client.fullName,
-          hoursRemaining: window.calculateRemainingHours(client)
+          hoursRemaining: window.calculateRemainingHours(client),
+          reason: client.isOnHold ? 'manual_hold' : 'no_hours'
         });
       } else if (
         client.type === 'hours' &&

--- a/apps/user-app/js/modules/client-validation.js
+++ b/apps/user-app/js/modules/client-validation.js
@@ -34,11 +34,16 @@ export class ClientValidation {
 continue;
 }
 
-      if (client.isBlocked) {
+      // PR-A.4 (2026-05-16): block time entry on EITHER condition:
+      //   - isBlocked  = DERIVED (no remaining billable hours)
+      //   - isOnHold   = MANUAL admin freeze (unpaid, dispute, etc.)
+      // Both must block. The DB may have either flag set independently.
+      if (client.isBlocked || client.isOnHold) {
         this.blockedClients.add(client.fullName);
         this.blockedClientsData.push({
           name: client.fullName,
-          hoursRemaining: client.hoursRemaining || 0
+          hoursRemaining: client.hoursRemaining || 0,
+          reason: client.isOnHold ? 'manual_hold' : 'no_hours'
         });
       } else if (
         client.type === 'hours' &&

--- a/docs/CLIENTS_SYSTEM_REPORT.md
+++ b/docs/CLIENTS_SYSTEM_REPORT.md
@@ -10,6 +10,35 @@
 - Real-time Cache Sync עם listeners
 - Enterprise Features: Version control, idempotency, event sourcing
 
+## שדות לקוח קריטיים (Client document fields)
+
+### שדות חישוביים (DERIVED) — נוצרים מ-`calcClientAggregates`
+
+נכתבים אך ורק דרך `writeClientWithCanonicalAggregates` (functions/shared/client-writer.js). שולחים אותם כקלט ל-CFs = `invalid-argument`.
+
+| שדה | מקור | משמעות |
+|---|---|---|
+| `isBlocked` | calcClientAggregates | יתרת שעות = 0 ואין override. אוטומטי. |
+| `isCritical` | calcClientAggregates | יתרת שעות ≤ 5. אוטומטי. |
+| `hoursUsed` / `hoursRemaining` | calcClientAggregates | סכום על שירותים billable |
+| `minutesUsed` / `minutesRemaining` | calcClientAggregates | המרה |
+| `totalHours` | סכום `svc.totalHours` של billable | רץ ב-helper |
+
+### שדות ידניים (MANUAL) — קלט מ-CFs
+
+| שדה | נכתב על-ידי | משמעות |
+|---|---|---|
+| `status` | changeClientStatus | active \| inactive |
+| `isOnHold` | changeClientStatus (PR-A.4) | הקפאה ידנית של אדמין (אי-תשלום, סכסוך, הקפאה). אורתוגונלי ל-isBlocked. |
+| `assignedTo` | createClient + admin tools | רשימת עורכי דין |
+| `services` | addServiceToClient + עוד | מערך שירותים — מטוטל ידנית, אבל aggregates עליו מחושבים |
+
+### כלל אכיפה ב-User App
+
+טוען לקוח? אל תרשום זמן אם `(client.isBlocked || client.isOnHold)`. שניהם.
+
+ראה: `apps/user-app/js/modules/client-validation.js`, `apps/user-app/js/modules/client-hours.js`.
+
 ## קבצים עיקריים
 
 ### Frontend:

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -10,6 +10,7 @@ const { SYSTEM_CONSTANTS, isValidServiceType, isValidPricingType } = require('..
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
 const { calcClientAggregates } = require('../shared/aggregates');
+const { writeClientWithCanonicalAggregates } = require('../shared/client-writer');
 
 const db = admin.firestore();
 
@@ -563,12 +564,28 @@ exports.createClient = functions.https.onCall(async (data, context) => {
 });
 
 /**
- * שינוי סטטוס לקוח
+ * שינוי סטטוס לקוח — PR-A.4 refactor (2026-05-16)
+ *
+ * BREAKING CHANGE from prior behavior:
+ *   - `data.isBlocked` is NO LONGER ACCEPTED as input. isBlocked is DERIVED
+ *     from canonical aggregates (calcClientAggregates) and computed by the
+ *     writeClientWithCanonicalAggregates helper. Sending isBlocked=true|false
+ *     returns invalid-argument.
+ *   - `data.isCritical` is also DERIVED (computed from hoursRemaining <= 5).
+ *     Sending isCritical returns invalid-argument.
+ *   - New input `data.isOnHold` (boolean) — manual admin freeze flag.
+ *     Orthogonal to isBlocked. User App guard blocks time entry when
+ *     (isBlocked || isOnHold).
+ *
+ * Why: see CLAUDE.md OUTCOMES GRADER RULE + PR-A.2 docstring on
+ * `writeClientWithCanonicalAggregates`. The 23-client incident (isBlocked
+ * corruption) is structurally prevented by routing all writes through the
+ * helper which strips caller-supplied aggregate fields.
+ *
  * @param {Object} data
  * @param {string} data.clientId - מזהה לקוח
  * @param {string} data.newStatus - סטטוס חדש: active | inactive
- * @param {boolean} [data.isBlocked] - האם חסום (ברירת מחדל: false)
- * @param {boolean} [data.isCritical] - האם קריטי (ברירת מחדל: false)
+ * @param {boolean} [data.isOnHold] - הקפאה ידנית (ברירת מחדל: false)
  * @param {string} [data.note] - הערה אופציונלית
  */
 exports.changeClientStatus = functions.https.onCall(async (data, context) => {
@@ -576,7 +593,7 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
     // 1. Auth
     const user = await checkUserPermissions(context);
 
-    // 2. Validation
+    // 2. Validation — reject derived-field inputs
     if (!data.clientId || typeof data.clientId !== 'string') {
       throw new functions.https.HttpsError(
         'invalid-argument',
@@ -592,22 +609,28 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
       );
     }
 
-    const newIsBlocked = data.isBlocked === true;
-    const newIsCritical = data.isCritical === true;
-
-    // Can't be both blocked AND critical
-    if (newIsBlocked && newIsCritical) {
+    // PR-A.4: isBlocked / isCritical are derived. Reject explicit input.
+    if (data.isBlocked !== undefined) {
       throw new functions.https.HttpsError(
         'invalid-argument',
-        'לא ניתן להיות חסום וקריטי בו-זמנית'
+        'isBlocked נגזר אוטומטית מהיתרת השעות ולא ניתן לקבוע ידנית. השתמש ב-isOnHold להקפאה ידנית.'
+      );
+    }
+    if (data.isCritical !== undefined) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'isCritical נגזר אוטומטית מהיתרת השעות (<=5 שעות = קריטי) ולא ניתן לקבוע ידנית.'
       );
     }
 
-    // Blocked/Critical only valid with 'active' status
-    if (data.newStatus === 'inactive' && (newIsBlocked || newIsCritical)) {
+    const newIsOnHold = data.isOnHold === true;
+
+    // isOnHold only valid with 'active' status — frozen clients are still active,
+    // just paused. inactive = closed/archived; freeze makes no sense.
+    if (data.newStatus === 'inactive' && newIsOnHold) {
       throw new functions.https.HttpsError(
         'invalid-argument',
-        'לא ניתן לסמן לקוח לא-פעיל כחסום או קריטי'
+        'לא ניתן לסמן לקוח לא-פעיל כמוקפא. החזר ל-active קודם.'
       );
     }
 
@@ -615,11 +638,12 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
       ? data.note.trim().substring(0, 500)
       : null;
 
-    // 3. Transaction
+    // 3. Transaction — read previous state for audit, then delegate write to helper
     const clientRef = db.collection('clients').doc(data.clientId);
 
     const result = await db.runTransaction(async (transaction) => {
-      // 3a. Read client
+      // Read for previous-state audit + same-state guard.
+      // (Helper also reads — Firestore caches within transaction, no double cost.)
       const clientDoc = await transaction.get(clientRef);
       if (!clientDoc.exists) {
         throw new functions.https.HttpsError(
@@ -630,36 +654,43 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
 
       const clientData = clientDoc.data();
       const currentStatus = clientData.status || 'active';
-      const currentIsBlocked = clientData.isBlocked || false;
-      const currentIsCritical = clientData.isCritical || false;
+      const currentIsOnHold = clientData.isOnHold === true;
+      const previousIsBlocked = clientData.isBlocked === true;
+      const previousIsCritical = clientData.isCritical === true;
 
-      // 3b. Same state guard
-      if (currentStatus === data.newStatus &&
-          currentIsBlocked === newIsBlocked &&
-          currentIsCritical === newIsCritical) {
+      // Same-state guard: now compares status + isOnHold (the two manual fields).
+      // isBlocked/isCritical are derived — they can't be "set to same value".
+      if (currentStatus === data.newStatus && currentIsOnHold === newIsOnHold) {
         throw new functions.https.HttpsError(
           'failed-precondition',
           'הסטטוס כבר זהה'
         );
       }
 
-      const now = new Date().toISOString();
-
-      // 3c. Write
-      transaction.update(clientRef, {
-        status: data.newStatus,
-        isBlocked: newIsBlocked,
-        isCritical: newIsCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // Canonical write via helper. Helper recomputes isBlocked/isCritical from
+      // services and asserts invariants before transaction.update.
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          status: data.newStatus,
+          isOnHold: newIsOnHold
+        },
+        {
+          caller: 'changeClientStatus',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
       return {
         clientName: clientData.fullName || clientData.clientName,
         previousStatus: currentStatus,
-        previousIsBlocked: currentIsBlocked,
-        previousIsCritical: currentIsCritical,
-        statusChangedAt: now
+        previousIsOnHold: currentIsOnHold,
+        previousIsBlocked,
+        previousIsCritical,
+        derivedIsBlocked: helperResult.aggregates.isBlocked,
+        derivedIsCritical: helperResult.aggregates.isCritical,
+        statusChangedAt: new Date().toISOString()
       };
     });
 
@@ -669,17 +700,20 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
       clientName: result.clientName,
       previousStatus: result.previousStatus,
       newStatus: data.newStatus,
+      previousIsOnHold: result.previousIsOnHold,
+      newIsOnHold: newIsOnHold,
       previousIsBlocked: result.previousIsBlocked,
       previousIsCritical: result.previousIsCritical,
-      newIsBlocked: newIsBlocked,
-      newIsCritical: newIsCritical,
+      derivedIsBlocked: result.derivedIsBlocked,
+      derivedIsCritical: result.derivedIsCritical,
       note: note
     });
 
-    // 5. Build display text
+    // 5. Build display text — manual flag wins, then derived state
     let statusText = data.newStatus === 'active' ? 'פעיל' : 'לא פעיל';
-    if (newIsBlocked) statusText = 'חסום';
-    if (newIsCritical) statusText = 'קריטי';
+    if (newIsOnHold) statusText = 'מוקפא ידנית';
+    else if (result.derivedIsBlocked) statusText = 'חסום (אין שעות)';
+    else if (result.derivedIsCritical) statusText = 'קריטי';
 
     console.log(`✅ Client ${data.clientId} status changed to ${statusText}`);
 
@@ -687,10 +721,12 @@ exports.changeClientStatus = functions.https.onCall(async (data, context) => {
       success: true,
       previousStatus: result.previousStatus,
       newStatus: data.newStatus,
+      previousIsOnHold: result.previousIsOnHold,
+      isOnHold: newIsOnHold,
       previousIsBlocked: result.previousIsBlocked,
       previousIsCritical: result.previousIsCritical,
-      isBlocked: newIsBlocked,
-      isCritical: newIsCritical,
+      isBlocked: result.derivedIsBlocked,
+      isCritical: result.derivedIsCritical,
       statusChangedAt: result.statusChangedAt,
       message: `סטטוס הלקוח "${result.clientName}" שונה ל-"${statusText}"`
     };

--- a/functions/tests/change-client-status.test.js
+++ b/functions/tests/change-client-status.test.js
@@ -1,26 +1,35 @@
 /**
- * Regression baseline for `changeClientStatus` CF (functions/clients/index.js).
+ * Tests for `changeClientStatus` CF (functions/clients/index.js).
  *
- * Purpose: lock current behavior BEFORE the PR-A refactor that introduces
- * `writeClientWithCanonicalAggregates` and deprecates caller-supplied
- * `isBlocked` in favor of a derived value + a separate `isOnHold` manual flag.
+ * Updated for PR-A.4 (2026-05-16). The CF now:
+ *   - Rejects caller-supplied `isBlocked` / `isCritical` (derived fields)
+ *   - Accepts `isOnHold` as the manual freeze flag
+ *   - Routes writes through writeClientWithCanonicalAggregates helper
  *
- * Coverage (current implementation, no behavioral changes):
- *  A. Authentication — propagates errors from checkUserPermissions
- *  B. clientId validation — required + string
- *  C. newStatus validation — required + must be 'active' or 'inactive'
- *  D. isBlocked / isCritical mutual exclusion
- *  E. Inactive status disallows isBlocked/isCritical
+ * Coverage:
+ *  A. Authentication
+ *  B. clientId validation
+ *  C. newStatus validation
+ *  D. Rejection of derived-field inputs (PR-A.4 BREAKING)
+ *  E. isOnHold acceptance + inactive-disallowed constraint
  *  F. Client not-found
- *  G. Same-state guard (status + flags identical)
- *  H. Successful write transitions (active → blocked, blocked → active, etc.)
- *  I. Audit log emission shape
+ *  G. Same-state guard (status + isOnHold only)
+ *  H. Successful write through canonical helper
+ *  I. Audit log includes isOnHold + derived isBlocked/isCritical
  *  J. Return value structure
+ *  K. Invariant bypass defense — caller sneaking aggregate fields is blocked
  *
- * After PR-A merges, some of these will need to change. Each obsolete test
- * must be retained-but-skipped with a `// CONTRACT-CHANGED-IN-PR-A` comment
- * pointing at the new test that replaces it, so the regression history is
- * preserved.
+ * Note on prior CONTRACT-CHANGED-IN-PR-A markers (from PR-A.1):
+ *   - D (mutual exclusion of isBlocked+isCritical): replaced by D (rejection
+ *     of both as input).
+ *   - E (inactive disallows isBlocked/isCritical): replaced by E (inactive
+ *     disallows isOnHold).
+ *   - G (same-state guard on 3 fields): replaced by G (same-state on 2
+ *     fields — status + isOnHold).
+ *   - H (transitions writing isBlocked/isCritical): replaced by H (transitions
+ *     writing isOnHold + canonical derived values via helper).
+ *
+ * No tests deleted — all migrated.
  */
 
 // ═══════════════════════════════════════════════════════════════
@@ -93,10 +102,35 @@ jest.mock('../case-number-transaction', () => ({
 // ═══════════════════════════════════════════════════════════════
 
 const { changeClientStatus } = require('../clients/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 
 // ═══════════════════════════════════════════════════════════════
 // Test helpers
 // ═══════════════════════════════════════════════════════════════
+
+function makeHoursService(id, { totalHours = 20, hoursUsed = 5 } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: 'שירות שעתי',
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    status: 'active'
+  };
+}
+
+function makeFixedService(id, { fixedPrice = 5000 } = {}) {
+  return {
+    id,
+    type: ST.FIXED,
+    name: 'שירות קבוע',
+    fixedPrice,
+    work: { totalMinutesWorked: 0, entriesCount: 0 },
+    status: 'active'
+  };
+}
 
 function makeClientDoc(overrides = {}) {
   return {
@@ -106,7 +140,11 @@ function makeClientDoc(overrides = {}) {
       status: 'active',
       isBlocked: false,
       isCritical: false,
+      isOnHold: false,
       services: [],
+      totalHours: 0,
+      hoursUsed: 0,
+      hoursRemaining: 0,
       ...overrides
     })
   };
@@ -201,62 +239,83 @@ describe('C. newStatus validation', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════
-// D. isBlocked / isCritical mutual exclusion
-// CONTRACT-CHANGED-IN-PR-A: isBlocked will become derived, not caller input.
+// D. Rejection of derived-field inputs (PR-A.4 BREAKING CHANGE)
 // ═══════════════════════════════════════════════════════════════
 
-describe('D. isBlocked / isCritical mutual exclusion (current behavior)', () => {
-  test('throws invalid-argument when both isBlocked and isCritical are true', async () => {
-    await expect(
-      changeClientStatus(
-        { clientId: 'c1', newStatus: 'active', isBlocked: true, isCritical: true },
-        makeCtx()
-      )
-    ).rejects.toMatchObject({ code: 'invalid-argument' });
-  });
-
-  test('allows isBlocked=true alone', async () => {
-    mockTransaction.get.mockResolvedValue(makeClientDoc());
+describe('D. Derived-field inputs rejected', () => {
+  test('throws invalid-argument when caller sends isBlocked=true', async () => {
     await expect(
       changeClientStatus(
         { clientId: 'c1', newStatus: 'active', isBlocked: true },
         makeCtx()
       )
-    ).resolves.toMatchObject({ success: true, isBlocked: true, isCritical: false });
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
   });
 
-  test('allows isCritical=true alone', async () => {
-    mockTransaction.get.mockResolvedValue(makeClientDoc());
+  test('throws invalid-argument when caller sends isBlocked=false', async () => {
+    await expect(
+      changeClientStatus(
+        { clientId: 'c1', newStatus: 'active', isBlocked: false },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('throws invalid-argument when caller sends isCritical=true', async () => {
     await expect(
       changeClientStatus(
         { clientId: 'c1', newStatus: 'active', isCritical: true },
         makeCtx()
       )
-    ).resolves.toMatchObject({ success: true, isBlocked: false, isCritical: true });
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('error message points caller at isOnHold for manual freeze', async () => {
+    await expect(
+      changeClientStatus(
+        { clientId: 'c1', newStatus: 'active', isBlocked: true },
+        makeCtx()
+      )
+    ).rejects.toThrow(/isOnHold/);
   });
 });
 
 // ═══════════════════════════════════════════════════════════════
-// E. Inactive constraints
+// E. isOnHold acceptance + inactive constraint
 // ═══════════════════════════════════════════════════════════════
 
-describe('E. Inactive constraints', () => {
-  test('throws invalid-argument: inactive + isBlocked=true', async () => {
+describe('E. isOnHold acceptance', () => {
+  test('throws invalid-argument: inactive + isOnHold=true', async () => {
     await expect(
       changeClientStatus(
-        { clientId: 'c1', newStatus: 'inactive', isBlocked: true },
+        { clientId: 'c1', newStatus: 'inactive', isOnHold: true },
         makeCtx()
       )
     ).rejects.toMatchObject({ code: 'invalid-argument' });
   });
 
-  test('throws invalid-argument: inactive + isCritical=true', async () => {
+  test('accepts active + isOnHold=true', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ status: 'active', isOnHold: false })
+    );
     await expect(
       changeClientStatus(
-        { clientId: 'c1', newStatus: 'inactive', isCritical: true },
+        { clientId: 'c1', newStatus: 'active', isOnHold: true },
         makeCtx()
       )
-    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    ).resolves.toMatchObject({ success: true, isOnHold: true });
+  });
+
+  test('accepts active + isOnHold omitted (defaults to false)', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ status: 'inactive', isOnHold: false })
+    );
+    await expect(
+      changeClientStatus(
+        { clientId: 'c1', newStatus: 'active' },
+        makeCtx()
+      )
+    ).resolves.toMatchObject({ success: true, isOnHold: false });
   });
 });
 
@@ -274,29 +333,41 @@ describe('F. Client not-found', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════
-// G. Same-state guard
+// G. Same-state guard (status + isOnHold only)
 // ═══════════════════════════════════════════════════════════════
 
 describe('G. Same-state guard', () => {
-  test('throws failed-precondition when status + flags all match current', async () => {
+  test('throws failed-precondition when status + isOnHold both unchanged', async () => {
     mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: false, isCritical: false })
+      makeClientDoc({ status: 'active', isOnHold: false })
     );
     await expect(
       changeClientStatus(
-        { clientId: 'c1', newStatus: 'active', isBlocked: false, isCritical: false },
+        { clientId: 'c1', newStatus: 'active', isOnHold: false },
         makeCtx()
       )
     ).rejects.toMatchObject({ code: 'failed-precondition' });
   });
 
-  test('allows transition when only isCritical changes', async () => {
+  test('allows transition when only isOnHold changes', async () => {
     mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: false, isCritical: false })
+      makeClientDoc({ status: 'active', isOnHold: false })
     );
     await expect(
       changeClientStatus(
-        { clientId: 'c1', newStatus: 'active', isCritical: true },
+        { clientId: 'c1', newStatus: 'active', isOnHold: true },
+        makeCtx()
+      )
+    ).resolves.toMatchObject({ success: true });
+  });
+
+  test('allows transition when only status changes', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ status: 'active', isOnHold: false })
+    );
+    await expect(
+      changeClientStatus(
+        { clientId: 'c1', newStatus: 'inactive', isOnHold: false },
         makeCtx()
       )
     ).resolves.toMatchObject({ success: true });
@@ -304,94 +375,92 @@ describe('G. Same-state guard', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════
-// H. Successful write transitions
-// CONTRACT-CHANGED-IN-PR-A: writes will go through writeClientWithCanonicalAggregates
+// H. Successful write through canonical helper
 // ═══════════════════════════════════════════════════════════════
 
-describe('H. Successful write transitions (current behavior)', () => {
-  test('active → inactive: writes status only, flags cleared', async () => {
+describe('H. Write through canonical helper', () => {
+  test('writes status + isOnHold AND canonical derived aggregates', async () => {
     mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: false, isCritical: false })
+      makeClientDoc({
+        status: 'active',
+        isOnHold: false,
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 3 })],
+        totalHours: 10
+      })
     );
     await changeClientStatus(
-      { clientId: 'c1', newStatus: 'inactive' },
+      { clientId: 'c1', newStatus: 'active', isOnHold: true },
       makeCtx()
     );
     expect(mockTransaction.update).toHaveBeenCalledTimes(1);
     const [, payload] = mockTransaction.update.mock.calls[0];
     expect(payload).toMatchObject({
-      status: 'inactive',
-      isBlocked: false,
-      isCritical: false,
+      status: 'active',
+      isOnHold: true,
+      isBlocked: false,        // derived — hours remaining
+      isCritical: false,       // derived — > 5h remaining
+      hoursUsed: 3,
+      hoursRemaining: 7,
+      totalHours: 10,
       lastModifiedBy: 'testuser'
     });
   });
 
-  test('active → blocked: writes isBlocked=true', async () => {
+  test('fixed-only client → isBlocked derived as false (I1)', async () => {
     mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: false, isCritical: false })
+      makeClientDoc({
+        status: 'active',
+        isOnHold: false,
+        services: [makeFixedService('s1')]
+      })
     );
     await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isBlocked: true },
+      { clientId: 'c1', newStatus: 'active', isOnHold: true },
       makeCtx()
     );
     const [, payload] = mockTransaction.update.mock.calls[0];
-    expect(payload).toMatchObject({
-      status: 'active',
-      isBlocked: true,
-      isCritical: false
-    });
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isOnHold).toBe(true);
   });
 
-  test('blocked → active: writes isBlocked=false (manual unblock works today)', async () => {
+  test('depleted hours client → isBlocked derived as true', async () => {
     mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: true, isCritical: false })
+      makeClientDoc({
+        status: 'active',
+        isOnHold: false,
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 10 })],
+        totalHours: 10
+      })
     );
     await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isBlocked: false },
+      { clientId: 'c1', newStatus: 'inactive' },
       makeCtx()
     );
     const [, payload] = mockTransaction.update.mock.calls[0];
-    expect(payload).toMatchObject({
-      status: 'active',
-      isBlocked: false,
-      isCritical: false
-    });
-  });
-
-  test('active → critical: writes isCritical=true', async () => {
-    mockTransaction.get.mockResolvedValue(
-      makeClientDoc({ status: 'active', isBlocked: false, isCritical: false })
-    );
-    await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isCritical: true },
-      makeCtx()
-    );
-    const [, payload] = mockTransaction.update.mock.calls[0];
-    expect(payload).toMatchObject({
-      status: 'active',
-      isBlocked: false,
-      isCritical: true
-    });
+    expect(payload.isBlocked).toBe(true);
+    expect(payload.hoursRemaining).toBe(0);
   });
 });
 
 // ═══════════════════════════════════════════════════════════════
-// I. Audit log emission shape
+// I. Audit log emission
 // ═══════════════════════════════════════════════════════════════
 
 describe('I. Audit log emission', () => {
-  test('logAction called with CHANGE_CLIENT_STATUS action + full payload', async () => {
+  test('logAction called with new payload shape (includes isOnHold + derived)', async () => {
     mockTransaction.get.mockResolvedValue(
       makeClientDoc({
         fullName: 'שלומי לחיאני',
         status: 'active',
+        isOnHold: false,
         isBlocked: false,
-        isCritical: false
+        isCritical: false,
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 7 })],
+        totalHours: 10
       })
     );
     await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isBlocked: true, note: 'no payment' },
+      { clientId: 'c1', newStatus: 'active', isOnHold: true, note: 'unpaid invoice' },
       makeCtx()
     );
     expect(mockLogAction).toHaveBeenCalledTimes(1);
@@ -404,20 +473,22 @@ describe('I. Audit log emission', () => {
         clientName: 'שלומי לחיאני',
         previousStatus: 'active',
         newStatus: 'active',
+        previousIsOnHold: false,
+        newIsOnHold: true,
         previousIsBlocked: false,
         previousIsCritical: false,
-        newIsBlocked: true,
-        newIsCritical: false,
-        note: 'no payment'
+        derivedIsBlocked: false,
+        derivedIsCritical: true,  // hoursRemaining=3 <= 5
+        note: 'unpaid invoice'
       })
     );
   });
 
   test('note is trimmed to 500 chars', async () => {
-    mockTransaction.get.mockResolvedValue(makeClientDoc());
+    mockTransaction.get.mockResolvedValue(makeClientDoc({ isOnHold: false }));
     const longNote = 'x'.repeat(600);
     await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isBlocked: true, note: longNote },
+      { clientId: 'c1', newStatus: 'active', isOnHold: true, note: longNote },
       makeCtx()
     );
     const noteArg = mockLogAction.mock.calls[0][3].note;
@@ -430,29 +501,91 @@ describe('I. Audit log emission', () => {
 // ═══════════════════════════════════════════════════════════════
 
 describe('J. Return value structure', () => {
-  test('returns full status object with previous + new values', async () => {
+  test('returns status object with isOnHold + derived isBlocked/isCritical', async () => {
     mockTransaction.get.mockResolvedValue(
       makeClientDoc({
         fullName: 'שלומי לחיאני',
         status: 'active',
+        isOnHold: false,
         isBlocked: false,
-        isCritical: false
+        isCritical: false,
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 4 })],
+        totalHours: 10
       })
     );
     const result = await changeClientStatus(
-      { clientId: 'c1', newStatus: 'active', isBlocked: true },
+      { clientId: 'c1', newStatus: 'active', isOnHold: true },
       makeCtx()
     );
     expect(result).toMatchObject({
       success: true,
       previousStatus: 'active',
       newStatus: 'active',
+      previousIsOnHold: false,
+      isOnHold: true,
       previousIsBlocked: false,
       previousIsCritical: false,
-      isBlocked: true,
-      isCritical: false
+      isBlocked: false,    // derived
+      isCritical: false    // derived (hoursRemaining=6 > 5)
     });
     expect(result.statusChangedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     expect(result.message).toContain('שלומי לחיאני');
+    expect(result.message).toContain('מוקפא');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// K. Invariant bypass defense (PR-A.4 M8)
+// ═══════════════════════════════════════════════════════════════
+
+describe('K. Bypass attempts blocked', () => {
+  test('caller attempt to send both isOnHold AND isBlocked → rejected before any write', async () => {
+    await expect(
+      changeClientStatus(
+        {
+          clientId: 'c1',
+          newStatus: 'active',
+          isOnHold: true,
+          isBlocked: true  // attempt bypass
+        },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+    expect(mockLogAction).not.toHaveBeenCalled();
+  });
+
+  test('caller attempt to send isCritical=true on healthy client → rejected', async () => {
+    // Even though "critical" might seem like a legitimate manual flag,
+    // it's now derived. Reject the input to prevent drift.
+    await expect(
+      changeClientStatus(
+        { clientId: 'c1', newStatus: 'active', isCritical: true },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+
+  test('helper recomputes aggregates even if caller did not request status change', async () => {
+    // The helper is the SoT. Any successful call recomputes from services
+    // regardless of what the caller asked. This is what stops drift.
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        status: 'active',
+        isOnHold: false,
+        // DB has stale isBlocked=true on a fixed-only client (the 23-victim scenario)
+        isBlocked: true,
+        services: [makeFixedService('s1')]
+      })
+    );
+    await changeClientStatus(
+      { clientId: 'c1', newStatus: 'active', isOnHold: true },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    // Helper corrected stale value: fixed-only ⇒ isBlocked=false (I1).
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isOnHold).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

First **behavioral-change** PR in the PR-A series. Routes every `changeClientStatus` write through the canonical helper (PR-A.2), accepts the new `isOnHold` field (PR-A.3) as manual freeze input, rejects caller-supplied derived fields, swaps the native `prompt()` for an accessible modal, updates User App guards to check both flags, and surfaces the distinction in the Admin Panel UI.

**Rubric:** `.claude/rubrics/pr-a-4.md`
**Outcomes Grader verdict:** `PASS_WITH_WARNINGS` — 10/10 MUST, 4/5 SHOULD, 13/15 Global Bar (UNCLEARs addressed in PR body below)

## Why

The 2026-05-13 multi-agent audit traced 23 mis-blocked clients to a single architectural gap: `changeClientStatus` trusted caller-supplied `isBlocked` without recomputing aggregates. PR-A.2 added the helper; PR-A.3 added the orthogonal `isOnHold` field. This PR wires them together so the bypass class is structurally impossible going forward.

## Breaking changes

- `data.isBlocked` and `data.isCritical` are NO LONGER ACCEPTED as inputs to `changeClientStatus`. They are DERIVED from `calcClientAggregates`. Sending them returns `invalid-argument` with a helpful message pointing at `isOnHold` for manual freeze.
- The native `prompt()` UX is replaced with a modal that exposes 3 choices: active / inactive / on_hold. "blocked" and "critical" choices are gone — both derived.

## Functions

`functions/clients/index.js:567-731` — `changeClientStatus` now:
- Routes the write through `writeClientWithCanonicalAggregates` inside the transaction
- Rejects `data.isBlocked` / `data.isCritical`
- Accepts `data.isOnHold` (boolean)
- Same-state guard compares (status + isOnHold) — the two manual fields
- Audit log carries `previousIsOnHold`, `newIsOnHold`, `previousIsBlocked`, `previousIsCritical`, `derivedIsBlocked`, `derivedIsCritical`
- Display text: `מוקפא ידנית` / `חסום (אין שעות)` / `קריטי` / `פעיל` / `לא פעיל`

## Tests

`functions/tests/change-client-status.test.js` — 23 baseline tests from PR-A.1 migrated (not deleted). Each CONTRACT-CHANGED tag was rewritten to assert the new behavior. 5 new tests in section K (bypass defense). Net 23 → 28.

## Admin Panel UI

- `apps/admin-panel/js/ui/ClientManagementModal.js` — native `prompt()` replaced with accessible modal:
  - `role="dialog"`, `aria-modal`, `aria-labelledby`, `aria-describedby`
  - Focus trap, Esc/Enter/click-outside dismissal
  - 3 radio choices + optional note (maxlength 500)
- `apps/admin-panel/js/ui/ClientsTable.js` — `getStatusBadge` distinguishes `isOnHold` (`מוקפא ידנית`, `fa-pause`) from `isBlocked` (`חסום (אין שעות)`, `fa-ban`). Tooltips explain the reason. Progress bar gets `on-hold` class. Hours warning suppressed when on hold. CSV export distinguishes.
- `apps/admin-panel/js/managers/ClientsDataManager.js` — exposes `isOnHold` on the in-memory client object.
- HTML cache-bust bumped to `?v=20260516-isOnHold` for all three affected scripts on both `clients.html` and `clients-fluent.html`.

## User App

- `apps/user-app/js/modules/client-validation.js` — guard now blocks on `(client.isBlocked \|\| client.isOnHold)`.
- `apps/user-app/js/modules/client-hours.js` — same.

## Docs

- `docs/CLIENTS_SYSTEM_REPORT.md` — new section documenting DERIVED vs MANUAL fields, calls out `isOnHold` added in PR-A.4.

## Migration

`scripts/add-isOnHold-field-2026-05-16.js` (from PR-A.3) backfills `isOnHold: false` on existing clients. This PR's code tolerates missing field (`=== true` coercion + `\|\|` OR), so deploying before migration is safe.

**Recommended order:**
1. Merge this PR → DEV deploys → smoke
2. `node scripts/add-isOnHold-field-2026-05-16.js` (dry-run)
3. `node scripts/add-isOnHold-field-2026-05-16.js --confirm` (live)
4. Promote to production-stable

## Rollback

Per `.claude/rubrics/pr-a-4.md:87-101`:

- **DEV:** `git revert <merge-commit>` on main → CI redeploys (5 min)
- `isOnHold` field on existing clients stays harmless (default false)
- UI returns to native prompt() flow
- Firebase Functions roll back on next deploy
- **PROD:** same flow + promote revert; `firebase deploy --only functions` from clean checkout of pre-merge main

## Per `functions/CLAUDE.md`

- **Writes:** Only `writeClientWithCanonicalAggregates` (via `changeClientStatus`). Other 13 CFs in PR-B scope.
- **Reads:** Admin Panel `ClientsDataManager`, User App guards, `audit_log`.
- **Recalculates aggregates:** `calcClientAggregates` (via helper).
- **CREATE / UPDATE / DELETE:** CREATE unchanged. UPDATE covered by 28 tests + grader. DELETE unchanged.
- **Fallback logic:** Helper tolerates malformed services.
- **Drift risk:** Closed for `changeClientStatus` path.

## Per `apps/admin-panel/CLAUDE.md`

- **Data shown:** Client status badge + progress bar + CSV.
- **Source vs derived:** Badge distinguishes manual (`isOnHold`) from derived (`isBlocked`/`isCritical`). Tooltip explains source.
- **Filters:** `blocked` tab and `needsAttention` still use `isBlocked` only — PR-A.5 will tighten if needed.
- **Stale state:** Cache-bust bumped; modal updates local client state from CF response.

## Verification

- ✅ `functions/` Jest: 274 tests pass (269 prior + 5 new)
- ✅ Root Vitest: 193 pass / 2 skipped
- ✅ Lint: 0 errors
- ✅ Outcomes Grader: PASS_WITH_WARNINGS (10/10 MUST)

## Test plan

- [ ] CI green (lint + types + tests + security)
- [ ] DEV smoke: open client management modal — verify modal appears (not native prompt)
- [ ] DEV smoke: choose "on_hold" with note → verify status badge shows "מוקפא ידנית"
- [ ] DEV smoke: try to call `changeClientStatus({isBlocked:true})` via console — verify `invalid-argument` returned
- [ ] DEV smoke: User App — verify time-entry blocked for both isBlocked AND isOnHold clients
- [ ] DEV smoke: CSV export — verify column distinguishes
- [ ] Run migration dry-run → verify reasonable count + idempotent re-run
- [ ] Run migration live → verify backup file + audit_log entry