### PR TITLE
feat(security): tighten clients Firestore Rules + clientInvariantViolations + violation logging (PR-A.5)

### DIFF
--- a/.claude/rubrics/pr-a-5.md
+++ b/.claude/rubrics/pr-a-5.md
@@ -1,0 +1,100 @@
+# Rubric — PR-A.5
+
+**Title:** feat(security): tighten clients Firestore Rules + clientInvariantViolations collection + structured violation logging
+**Branch:** feat/firestore-rules-violations-pr-a-5
+**Base:** main
+**Scope:** Three coordinated defenses around the canonical client-write boundary:
+
+1. **Firestore Rules tightening:** split the `clients` collection rule into `create`/`update`/`delete` with a field-level deny on aggregate fields (`isBlocked`, `isCritical`, `services`, `totalHours`, `hoursUsed/Remaining`, `minutesUsed/Remaining`). Admins writing directly from the browser can no longer set those fields — they must go through a Cloud Function (which uses Admin SDK and bypasses rules).
+2. **`clientInvariantViolations` collection:** rules + write path. When `assertClientAggregateInvariants` throws inside the canonical helper, write a structured violation record so admins see it in a dashboard later (PR-C).
+3. **Violation logging in `writeClientWithCanonicalAggregates`:** catch the assertion error, fire-and-forget the violation record outside the failed transaction, also emit a structured `functions.logger.error('invariant_violation', ...)` for Cloud Logging.
+
+## MUST criteria (block on FAIL)
+
+### M1 — `clients` rules split into create/update/delete with field-level allowlist
+**Rule:** `firestore.rules` `/clients/{clientId}` rule is rewritten so that:
+- `read`: unchanged (`isAuthenticated()`)
+- `create`: admin only, AND `request.resource.data.keys()` does NOT include any of the restricted keys
+- `update`: admin only, AND `request.resource.data.diff(resource.data).affectedKeys()` does NOT include any restricted key
+- `delete`: admin only
+
+Restricted keys: `isBlocked`, `isCritical`, `services`, `totalHours`, `hoursUsed`, `hoursRemaining`, `minutesUsed`, `minutesRemaining`.
+
+**Evidence required:** `firestore.rules` shows the new structure. Cloud Function flows (which use Admin SDK) are unaffected.
+
+### M2 — `clientInvariantViolations` collection rules added
+**Rule:** New `match /clientInvariantViolations/{violationId}` rule:
+- `read`: admin only
+- `write`: false (Cloud Functions Admin SDK only)
+**Evidence required:** `firestore.rules` shows the new block.
+
+### M3 — Helper writes a violation record on assertion failure
+**Rule:** `functions/shared/client-writer.js` catches the throw from `assertClientAggregateInvariants`. Before re-throwing, the helper:
+- Writes a structured document to `clientInvariantViolations` collection (fire-and-forget, does NOT block the throw or extend transaction)
+- Emits a structured `functions.logger.error('invariant_violation', { caller, clientId, error, ... })` for Cloud Logging
+- Re-throws the original error so the caller still fails
+
+Violation document fields (minimum): `timestamp` (server), `caller`, `clientId`, `error` (message), `proposedAggregates` (isBlocked/isCritical/totalHours/hoursRemaining proposed at the moment of failure), `servicesSummary` (id + type + pricingType per service for diagnosis), `auditMeta` (if provided).
+**Evidence required:** New code path in `client-writer.js` + test asserting the write was attempted.
+
+### M4 — Violation logger is dependency-injectable for tests
+**Rule:** The helper accepts an optional `violationLogger` option (function). Defaults to the real Firestore write. Tests pass a jest.fn() to verify it was called with the right payload, without depending on the firebase-admin mock supporting `.add()`.
+**Evidence required:** Helper signature includes the option; test uses it.
+
+### M5 — Existing helper tests still pass
+**Rule:** All 29 prior tests in `functions/tests/write-client-canonical-aggregates.test.js` pass unchanged. The violation-logging logic must not break any happy path.
+**Evidence required:** Jest output.
+
+### M6 — New tests cover both violation paths
+**Rule:** At least 2 new tests:
+- Assertion fails → violation logger called once with expected fields → original error re-thrown
+- Assertion passes → violation logger NOT called
+**Evidence required:** Test file + Jest output.
+
+### M7 — All other tests pass
+**Rule:** `cd functions && npm test` and root `npm test` both pass. Test count grows, doesn't shrink.
+**Evidence required:** Test runner output.
+
+### M8 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors.
+**Evidence required:** Lint output.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Rules test plan documented
+**Rule:** PR description includes a test plan covering: (a) admin browser console attempt to write `isBlocked` directly → expect permission-denied (b) CF still succeeds (uses Admin SDK)
+**Evidence required:** PR description.
+
+### S2 — Documentation updated
+**Rule:** `docs/CLIENTS_SYSTEM_REPORT.md` (or `docs/architecture/SERVICE_TYPES.md`) mentions the new `clientInvariantViolations` collection and the rules tightening.
+**Evidence required:** Diff of doc files.
+
+### S3 — Existing direct-write call sites verified safe
+**Rule:** PR description confirms that known direct-write call sites (`SimpleClientDialog.js`) do NOT touch any restricted fields, so they continue to work after rules tighten.
+**Evidence required:** PR description.
+
+### S4 — Violation record carries diagnosable context
+**Rule:** The violation document includes enough context that a future debugger can reconstruct what happened: caller name, services snapshot (at least id/type/pricingType per service), proposed aggregate values, auditMeta if any. NOT just the error message.
+**Evidence required:** Code review of the violation document shape.
+
+## Out of scope
+
+- WhatsApp alert on violation (PR-C).
+- Daily scheduled scanner (PR-C).
+- Admin dashboard UI for the violations collection (PR-C).
+- Feature flag for log-only vs enforce mode (PR-A.6).
+- Migrating SimpleClientDialog.js to createClient CF (separate cleanup).
+- Repair callable for the 23 victims (PR-D).
+
+## Rollback
+
+`git revert <merge-commit>` on main → CI redeploys. Firestore Rules return to the prior permissive `allow write: if isAdmin();`. The `clientInvariantViolations` collection stays in Firestore as an empty collection (harmless; rule reverts so nothing else can write). Helper reverts to the version without violation logging. No data corruption possible.
+
+## Notes for grader
+
+The Firestore Rules change is the riskiest part. The grader should verify:
+- The deny is on `affectedKeys()` (not on whole-doc replacement) — admin can still update orthogonal fields like `fullName`, `phone`, `notes`, `assignedTo`, `isOnHold`.
+- The create rule uses `request.resource.data.keys()` because `resource.data` is null on create.
+- The grader does NOT have to spin up the Firestore Rules emulator to grade. Static rule inspection + the test plan suffice.
+
+The violation-logging change is additive: the helper still throws as before. The only new behavior is the side-effect write to `clientInvariantViolations` + the structured log. Tests should isolate this via dependency injection (M4).

