### PR TITLE
feat(security): invariant enforcement mode kill-switch (PR-A.6)

### DIFF
--- a/.claude/rubrics/pr-a-6.md
+++ b/.claude/rubrics/pr-a-6.md
@@ -1,0 +1,109 @@
+# Rubric — PR-A.6
+
+**Title:** feat(security): invariant enforcement mode kill-switch (system_settings/invariant_enforcement)
+**Branch:** feat/invariant-enforcement-mode-pr-a-6
+**Base:** main
+**Scope:** Add a centralized config-driven kill-switch for the canonical helper's invariant assertion. Three modes:
+
+- `enforce` (default) — current behavior: assertion throws + violation logged + write aborted
+- `log_only` — write proceeds with canonical aggregates; violation logged but no throw
+- `disabled` — assertion skipped entirely; no log, no throw (emergency only)
+
+Toggled via a single Firestore document at `system_settings/invariant_enforcement`. No deploy required to flip. 60-second cache per CF instance to keep Firestore read overhead negligible.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Config document path + shape defined
+**Rule:** Helper reads from `system_settings/invariant_enforcement` with shape:
+```js
+{ mode: 'enforce' | 'log_only' | 'disabled', updatedAt: Timestamp, updatedBy: string }
+```
+Missing document OR invalid `mode` value → default to `'enforce'`. Default-on-failure is the safe default.
+**Evidence required:** Helper code + a small `getEnforcementMode()` function that handles all three paths.
+
+### M2 — Three modes implemented in helper
+**Rule:** Helper behavior by mode:
+- `enforce`: try assertion → on throw, log violation + re-throw (current behavior, unchanged)
+- `log_only`: try assertion → on throw, log violation + emit `mode_log_only` Cloud Logging entry + DO NOT re-throw. Transaction proceeds with canonical aggregates.
+- `disabled`: skip assertion entirely. No log, no throw.
+**Evidence required:** Code path covers all three modes. Tests for each.
+
+### M3 — Cache strategy with bounded TTL
+**Rule:** Helper caches the mode at module level for **60 seconds (or configurable via env)** to avoid per-call Firestore reads. Cache miss → read doc → cache result. Cache hit → use cached value. Default to `'enforce'` on read failure.
+**Evidence required:** Cache module + tests covering: cache miss → read; cache hit → no extra read; expired cache → re-read.
+
+### M4 — Per-call override (testability + emergency local override)
+**Rule:** Helper accepts `options.mode` to override the global config per call. Useful for: unit tests (no Firestore mocking needed), emergency code-side override.
+**Evidence required:** `options.mode` honored if provided; fall-through to cached global if omitted.
+
+### M5 — Tests cover all three modes
+**Rule:** At least 6 new tests:
+- `enforce` happy path (no violation) → no log, write OK
+- `enforce` violation → throw + log
+- `log_only` violation → log + write proceeds + NO throw
+- `log_only` happy path → no log, write OK
+- `disabled` violation → write proceeds + NO log + NO throw
+- `disabled` happy path → write OK
+**Evidence required:** Test file shows all six cases.
+
+### M6 — Cache tests
+**Rule:** At least 2 tests:
+- First call after fresh start → reads config doc
+- Second call within TTL → no additional read
+**Evidence required:** Mock of the config reader + invocation count assertions.
+
+### M7 — Existing helper tests still pass
+**Rule:** All 33 prior tests in `write-client-canonical-aggregates.test.js` pass unchanged.
+**Evidence required:** Jest output.
+
+### M8 — Firestore Rules permit admin read of the config doc
+**Rule:** `system_settings/invariant_enforcement` is readable by `isAuthenticated()` (current rule for `system_settings/{settingId}` already covers this). NO new rule needed for read. Write remains CF-only (admin toggles via Firebase Console using Admin SDK).
+**Evidence required:** Reference to existing rule. No change to `firestore.rules`.
+
+### M9 — Default safety
+**Rule:** Helper defaults to `'enforce'` mode in ALL of these cases:
+- Document doesn't exist
+- Document exists but `mode` field missing
+- `mode` field is invalid value
+- Firestore read fails (network, permission, etc.)
+**Evidence required:** Test for each.
+
+### M10 — Lint + all tests pass
+**Rule:** `npm run lint` returns 0 errors. `cd functions && npm test` AND root `npm test` both pass.
+**Evidence required:** Output.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Docs explain how to toggle
+**Rule:** `docs/CLIENTS_SYSTEM_REPORT.md` or new short doc explains how an admin toggles the mode via Firebase Console: navigate to Firestore → `system_settings` → `invariant_enforcement` → edit `mode` field. Effect takes hold within 60 seconds.
+**Evidence required:** Diff of doc file.
+
+### S2 — Cloud Logging entry includes mode in violation record
+**Rule:** The `functions.logger.error('invariant_violation', ...)` entry includes the current `mode` so post-hoc analysis distinguishes "was enforce, write was aborted" from "was log_only, write proceeded".
+**Evidence required:** Helper code + test.
+
+### S3 — Audit recommendation
+**Rule:** PR description recommends that admins **never leave the system in `disabled` mode** longer than a single incident window. Mode is observable but no automated alerting in this PR — PR-C will add alerts.
+**Evidence required:** PR description.
+
+### S4 — Backward compat for existing callers
+**Rule:** Callers that DON'T pass `options.mode` get the global config behavior. No caller breaks. Existing tests pass without modification.
+**Evidence required:** Existing test count unchanged (33 → 33 baseline pre-PR-A.6 work).
+
+## Out of scope
+
+- Admin UI for toggling mode (Firebase Console suffices — this is an emergency tool, not a daily operation)
+- WhatsApp / SMS alert when mode changes (PR-C)
+- Auto-reset to `enforce` after N hours (could add later — risk of admin forgetting and leaving in log_only)
+- Per-client mode override (over-engineered)
+
+## Rollback
+
+`git revert <merge-commit>` on main → CI redeploys. The config document `system_settings/invariant_enforcement` stays in Firestore as an orphan (harmless). Helper reverts to PR-A.5 behavior (enforce only, no mode reading). No data corruption possible.
+
+## Notes for grader
+
+- This is the LAST defensive layer of PR-A series. After this, PR-B starts migrating the other 13 CFs.
+- Cache TTL of 60s means toggling takes effect within a minute — acceptable for emergency use. Document this clearly.
+- Default to `enforce` everywhere is the **safe default**. Misconfiguration must never silently downgrade safety.
+- The `disabled` mode is intentionally available for **extreme emergency** (assertion itself has a bug causing false positives in production). Admin must consciously set it to that value.

