### PR TITLE
fix(admin-modal): bump status-change dialog z-index above ClientManagementModal (PR-A.4.3)

### DIFF
--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -580,7 +580,7 @@
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
     <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
-    <script src="js/ui/ClientManagementModal.js?v=20260516-isOnHold"></script>
+    <script src="js/ui/ClientManagementModal.js?v=20260517-zindex"></script>
     <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
 
     <!-- ===== Shared Components ===== -->

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -1170,7 +1170,12 @@ return; // user cancelled
                 const overlay = document.createElement('div');
                 overlay.className = 'cm-status-overlay';
                 overlay.setAttribute('role', 'presentation');
-                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:10000;display:flex;align-items:center;justify-content:center;';
+                // z-index 10500 — must exceed ClientManagementModal's 10200 (clients-modals.css:53,
+                // documented as "highest in app"). Inline value matches the existing high-z-index
+                // pattern in components.css:2580 ("Higher than UserDetailsModal").
+                // Without this, when this dialog is triggered from inside the management modal,
+                // it renders BEHIND the management modal and becomes invisible/unclickable.
+                overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:10500;display:flex;align-items:center;justify-content:center;';
 
                 const dialog = document.createElement('div');
                 dialog.setAttribute('role', 'dialog');


### PR DESCRIPTION
## Summary

Surfaced during PR-A.6 DEV smoke. When the status-change dialog from PR-A.4 is triggered from inside the ניהול לקוח modal, the dialog renders **behind** the management modal — invisible/unclickable. From the table-row dropdown (outside any modal) it renders correctly.

## Root cause

| Element | z-index | File |
|---------|---------|------|
| ClientManagementModal | 10200 | `apps/admin-panel/css/clients-modals.css:53` (documented "highest in app") |
| Status-change dialog (PR-A.4) | 10000 | `apps/admin-panel/js/ui/ClientManagementModal.js:1173` |

`10000 < 10200` → dialog stacked below management modal whenever triggered from inside it.

## Fix

Bump dialog overlay's inline z-index `10000 → 10500`. Matches existing high-z-index pattern in `components.css:2580` ("Higher than UserDetailsModal"). Still below `11000` reserved for QuickMessage. Inline comment names the cause + cites the CSS line.

## Cache-bust

`ClientManagementModal.js?v=20260516-isOnHold` → `?v=20260517-zindex` on `clients.html`.

## Verification

- ✅ Vitest: 193 pass / 2 skipped (no regression)
- ✅ Lint: 0 errors
- Display-only fix. No CF, no User App, no data path.

## Scope

Pure CSS/inline-style number. 1 line of behavior change + 1 comment block + 1 cache-bust line.

## Test plan

- [ ] CI green
- [ ] DEV smoke: open client → ניהול → "שינוי סטטוס" button → dialog appears IN FRONT of management modal
- [ ] DEV smoke: same flow from row dropdown → dialog still works
- [ ] Cancel / Esc / click-outside still closes the dialog cleanly

## Rollback

`git revert <merge-commit>` → CI redeploys. Dialog reverts to z-index 10000 (the prior misrender). No data effect.