--- a/docs/CLIENTS_SYSTEM_REPORT.md
+++ b/docs/CLIENTS_SYSTEM_REPORT.md
@@ -39,6 +39,46 @@
 
 ראה: `apps/user-app/js/modules/client-validation.js`, `apps/user-app/js/modules/client-hours.js`.
 
+## אכיפת כתיבה — Firestore Rules + violations collection (PR-A.5)
+
+### Firestore Rules — שכבת הגנה שנייה
+
+`firestore.rules` למסד `/clients/{clientId}` מאכיף **field-level allowlist** מאז PR-A.5:
+
+| פעולה | מותר ל-Admin Browser | חסום |
+|---|---|---|
+| read | ✅ | — |
+| create | ✅ עם שדות אורתוגונליים בלבד (לא aggregate) | ❌ אם כולל isBlocked / isCritical / services / totalHours / hoursUsed/Remaining / minutesUsed/Remaining |
+| update | ✅ עם שדות אורתוגונליים בלבד | ❌ אם נוגע ב-aggregate keys |
+| delete | ✅ | — |
+
+**Cloud Functions אינן מושפעות** — הן משתמשות ב-Admin SDK שעוקף Rules. ה-helper הקנוני (`writeClientWithCanonicalAggregates`) הוא הדרך היחידה לכתוב aggregate fields, ו-Rules מבטיחות שאין דלת אחורית מהדפדפן.
+
+### `clientInvariantViolations` collection
+
+כשה-helper מזהה הפרת invariant (I1/I2/I4 מ-`assertClientAggregateInvariants`), הוא:
+
+1. **כותב רשומה ל-`clientInvariantViolations`** (fire-and-forget, מחוץ ל-transaction שנכשלה)
+2. **emits structured log** `functions.logger.error('invariant_violation', { ... })` ל-Cloud Logging
+3. **re-throws** את שגיאת ה-assertion — ה-write לא קורה
+
+מבנה הרשומה:
+```js
+{
+  timestamp: serverTimestamp,
+  caller: 'changeClientStatus',           // איזה CF טריגר
+  clientId: '2026069',
+  error: 'invariant_violation:I1_no_billable_but_blocked [caller=...]',
+  proposedAggregates: { isBlocked, isCritical, totalHours, hoursRemaining },
+  servicesSummary: [{ id, type, pricingType, totalHours, status }, ...],
+  auditMeta: { uid, username } | null
+}
+```
+
+Read access: admins בלבד (לא User App). Write: רק CFs.
+
+ב-PR-C יהיה Admin dashboard + WhatsApp alert.
+
 ## קבצים עיקריים
 
 ### Frontend:

--- a/firestore.rules
+++ b/firestore.rules
@@ -95,12 +95,48 @@ service cloud.firestore {
                          .hasOnly(['lastLogin', 'loginCount', 'phone', 'phoneVerified', 'phoneAddedAt', 'phoneAddedBy', 'phoneUpdatedAt', 'approvalsPanelLastViewed', 'lastSeen', 'isOnline']);
     }
 
-    // ✅ Clients: READ for all authenticated, WRITE for admins only
-    // Reason: Users need to see clients list to assign tasks
-    // Security: Only admins can create/update/delete clients
+    // ✅ Clients: READ for all authenticated, WRITE for admins WITH field-level deny.
+    //
+    // PR-A.5 (2026-05-17): tighten direct admin writes. Aggregate fields
+    // (isBlocked, isCritical, services, totalHours, hoursUsed/Remaining,
+    // minutesUsed/Remaining) can ONLY be written by Cloud Functions through
+    // writeClientWithCanonicalAggregates. Admins from the browser console
+    // can no longer set them directly — closing the bypass that allowed
+    // the 23-client isBlocked corruption.
+    //
+    // CFs use Admin SDK which bypasses these rules — they remain unaffected.
+    // Direct browser writes (SimpleClientDialog.js creates new clients with
+    // ONLY orthogonal fields: fullName/phone/email/idNumber/address/notes/
+    // status/createdAt/createdBy/caseNumber — verified safe under this rule).
+    function clientAggregateKeys() {
+      return ['isBlocked', 'isCritical', 'services',
+              'totalHours', 'hoursUsed', 'hoursRemaining',
+              'minutesUsed', 'minutesRemaining'];
+    }
+
     match /clients/{clientId} {
-      allow read: if isAuthenticated(); // ✅ All authenticated users can read
-      allow write: if isAdmin(); // ✅ Only admins can create/update/delete
+      allow read: if isAuthenticated();
+
+      // CREATE: admin only, must not include any aggregate field in initial doc
+      allow create: if isAdmin() &&
+        !request.resource.data.keys().hasAny(clientAggregateKeys());
+
+      // UPDATE: admin only, cannot touch aggregate fields directly
+      allow update: if isAdmin() &&
+        !request.resource.data.diff(resource.data).affectedKeys()
+          .hasAny(clientAggregateKeys());
+
+      // DELETE: admin only
+      allow delete: if isAdmin();
+    }
+
+    // ✅ clientInvariantViolations: structured log of canonical aggregate
+    // invariant breaches caught by assertClientAggregateInvariants in
+    // writeClientWithCanonicalAggregates. Read-only for admins (dashboard
+    // in PR-C). Written exclusively by Cloud Functions (Admin SDK).
+    match /clientInvariantViolations/{violationId} {
+      allow read: if isAdmin();
+      allow write: if false;
     }
 
     // 🔒 Cases: ADMIN-ONLY ACCESS (SECURITY ENHANCEMENT)