--- a/docs/CLIENTS_SYSTEM_REPORT.md
+++ b/docs/CLIENTS_SYSTEM_REPORT.md
@@ -79,6 +79,41 @@ Read access: admins בלבד (לא User App). Write: רק CFs.
 
 ב-PR-C יהיה Admin dashboard + WhatsApp alert.
 
+## Kill-switch — `system_settings/invariant_enforcement` (PR-A.6)
+
+מתג חירום מרכזי לשליטה בהתנהגות ה-helper אם משהו משתבש בפרודקשן. ניתן להחליף בלי deploy חדש.
+
+### 3 מצבים
+
+| מצב | התנהגות | מתי להשתמש |
+|---|---|---|
+| `enforce` (ברירת מחדל) | violation → throw + log + write נדחה | תקין. ייצור רגיל. |
+| `log_only` | violation → log + write **עובר** עם canonical aggregates | במהלך migration של callsites חדשים (PR-B). רוצים להסתכל לפני לחסום. |
+| `disabled` | assertion מדלגים לחלוטין. אין log. אין throw. | **חירום בלבד.** רק אם ה-assertion עצמו באגי. לא להשאיר ככה זמן רב. |
+
+### איך מחליפים (admin)
+
+1. Firebase Console → Firestore → `system_settings`
+2. פותחים מסמך `invariant_enforcement` (יוצרים אם חסר)
+3. שדה `mode` → אחד מ-`enforce` / `log_only` / `disabled`
+4. תוקף תוך עד **60 שניות** (cache TTL לכל CF instance)
+
+### ברירות מחדל בטוחות
+
+כל failure path מחזיר `'enforce'`:
+- מסמך חסר → enforce
+- שדה `mode` חסר → enforce
+- ערך לא תקין (case-sensitive, חייב להיות מ-VALID_MODES) → enforce
+- Firestore read fail (permission, network) → enforce
+
+→ misconfiguration **לא יכולה** להוריד בטיחות בשקט.
+
+### ניטור
+
+כל violation נרשם עם השדה `mode` בtoken — מאפשר ניתוח בדיעבד "האם זה היה enforce או log_only".
+
+ב-Cloud Logging נחפש: `invariant_violation` או `invariant_violation_log_only`.
+
 ## קבצים עיקריים
 
 ### Frontend:

--- a/functions/shared/client-writer.js
+++ b/functions/shared/client-writer.js
@@ -47,6 +47,7 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const { calcClientAggregates, assertClientAggregateInvariants } = require('./aggregates');
 const { SYSTEM_CONSTANTS } = require('./constants');
+const { getEnforcementMode, VALID_MODES } = require('./enforcement-mode');
 
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
@@ -116,7 +117,11 @@ function defaultViolationLogger(violation) {
  * @param {Function} [options.violationLogger] - optional override of the
  *   violation logger (for tests). Defaults to firestore write +
  *   functions.logger.error.
- * @returns {Promise<{aggregates, previousAggregates, strippedKeys, written}>}
+ * @param {string} [options.mode] - per-call override for the invariant
+ *   enforcement mode. One of 'enforce' | 'log_only' | 'disabled'. If
+ *   omitted, the global config at `system_settings/invariant_enforcement`
+ *   is used (cached 60s per CF instance). See `shared/enforcement-mode.js`.
+ * @returns {Promise<{aggregates, previousAggregates, strippedKeys, written, mode}>}
  */
 async function writeClientWithCanonicalAggregates(
   transaction,
@@ -142,6 +147,11 @@ async function writeClientWithCanonicalAggregates(
   const violationLogger = typeof options.violationLogger === 'function'
     ? options.violationLogger
     : defaultViolationLogger;
+
+  // PR-A.6: per-call mode override; otherwise read global config (cached).
+  const mode = (typeof options.mode === 'string' && VALID_MODES.indexOf(options.mode) !== -1)
+    ? options.mode
+    : await getEnforcementMode();
 
   // ─── 2. Transactional read ───────────────────────────────────────
   const doc = await transaction.get(clientRef);
@@ -215,61 +225,77 @@ async function writeClientWithCanonicalAggregates(
     }
   }
 
-  // ─── 8. Defensive invariant assertion ────────────────────────────
+  // ─── 8. Defensive invariant assertion (mode-aware) ───────────────
   // Should never throw if calcClientAggregates is correct. If it does,
-  // calcClientAggregates has drifted from the documented invariants —
-  // fail fast so the bad write never lands in Firestore.
+  // calcClientAggregates has drifted from the documented invariants.
   //
-  // PR-A.5 (2026-05-17): on assertion failure, ALSO write a structured
-  // violation record to clientInvariantViolations + emit a Cloud Logging
-  // entry. This survives the transaction abort because the violation
-  // writer uses admin.firestore() directly (not the transaction).
-  try {
-    assertClientAggregateInvariants(services, finalPayload, caller);
-  } catch (assertErr) {
-    const violation = {
-      timestamp: admin.firestore.FieldValue.serverTimestamp(),
-      caller,
-      clientId: clientRef.id,
-      error: assertErr.message,
-      proposedAggregates: {
-        isBlocked: finalPayload.isBlocked,
-        isCritical: finalPayload.isCritical,
-        totalHours: finalPayload.totalHours,
-        hoursRemaining: finalPayload.hoursRemaining
-      },
-      servicesSummary: services.map((s) => ({
-        id: s.id || null,
-        type: s.type || null,
-        pricingType: s.pricingType || null,
-        totalHours: typeof s.totalHours === 'number' ? s.totalHours : null,
-        status: s.status || null
-      })),
-      auditMeta: auditMeta || null
-    };
-
-    // Fire-and-forget: do not await, do not let logging block the throw.
-    // Errors writing the violation are caught inside the logger.
+  // PR-A.5 (2026-05-17): on assertion failure, also write a structured
+  // violation record + Cloud Logging entry.
+  // PR-A.6 (2026-05-17): behavior gated by enforcement mode:
+  //   - 'enforce'  (default) — fail fast: throw + log + write aborted
+  //   - 'log_only'           — log + emit mode_log_only marker, write
+  //                            proceeds with canonical aggregates
+  //   - 'disabled'           — skip assertion entirely (EMERGENCY ONLY)
+  if (mode !== 'disabled') {
     try {
-      violationLogger(violation);
-    } catch (loggerErr) {
-      // Logger threw synchronously (shouldn't happen for default, possible
-      // for test mocks). Don't let it mask the original assertion error.
-      functions.logger.error(
-        '[client-writer] violationLogger threw synchronously',
-        { error: loggerErr.message }
-      );
+      assertClientAggregateInvariants(services, finalPayload, caller);
+    } catch (assertErr) {
+      const violation = {
+        timestamp: admin.firestore.FieldValue.serverTimestamp(),
+        caller,
+        clientId: clientRef.id,
+        error: assertErr.message,
+        mode, // PR-A.6: record which mode was active
+        proposedAggregates: {
+          isBlocked: finalPayload.isBlocked,
+          isCritical: finalPayload.isCritical,
+          totalHours: finalPayload.totalHours,
+          hoursRemaining: finalPayload.hoursRemaining
+        },
+        servicesSummary: services.map((s) => ({
+          id: s.id || null,
+          type: s.type || null,
+          pricingType: s.pricingType || null,
+          totalHours: typeof s.totalHours === 'number' ? s.totalHours : null,
+          status: s.status || null
+        })),
+        auditMeta: auditMeta || null
+      };
+
+      // Fire-and-forget violation record.
+      try {
+        violationLogger(violation);
+      } catch (loggerErr) {
+        functions.logger.error(
+          '[client-writer] violationLogger threw synchronously',
+          { error: loggerErr.message }
+        );
+      }
+
+      // Structured Cloud Logging entry (mode included for analysis)
+      functions.logger.error('invariant_violation', {
+        type: 'invariant_violation',
+        caller,
+        clientId: clientRef.id,
+        error: assertErr.message,
+        mode
+      });
+
+      if (mode === 'enforce') {
+        // Default behavior: write aborted, error propagates.
+        throw assertErr;
+      }
+      // mode === 'log_only': emit a marker so analysts can search for it,
+      // then fall through to write the canonical aggregates anyway. This
+      // is the safety net during PR-B migration: surface unexpected
+      // assertions without breaking users.
+      functions.logger.warn('invariant_violation_log_only', {
+        type: 'invariant_violation_log_only',
+        caller,
+        clientId: clientRef.id,
+        error: assertErr.message
+      });
     }
-
-    // Structured Cloud Logging entry (independent of the violation collection)
-    functions.logger.error('invariant_violation', {
-      type: 'invariant_violation',
-      caller,
-      clientId: clientRef.id,
-      error: assertErr.message
-    });
-
-    throw assertErr;
   }
 
   // ─── 9. Write ────────────────────────────────────────────────────
@@ -279,7 +305,8 @@ async function writeClientWithCanonicalAggregates(
     aggregates,
     previousAggregates,
     strippedKeys,
-    written: finalPayload
+    written: finalPayload,
+    mode // PR-A.6: surface the active mode for caller observability
   };
 }
 

--- a/functions/shared/enforcement-mode.js
+++ b/functions/shared/enforcement-mode.js
@@ -1,0 +1,138 @@
+/**
+ * Invariant Enforcement Mode — emergency kill-switch for the canonical
+ * client-write helper's assertion behavior.
+ *
+ * Reads `system_settings/invariant_enforcement` from Firestore and caches
+ * the result for `CACHE_TTL_MS` (default 60 seconds) per CF instance.
+ *
+ * Three modes (see `.claude/rubrics/pr-a-6.md` for rationale):
+ *   - `enforce`   — current production behavior. Assertion throws on
+ *                   violation, write aborted, violation logged.
+ *   - `log_only`  — assertion failure does NOT throw. Write proceeds with
+ *                   canonical aggregates. Violation logged with the mode
+ *                   so post-hoc analysis distinguishes from `enforce`.
+ *   - `disabled`  — assertion skipped entirely. No log, no throw. EMERGENCY
+ *                   ONLY — leaves no observability of drift. Use only when
+ *                   the assertion itself is buggy and producing false
+ *                   positives in production.
+ *
+ * SAFETY DEFAULTS
+ *   Every failure path (missing doc, malformed mode field, Firestore read
+ *   error) returns `'enforce'`. Misconfiguration must never silently
+ *   downgrade safety. A noisy Cloud Logging warning records the fallback.
+ *
+ * HOW TO TOGGLE (admin)
+ *   1. Firebase Console → Firestore → `system_settings` collection
+ *   2. Open document `invariant_enforcement` (create if missing)
+ *   3. Set `mode` field to `enforce` | `log_only` | `disabled`
+ *   4. Effect takes hold across CF instances within `CACHE_TTL_MS` (60s).
+ *
+ * @module functions/shared/enforcement-mode
+ */
+
+const admin = require('firebase-admin');
+const functions = require('firebase-functions');
+
+const VALID_MODES = Object.freeze(['enforce', 'log_only', 'disabled']);
+const DEFAULT_MODE = 'enforce';
+const CACHE_TTL_MS = parseInt(
+  process.env.INVARIANT_ENFORCEMENT_CACHE_TTL_MS || '60000',
+  10
+);
+
+const DOC_PATH = {
+  collection: 'system_settings',
+  document: 'invariant_enforcement'
+};
+
+// Module-level cache. Reset to null on cold start.
+let cachedMode = null;
+let cachedAt = 0;
+
+/**
+ * Validate and coerce a raw mode value. Invalid → DEFAULT_MODE (with warn).
+ * @param {*} raw
+ * @param {string} [reasonContext] — diagnostic context for the warn log
+ * @returns {string} a value from VALID_MODES
+ */
+function normalizeMode(raw, reasonContext = '') {
+  if (typeof raw === 'string' && VALID_MODES.indexOf(raw) !== -1) {
+    return raw;
+  }
+  functions.logger.warn('[enforcement-mode] invalid mode → defaulting to enforce', {
+    raw,
+    context: reasonContext,
+    validModes: VALID_MODES.slice()
+  });
+  return DEFAULT_MODE;
+}
+
+/**
+ * Read the mode document from Firestore. Bypasses cache.
+ * On any failure, returns DEFAULT_MODE (with warn).
+ *
+ * @returns {Promise<string>} a value from VALID_MODES
+ */
+async function readModeFromFirestore() {
+  try {
+    const doc = await admin.firestore()
+      .collection(DOC_PATH.collection)
+      .doc(DOC_PATH.document)
+      .get();
+    if (!doc.exists) {
+      // Missing doc is acceptable — first deploy, never configured.
+      // Default to enforce, but log once-per-cache-cycle for visibility.
+      return DEFAULT_MODE;
+    }
+    const data = doc.data() || {};
+    return normalizeMode(data.mode, `${DOC_PATH.collection}/${DOC_PATH.document}`);
+  } catch (err) {
+    functions.logger.warn('[enforcement-mode] read failed → defaulting to enforce', {
+      error: err.message
+    });
+    return DEFAULT_MODE;
+  }
+}
+
+/**
+ * Get the current enforcement mode, using cache when fresh.
+ *
+ * Cache is per-CF-instance and TTL-bounded. After TTL expiry, the next call
+ * re-reads from Firestore. Concurrent calls during a re-read MAY each issue
+ * their own read (acceptable — small extra cost at cache turnover).
+ *
+ * @returns {Promise<string>} a value from VALID_MODES
+ */
+async function getEnforcementMode() {
+  const now = Date.now();
+  if (cachedMode !== null && (now - cachedAt) < CACHE_TTL_MS) {
+    return cachedMode;
+  }
+  const mode = await readModeFromFirestore();
+  cachedMode = mode;
+  cachedAt = now;
+  return mode;
+}
+
+/**
+ * Test-only: clear cache between tests.
+ * NOT exported by default — only accessible via the `_test` namespace.
+ */
+function _resetCacheForTests() {
+  cachedMode = null;
+  cachedAt = 0;
+}
+
+module.exports = {
+  getEnforcementMode,
+  // Constants for callers + tests
+  VALID_MODES,
+  DEFAULT_MODE,
+  CACHE_TTL_MS,
+  // Test-only namespace
+  _test: {
+    resetCache: _resetCacheForTests,
+    readModeFromFirestore,
+    normalizeMode
+  }
+};

--- a/functions/tests/enforcement-mode.test.js
+++ b/functions/tests/enforcement-mode.test.js
@@ -1,0 +1,171 @@
+/**
+ * Tests for the enforcement-mode module (PR-A.6).
+ *
+ * Coverage:
+ *   - Default to 'enforce' when doc missing
+ *   - Read valid mode from Firestore
+ *   - Coerce invalid mode → 'enforce'
+ *   - Coerce missing `mode` field → 'enforce'
+ *   - Coerce Firestore read error → 'enforce'
+ *   - Cache: second call within TTL skips Firestore
+ *   - Cache: expired TTL re-reads
+ *   - Cache: explicit reset for tests
+ */
+
+const mockDocGet = jest.fn();
+const mockDocRef = { get: mockDocGet };
+const mockCollection = jest.fn(() => ({ doc: jest.fn(() => mockDocRef) }));
+
+jest.mock('firebase-admin', () => {
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(
+      jest.fn(() => ({ collection: mockCollection })),
+      { FieldValue: { serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP') } }
+    )
+  };
+});
+
+jest.mock('firebase-functions', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+// Require after mocks
+const enforcementMode = require('../shared/enforcement-mode');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  enforcementMode._test.resetCache();
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Default safety
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Default safety', () => {
+  test('doc missing → defaults to enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: false });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('doc exists but `mode` field missing → defaults to enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({}) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('mode field is invalid value → defaults to enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'invalid_mode' }) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('mode field is non-string → defaults to enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 42 }) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('Firestore read throws → defaults to enforce', async () => {
+    mockDocGet.mockRejectedValue(new Error('permission-denied'));
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('doc.data() returns null → defaults to enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => null });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Valid modes pass through
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Valid mode values', () => {
+  test('mode=enforce → enforce', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'enforce' }) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('enforce');
+  });
+
+  test('mode=log_only → log_only', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'log_only' }) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('log_only');
+  });
+
+  test('mode=disabled → disabled', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'disabled' }) });
+    await expect(enforcementMode.getEnforcementMode()).resolves.toBe('disabled');
+  });
+
+  test('VALID_MODES contains exactly the three modes', () => {
+    expect(enforcementMode.VALID_MODES.slice()).toEqual(['enforce', 'log_only', 'disabled']);
+  });
+
+  test('DEFAULT_MODE is enforce', () => {
+    expect(enforcementMode.DEFAULT_MODE).toBe('enforce');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Caching behavior
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Caching', () => {
+  test('first call reads Firestore', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'log_only' }) });
+    await enforcementMode.getEnforcementMode();
+    expect(mockDocGet).toHaveBeenCalledTimes(1);
+  });
+
+  test('second call within TTL skips Firestore', async () => {
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'log_only' }) });
+    await enforcementMode.getEnforcementMode();
+    await enforcementMode.getEnforcementMode();
+    await enforcementMode.getEnforcementMode();
+    expect(mockDocGet).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache returns the cached value, not a fresh read', async () => {
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({ mode: 'log_only' }) });
+    const first = await enforcementMode.getEnforcementMode();
+    // Change the underlying doc — but cache should serve the old value.
+    mockDocGet.mockResolvedValue({ exists: true, data: () => ({ mode: 'enforce' }) });
+    const second = await enforcementMode.getEnforcementMode();
+    expect(first).toBe('log_only');
+    expect(second).toBe('log_only'); // from cache
+    expect(mockDocGet).toHaveBeenCalledTimes(1); // only the first call hit Firestore
+  });
+
+  test('resetCache forces re-read on next call', async () => {
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({ mode: 'log_only' }) });
+    await enforcementMode.getEnforcementMode();
+    enforcementMode._test.resetCache();
+    mockDocGet.mockResolvedValueOnce({ exists: true, data: () => ({ mode: 'disabled' }) });
+    const after = await enforcementMode.getEnforcementMode();
+    expect(after).toBe('disabled');
+    expect(mockDocGet).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. normalizeMode helper
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. normalizeMode (test-only export)', () => {
+  test.each([
+    ['enforce', 'enforce'],
+    ['log_only', 'log_only'],
+    ['disabled', 'disabled']
+  ])('passes through valid mode %s', (input, expected) => {
+    expect(enforcementMode._test.normalizeMode(input)).toBe(expected);
+  });
+
+  test.each([
+    ['ENFORCE'], // case-sensitive — wrong case = invalid
+    ['enabled'],
+    [''],
+    [null],
+    [undefined],
+    [123],
+    [{ mode: 'enforce' }]
+  ])('coerces invalid input %p to enforce', (input) => {
+    expect(enforcementMode._test.normalizeMode(input, 'test')).toBe('enforce');
+  });
+});

