### PR TITLE
fix(admin-report): use canonical isFixedService in ClientReportModal (PR-A.4.1)

### DIFF
--- a/.claude/rubrics/pr-a-4-1.md
+++ b/.claude/rubrics/pr-a-4-1.md
@@ -1,0 +1,57 @@
+# Rubric — PR-A.4.1
+
+**Title:** fix(admin-report): use canonical isFixedService in ClientReportModal service card
+**Branch:** fix/client-report-modal-type-tag-pr-a-4-1
+**Base:** main
+**Scope:** Quick fix for a visible UI bug in the Client Report modal. Service cards rendered "שעות" (hourly) badge for plain `type: 'fixed'` services because the legacy check `pricingType === 'fixed'` only matched `legal_procedure + pricingType=fixed`. Switch to the canonical `isFixedService` check (already exposed via `window.ClientTypeDisplay`). Display only — no data path changes.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Canonical isFixedService used in createServiceCard
+**Rule:** `apps/admin-panel/js/ui/ClientReportModal.js:createServiceCard` computes `isFixedPrice` via `window.ClientTypeDisplay.isFixedService(serviceInfo)`. A fallback for the rare case the helper is not loaded must mirror its exact logic (`type === 'fixed' || (type === 'legal_procedure' && pricingType === 'fixed')`).
+**Evidence required:** Grep for `isFixedService` in the file shows the new call site.
+
+### M2 — Legacy `pricingType === 'fixed'` only on its own line removed
+**Rule:** The previous single-line check `const isFixedPrice = serviceInfo.pricingType === 'fixed';` is gone from `createServiceCard`. Other callers of `pricingType === 'fixed'` are allowed elsewhere if they handle the legal_procedure subtype explicitly.
+**Evidence required:** Diff of ClientReportModal.js shows the replacement.
+
+### M3 — Cache-bust bumped
+**Rule:** Both `apps/admin-panel/clients.html` and `apps/admin-panel/clients-fluent.html` reference `ClientReportModal.js?v=...` with a fresh version string (NOT the prior `20260507-stage-2`).
+**Evidence required:** Grep on both HTML files.
+
+### M4 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors.
+**Evidence required:** Lint output.
+
+### M5 — All existing tests pass
+**Rule:** Root `npm test` (Vitest) passes. `cd functions && npm test` (Jest) passes. No regression in count.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — No data-path changes
+**Rule:** Edit confined to display/badge logic. No changes to `procedureType` / `type` / `pricingType` writes anywhere. No CF touched. No User App touched.
+**Evidence required:** Diff scope inspection.
+
+### S2 — Comment explains the bug
+**Rule:** Inline comment near the fix references the cause (legacy check missed plain `type: 'fixed'`).
+**Evidence required:** Diff shows comment.
+
+### S3 — Other isFixedPrice consumers in the same function still work
+**Rule:** `isFixedPrice` is reused at lines ~757 (`card.classList.add('fixed')`), ~838 (badge), ~869 (time tracker), ~897 (stats grid). Verify the new computation does not silently downgrade behavior for legal_procedure+fixed services.
+**Evidence required:** Confirm the new `isFixedService` returns true for both `type === 'fixed'` AND `type === 'legal_procedure' && pricingType === 'fixed'`.
+
+## Out of scope
+
+- `ReportGenerator.js` legacy `client.type === 'hours' || ... || procedureType === 'legal_procedure'` chains — separate bug class, separate PR.
+- Any change to the actual hours / fixed-price calculations.
+- Migration of historical client documents (PR-D).
+- Any new tests for the Report modal (existing tests cover client-type-display + aggregates; this fix uses the same canonical helper).
+
+## Rollback
+
+`git revert <merge-commit>` on main → CI redeploys. The badge reverts to the prior "שעות" misrender; no data effect.
+
+## Notes for grader
+
+This is a 1-function fix. Don't expect new unit tests — the canonical `isFixedService` helper is already covered (29 tests in `write-client-canonical-aggregates.test.js` and the 30 tests in `tests/unit/admin-panel/client-type-display.test.ts`). The fix is wiring an existing-and-tested helper into a UI consumer that was using stale logic.

--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -438,7 +438,7 @@
     <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
 
     <!-- Fluent Design Components -->

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -579,7 +579,7 @@
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260507-stage-2"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
     <script src="js/ui/ClientManagementModal.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
 