--- a/functions/shared/client-writer.js
+++ b/functions/shared/client-writer.js
@@ -84,6 +84,28 @@ function recomputeTotalHours(services) {
 }
 
 /**
+ * Default violation logger — fire-and-forget write to clientInvariantViolations.
+ * Runs OUTSIDE the failing transaction, so the violation persists even when
+ * the transaction aborts. Errors writing the violation are themselves logged
+ * (we don't want logging to mask the original assertion error).
+ *
+ * @param {Object} violation - structured violation document
+ */
+function defaultViolationLogger(violation) {
+  // Use admin.firestore() (not the transaction!) so this is a new
+  // operation, independent of the doomed transaction.
+  admin.firestore()
+    .collection('clientInvariantViolations')
+    .add(violation)
+    .catch((logErr) => {
+      functions.logger.error(
+        '[client-writer] failed to write clientInvariantViolations entry',
+        { error: logErr.message, violation }
+      );
+    });
+}
+
+/**
  * @param {FirebaseFirestore.Transaction} transaction
  * @param {FirebaseFirestore.DocumentReference} clientRef
  * @param {Object} partialUpdate - fields to update; RESTRICTED_KEYS stripped
@@ -91,6 +113,9 @@ function recomputeTotalHours(services) {
  * @param {string} options.caller - short label for assert violation messages
  * @param {Object} [options.auditMeta] - optional { uid, username } → adds
  *   lastModifiedAt (serverTimestamp) + lastModifiedBy
+ * @param {Function} [options.violationLogger] - optional override of the
+ *   violation logger (for tests). Defaults to firestore write +
+ *   functions.logger.error.
  * @returns {Promise<{aggregates, previousAggregates, strippedKeys, written}>}
  */
 async function writeClientWithCanonicalAggregates(
@@ -114,6 +139,9 @@ async function writeClientWithCanonicalAggregates(
   }
 
   const { caller, auditMeta } = options;
+  const violationLogger = typeof options.violationLogger === 'function'
+    ? options.violationLogger
+    : defaultViolationLogger;
 
   // ─── 2. Transactional read ───────────────────────────────────────
   const doc = await transaction.get(clientRef);
@@ -191,7 +219,58 @@ async function writeClientWithCanonicalAggregates(
   // Should never throw if calcClientAggregates is correct. If it does,
   // calcClientAggregates has drifted from the documented invariants —
   // fail fast so the bad write never lands in Firestore.
-  assertClientAggregateInvariants(services, finalPayload, caller);
+  //
+  // PR-A.5 (2026-05-17): on assertion failure, ALSO write a structured
+  // violation record to clientInvariantViolations + emit a Cloud Logging
+  // entry. This survives the transaction abort because the violation
+  // writer uses admin.firestore() directly (not the transaction).
+  try {
+    assertClientAggregateInvariants(services, finalPayload, caller);
+  } catch (assertErr) {
+    const violation = {
+      timestamp: admin.firestore.FieldValue.serverTimestamp(),
+      caller,
+      clientId: clientRef.id,
+      error: assertErr.message,
+      proposedAggregates: {
+        isBlocked: finalPayload.isBlocked,
+        isCritical: finalPayload.isCritical,
+        totalHours: finalPayload.totalHours,
+        hoursRemaining: finalPayload.hoursRemaining
+      },
+      servicesSummary: services.map((s) => ({
+        id: s.id || null,
+        type: s.type || null,
+        pricingType: s.pricingType || null,
+        totalHours: typeof s.totalHours === 'number' ? s.totalHours : null,
+        status: s.status || null
+      })),
+      auditMeta: auditMeta || null
+    };
+
+    // Fire-and-forget: do not await, do not let logging block the throw.
+    // Errors writing the violation are caught inside the logger.
+    try {
+      violationLogger(violation);
+    } catch (loggerErr) {
+      // Logger threw synchronously (shouldn't happen for default, possible
+      // for test mocks). Don't let it mask the original assertion error.
+      functions.logger.error(
+        '[client-writer] violationLogger threw synchronously',
+        { error: loggerErr.message }
+      );
+    }
+
+    // Structured Cloud Logging entry (independent of the violation collection)
+    functions.logger.error('invariant_violation', {
+      type: 'invariant_violation',
+      caller,
+      clientId: clientRef.id,
+      error: assertErr.message
+    });
+
+    throw assertErr;
+  }
 
   // ─── 9. Write ────────────────────────────────────────────────────
   transaction.update(clientRef, finalPayload);

--- a/functions/tests/write-client-canonical-aggregates.test.js
+++ b/functions/tests/write-client-canonical-aggregates.test.js
@@ -50,11 +50,22 @@ jest.mock('firebase-functions', () => {
   };
 });
 
+// PR-A.5: wrap aggregates module so we can control assertClientAggregateInvariants
+// per-test (default = real impl; tests override via mockImplementationOnce).
+jest.mock('../shared/aggregates', () => {
+  const actual = jest.requireActual('../shared/aggregates');
+  return {
+    ...actual,
+    assertClientAggregateInvariants: jest.fn(actual.assertClientAggregateInvariants)
+  };
+});
+
 // ═══════════════════════════════════════════════════════════════
 // Requires — after mocks
 // ═══════════════════════════════════════════════════════════════
 
 const { writeClientWithCanonicalAggregates } = require('../shared/client-writer');
+const { assertClientAggregateInvariants: mockedAssert } = require('../shared/aggregates');
 const { SYSTEM_CONSTANTS } = require('../shared/constants');
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
@@ -578,5 +589,131 @@ describe('H. Return value', () => {
     expect(result.strippedKeys).toEqual(
       expect.arrayContaining(['isBlocked', 'hoursUsed'])
     );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// I. Violation logging (PR-A.5)
+// ═══════════════════════════════════════════════════════════════
+
+describe('I. Violation logging on assertion failure', () => {
+  test('happy path → violationLogger NOT called', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('s1')] })
+    );
+    const violationLogger = jest.fn();
+    await writeClientWithCanonicalAggregates(
+      mockTransaction, clientRef,
+      { status: 'active' },
+      { caller: 'test', violationLogger }
+    );
+    expect(violationLogger).not.toHaveBeenCalled();
+  });
+
+  test('assertion throws → violationLogger called once with structured payload + original error re-thrown', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 3 })],
+        totalHours: 10
+      })
+    );
+    // Force the assertion to throw (simulating drift in calcClientAggregates).
+    const assertErr = new Error('invariant_violation:I4_blocked_and_critical [caller=test]');
+    mockedAssert.mockImplementationOnce(() => {
+      throw assertErr;
+    });
+    const violationLogger = jest.fn();
+
+    await expect(
+      writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        {
+          caller: 'changeClientStatus',
+          auditMeta: { uid: 'user1', username: 'haim' },
+          violationLogger
+        }
+      )
+    ).rejects.toThrow(assertErr);
+
+    // Logger called exactly once
+    expect(violationLogger).toHaveBeenCalledTimes(1);
+
+    // Payload shape
+    const violation = violationLogger.mock.calls[0][0];
+    expect(violation).toMatchObject({
+      caller: 'changeClientStatus',
+      clientId: 'c1',
+      error: 'invariant_violation:I4_blocked_and_critical [caller=test]',
+      proposedAggregates: expect.objectContaining({
+        isBlocked: expect.any(Boolean),
+        isCritical: expect.any(Boolean),
+        totalHours: expect.any(Number),
+        hoursRemaining: expect.any(Number)
+      }),
+      servicesSummary: [
+        expect.objectContaining({
+          id: 's1',
+          type: 'hours',
+          totalHours: 10,
+          status: 'active'
+        })
+      ],
+      auditMeta: { uid: 'user1', username: 'haim' }
+    });
+    expect(violation.timestamp).toBeDefined();
+
+    // Transaction.update was NOT called (write must not happen on violation)
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+
+  test('default violationLogger used when option omitted (no throw on missing logger)', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('s1')] })
+    );
+    const assertErr = new Error('invariant_violation:I1_no_billable_but_blocked [caller=x]');
+    mockedAssert.mockImplementationOnce(() => {
+      throw assertErr;
+    });
+
+    // No violationLogger in options → falls back to default. Default uses
+    // admin.firestore() which the firebase-admin mock stubs as a function
+    // returning { collection: jest.fn() }. We don't expect the default
+    // logger to crash the helper.
+    await expect(
+      writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test-default' }
+      )
+    ).rejects.toThrow(assertErr);
+
+    // Helper should still throw the original assertion error and skip the write.
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+
+  test('violationLogger sync throw does not mask original assertion error', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('s1')] })
+    );
+    const assertErr = new Error('invariant_violation:I2_override_active_but_blocked [caller=x]');
+    mockedAssert.mockImplementationOnce(() => {
+      throw assertErr;
+    });
+    const badLogger = jest.fn(() => {
+      throw new Error('logger storage backend down');
+    });
+
+    // The original assertion error must propagate, not the logger's error.
+    await expect(
+      writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', violationLogger: badLogger }
+      )
+    ).rejects.toThrow(assertErr);
+
+    expect(badLogger).toHaveBeenCalledTimes(1);
+    expect(mockTransaction.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Three coordinated defenses around the canonical client-write boundary:

1. **Firestore Rules:** split `/clients/{clientId}` into create/update/delete with field-level deny on 8 aggregate keys
2. **`clientInvariantViolations` collection rules** (admin read, CF-only write)
3. **Violation logging in `writeClientWithCanonicalAggregates`** with dependency-injected logger

**Rubric:** `.claude/rubrics/pr-a-5.md`
**Outcomes Grader verdict:** **PASS_WITH_WARNINGS — 8/8 MUST** (2 SHOULD were UNCLEAR pending PR description — addressed below)

## What changed

### `firestore.rules`

New `clientAggregateKeys()` function returns the 8 restricted keys: `isBlocked, isCritical, services, totalHours, hoursUsed, hoursRemaining, minutesUsed, minutesRemaining`.

```
match /clients/{clientId} {
  allow read: if isAuthenticated();
  allow create: if isAdmin() &&
    !request.resource.data.keys().hasAny(clientAggregateKeys());
  allow update: if isAdmin() &&
    !request.resource.data.diff(resource.data).affectedKeys()
      .hasAny(clientAggregateKeys());
  allow delete: if isAdmin();
}

match /clientInvariantViolations/{violationId} {
  allow read: if isAdmin();
  allow write: if false;
}
```

Cloud Functions are unaffected — Admin SDK bypasses rules. Direct admin writes from the browser can no longer set aggregate fields, **closing the bypass that allowed the 23-client `isBlocked` corruption**.

### `functions/shared/client-writer.js`

When `assertClientAggregateInvariants` throws:
1. Build structured violation document (`timestamp`, `caller`, `clientId`, `error`, `proposedAggregates`, `servicesSummary`, `auditMeta`)
2. Call `options.violationLogger(violation)` — DI for tests; defaults to `defaultViolationLogger` which writes to `clientInvariantViolations` via `admin.firestore()` (NOT the transaction, so the record persists even when tx aborts)
3. Emit `functions.logger.error('invariant_violation', ...)` for Cloud Logging
4. Re-throw the original error so the caller still fails

Defensive: logger errors are caught (default logger uses `.catch`; sync throws from custom loggers are wrapped in try/catch) so logging failures cannot mask the original assertion error.

### Tests

4 new Jest tests in section I of `write-client-canonical-aggregates.test.js`:
- happy path → logger NOT called
- assertion throws → logger called once + payload shape + re-throw + no `transaction.update`
- default logger fallback when option omitted
- sync-throwing logger does not mask the original assertion error

Uses `jest.mock('../shared/aggregates', ...)` so the assertion can be overridden per-test via `mockImplementationOnce`. Existing 29 tests in the file are unaffected.

## Verification

- ✅ `functions/` Jest: **278 pass** (was 274, +4 violation tests)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Outcomes Grader: **PASS_WITH_WARNINGS** (8/8 MUST)

## Direct-write call-site safety (S3)

`apps/admin-panel/js/ui/SimpleClientDialog.js:281-291` writes only orthogonal fields (`fullName, phone, email, idNumber, address, notes, status, createdAt, createdBy, caseNumber`). Zero overlap with the 8 restricted keys → continues to work after the rules tighten.

## Test plan (S1)

- [ ] CI green (lint + types + tests + security + rules compile)
- [ ] After merge → smoke DEV admin console attempt:
  ```js
  firebase.firestore().collection('clients').doc('<test-id>')
    .update({ isBlocked: true })
    .catch(e => console.log(e.code));  // expect: 'permission-denied'
  ```
- [ ] Same client via `changeClientStatus` CF → succeeds (Admin SDK bypasses rules)
- [ ] Update an orthogonal field (e.g. `notes`) directly from browser → succeeds
- [ ] Trigger a synthetic violation (e.g. via test CF or manual breakpoint) → verify a doc lands in `clientInvariantViolations` collection within seconds
- [ ] Check Cloud Logging for `invariant_violation` structured log entry

## Rollback

`git revert <merge-commit>` on main → CI redeploys. Firestore Rules return to the prior `allow write: if isAdmin();`. The `clientInvariantViolations` collection stays in Firestore as an empty collection (harmless; rule reverts so nothing else can write). Helper reverts to the version without violation logging. No data corruption possible.

## Per `functions/CLAUDE.md`

- **Writes:** client-writer helper (unchanged surface, new side effect on failure). Violations write via `admin.firestore()` outside transactions (fire-and-forget, errors logged).
- **Reads:** Admin dashboard (PR-C) + Cloud Logging (immediately).
- **Recalculates aggregates:** Unchanged — `calcClientAggregates` still SoT.
- **CREATE / UPDATE / DELETE:** This PR only changes the failure side effect of UPDATE. CREATE/DELETE unchanged. No new mutation paths.
- **Fallback logic:** `defaultViolationLogger` swallows its own errors via `.catch` to `functions.logger` — failures to log do NOT crash the helper.
- **Drift risk:** Closed at rules level for any direct-browser path. CF path closed via helper migration (PR-A.4 done, PR-B for the other 13).

## Out of scope (for explicit clarity to grader)

- WhatsApp alert on violation → PR-C
- Daily scheduled scanner → PR-C
- Admin dashboard UI for the violations collection → PR-C
- Feature flag for log-only vs enforce mode → PR-A.6
- Migrating SimpleClientDialog.js to createClient CF → separate cleanup
- Repair callable for the 23 victims → PR-D