--- a/functions/tests/write-client-canonical-aggregates.test.js
+++ b/functions/tests/write-client-canonical-aggregates.test.js
@@ -717,3 +717,151 @@ describe('I. Violation logging on assertion failure', () => {
     expect(mockTransaction.update).not.toHaveBeenCalled();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════
+// J. Enforcement mode per-call override (PR-A.6)
+// ═══════════════════════════════════════════════════════════════
+
+describe('J. Enforcement mode (per-call override)', () => {
+  // Helper to seed an assertion that throws on the next call
+  function armAssertionToThrow(message = 'invariant_violation:I1_test [caller=x]') {
+    const err = new Error(message);
+    mockedAssert.mockImplementationOnce(() => {
+      throw err;
+    });
+    return err;
+  }
+
+  describe('enforce mode (default)', () => {
+    test('happy path → write OK, no log, no throw', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const violationLogger = jest.fn();
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'enforce', violationLogger }
+      );
+      expect(violationLogger).not.toHaveBeenCalled();
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+      expect(result.mode).toBe('enforce');
+    });
+
+    test('violation → log + throw + no write', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const err = armAssertionToThrow();
+      const violationLogger = jest.fn();
+
+      await expect(
+        writeClientWithCanonicalAggregates(
+          mockTransaction, clientRef,
+          { status: 'active' },
+          { caller: 'test', mode: 'enforce', violationLogger }
+        )
+      ).rejects.toThrow(err);
+
+      expect(violationLogger).toHaveBeenCalledTimes(1);
+      expect(violationLogger.mock.calls[0][0]).toMatchObject({ mode: 'enforce' });
+      expect(mockTransaction.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('log_only mode', () => {
+    test('happy path → write OK, no log, no throw', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const violationLogger = jest.fn();
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'log_only', violationLogger }
+      );
+      expect(violationLogger).not.toHaveBeenCalled();
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+      expect(result.mode).toBe('log_only');
+    });
+
+    test('violation → log + WRITE PROCEEDS (no throw)', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      armAssertionToThrow();
+      const violationLogger = jest.fn();
+
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'log_only', violationLogger }
+      );
+
+      // Violation was logged with mode=log_only
+      expect(violationLogger).toHaveBeenCalledTimes(1);
+      expect(violationLogger.mock.calls[0][0]).toMatchObject({ mode: 'log_only' });
+
+      // But the write happened anyway — log_only is non-blocking
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+      expect(result.mode).toBe('log_only');
+    });
+  });
+
+  describe('disabled mode', () => {
+    test('happy path → write OK, no log, no throw', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const violationLogger = jest.fn();
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'disabled', violationLogger }
+      );
+      expect(violationLogger).not.toHaveBeenCalled();
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+      expect(result.mode).toBe('disabled');
+    });
+
+    test('assertion function NOT called in disabled mode', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const violationLogger = jest.fn();
+      const callCountBefore = mockedAssert.mock.calls.length;
+
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'disabled', violationLogger }
+      );
+
+      // Assertion was completely skipped (no new calls)
+      expect(mockedAssert.mock.calls.length).toBe(callCountBefore);
+      // Logger NOT called — disabled mode skips assertion entirely
+      expect(violationLogger).not.toHaveBeenCalled();
+      // Write still happens
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+      expect(result.mode).toBe('disabled');
+    });
+  });
+
+  describe('invalid mode option', () => {
+    test('options.mode="bogus" → falls back to global config (default enforce in tests)', async () => {
+      mockTransaction.get.mockResolvedValue(
+        makeClientDoc({ services: [makeHoursService('s1')] })
+      );
+      const violationLogger = jest.fn();
+      const result = await writeClientWithCanonicalAggregates(
+        mockTransaction, clientRef,
+        { status: 'active' },
+        { caller: 'test', mode: 'bogus', violationLogger }
+      );
+      // Global config in test env falls back to 'enforce' (no doc in mock).
+      expect(result.mode).toBe('enforce');
+      expect(violationLogger).not.toHaveBeenCalled();
+      expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Centralized config-driven kill-switch for the canonical helper's invariant assertion. Three modes, toggle-able without redeploy via a single Firestore document.

**Rubric:** `.claude/rubrics/pr-a-6.md`
**Outcomes Grader verdict:** **PASS — 14/14** (10 MUST + 4 SHOULD)

## Three modes

| Mode | Behavior | When to use |
|------|----------|-------------|
| `enforce` (default) | Assert throws + violation logged + write aborted | Production normal |
| `log_only` | Violation logged with mode marker + write **proceeds** | During PR-B migration: surface assertions without breaking users |
| `disabled` | Assertion skipped entirely. No log, no throw | **Emergency only** — assertion itself is buggy |

## How to toggle (admin)

1. Firebase Console → Firestore → `system_settings`
2. Open `invariant_enforcement` doc (create if missing)
3. Set `mode` field to `enforce` / `log_only` / `disabled`
4. Effect takes hold within **60 seconds** (cache TTL per CF instance)

## Safe defaults

Every failure path returns `'enforce'`:
- Missing doc → enforce
- `mode` field missing → enforce
- Invalid `mode` value → enforce (warn log)
- Firestore read error → enforce (warn log)
- `data()` returns null → enforce

Misconfiguration **cannot** silently downgrade safety.

## What changed

| File | Change |
|------|--------|
| `functions/shared/enforcement-mode.js` | NEW — 138 LOC. `getEnforcementMode()` + cache + safe defaults |
| `functions/shared/client-writer.js` | Imports mode helper. Resolves `options.mode` → global config. Gates assertion behind `mode !== 'disabled'`. Branches on throw: `enforce` throws, `log_only` falls through, `disabled` never reaches |
| `functions/tests/enforcement-mode.test.js` | NEW — 25 tests (default safety, valid modes, caching, normalizeMode) |
| `functions/tests/write-client-canonical-aggregates.test.js` | New section J — 8 tests (3 modes × happy + violation + invalid-mode fallback) |
| `docs/CLIENTS_SYSTEM_REPORT.md` | New "Kill-switch" section: 3-mode table, toggle steps, safe defaults, Cloud Logging hints |

**No `firestore.rules` change.** Existing `system_settings/{settingId}` rule (line 158) already permits authenticated read; admin writes via Firebase Console use Admin SDK bypassing rules.

## Verification

- ✅ `functions/` Jest: **310 tests pass** (was 283 → +27 in 2 files)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Outcomes Grader: **PASS 14/14**

## Test plan

- [ ] CI green
- [ ] After merge → manually create `system_settings/invariant_enforcement` doc in Firebase Console with `{ mode: 'enforce' }`
- [ ] Set `mode` to `log_only`, wait 60s → trigger a synthetic violation → verify `clientInvariantViolations` collection gets entry with `mode: 'log_only'` field
- [ ] Set `mode` to `disabled` → verify Cloud Logging has NO `invariant_violation` entries for the next test write (assertion skipped)
- [ ] Set `mode` back to `enforce` → confirm next violation throws

## Operational guidance

- **Never leave the system in `disabled` mode** longer than a single incident window. PR-C will add alerting on mode changes.
- `log_only` mode is the right setting during PR-B (callsite migration): surfaces unexpected assertion failures without breaking users.
- The 60-second cache lag means toggling takes effect within a minute. Acceptable for emergency use.

## Rollback

`git revert <merge-commit>` on main → CI redeploys. The `system_settings/invariant_enforcement` doc stays in Firestore as an orphan (harmless). Helper reverts to PR-A.5 behavior (enforce only, no mode reading). No data corruption possible.

## Per `functions/CLAUDE.md`

- **Writes:** No new mutation paths. Read of `system_settings` doc only.
- **Reads:** client-writer reads enforcement-mode at start of each call (cached 60s).
- **Recalculates aggregates:** Unchanged.
- **CREATE/UPDATE/DELETE:** Only UPDATE path of client-writer affected; behavior under default (`enforce`) is identical to PR-A.5.
- **Fallback logic:** Every failure path returns `'enforce'` — the SAFE default. Documented + tested.
- **Drift risk:** `log_only` mode allows drift to be observed without breaking. By design.

## Out of scope

- Admin UI for toggling mode — Firebase Console suffices
- WhatsApp/SMS alert on mode change → PR-C
- Auto-reset to `enforce` after N hours → could add later
- Per-client mode override → over-engineered