--- a/apps/admin-panel/js/ui/ClientReportModal.js
+++ b/apps/admin-panel/js/ui/ClientReportModal.js
@@ -734,8 +734,17 @@ return;
             const totalHours = parseFloat(serviceInfo.totalHours) || 0;
 
             // 🎯 Detect service type and pricing
+            // PR-A.4.1 (2026-05-16): use canonical isFixedService check.
+            // BUG fixed: prior `pricingType === 'fixed'` only matched legal_procedure+fixed
+            // and missed plain `type === 'fixed'` services (e.g. שירות קבוע / "פתיחת חברת יחיד").
+            // Result was the badge falling through to "שעות" + clock icon, despite the
+            // Client Management modal correctly showing "מחיר קבוע".
+            // Canonical check mirrors functions/shared/aggregates.js:isFixedService.
             const isLegalProcedure = serviceInfo.type === 'legal_procedure';
-            const isFixedPrice = serviceInfo.pricingType === 'fixed';
+            const isFixedPrice = (window.ClientTypeDisplay && window.ClientTypeDisplay.isFixedService)
+                ? window.ClientTypeDisplay.isFixedService(serviceInfo)
+                : (serviceInfo.type === 'fixed' ||
+                    (serviceInfo.type === 'legal_procedure' && serviceInfo.pricingType === 'fixed'));
             const isHourlyBased = !isFixedPrice; // שעתי או הליך משפטי שעתי
 
             const hasOverdraft = serviceInfo.overdraftResolved?.isResolved !== true &&


### PR DESCRIPTION
## Summary

Surfaced during PR-A.4 DEV smoke: Client Report modal rendered "שעות" badge with clock icon for plain `type: 'fixed'` services (e.g. שלומי לחיאני's "פתיחת חברת יחיד"), even though Client Management modal correctly showed "מחיר קבוע". Visible UI bug, no data path.

**Rubric:** `.claude/rubrics/pr-a-4-1.md`
**Outcomes Grader verdict:** **PASS — 8/8** (5 MUST + 3 SHOULD)

## Root cause

`apps/admin-panel/js/ui/ClientReportModal.js:createServiceCard` computed:

```js
const isFixedPrice = serviceInfo.pricingType === 'fixed';
```

Matches only `legal_procedure + pricingType=fixed`. Plain `type: 'fixed'` services don't set `pricingType` — their `type` field IS the type. So `isFixedPrice` evaluated false → badge fell through to default "שעות" branch with `fa-clock` icon.

The canonical check (`functions/shared/aggregates.js:isFixedService`, mirrored in `apps/admin-panel/js/core/client-type-display.js:175`) handles both cases. Already wired in #267 for ClientsTable + ClientsDataManager + exposed on window. Report modal was never migrated.

## Fix

Replace the single-line legacy check with a call to `window.ClientTypeDisplay.isFixedService(serviceInfo)` + defensive fallback mirroring the helper's exact logic.

All 4 downstream uses of `isFixedPrice` in the same function (card class, badge, time tracker, stats grid) benefit from corrected truth — equal-or-broader detection, never narrower.

## Verification

- ✅ Vitest: 193 pass / 2 skipped (no regression)
- ✅ Jest (functions): 274 pass (no regression)
- ✅ Lint: 0 errors
- ✅ Outcomes Grader: **PASS — 8/8**

## Scope

Display-only. No CF, no User App, no data path. `ReportGenerator.js` has a sibling legacy-check class — out of scope here, flagged for follow-up PR.

## Rollback

`git revert <merge-commit>` → CI redeploys. Badge reverts to prior misrender. No data effect.

## Cache-bust

`ClientReportModal.js?v=20260507-stage-2` → `v=20260516-fixed-tag` on both `clients.html` and `clients-fluent.html`.

## Test plan

- [ ] CI green
- [ ] DEV smoke: open Report modal for שלומי לחיאני → verify service card shows "פיקס" with `fa-dollar-sign` icon (not "שעות")
- [ ] DEV smoke: open Report modal for a legal_procedure+fixed client → verify badge shows "פיקס" with `fa-gavel` icon
- [ ] DEV smoke: open Report modal for a regular hours client → verify badge shows "שעות" with `fa-clock` icon (unchanged)
- [ ] DEV smoke: open Report modal for legal_procedure+hourly client → verify badge shows "שעתי" with `fa-gavel` icon (unchanged)