### PR TITLE
refactor(functions): migrate setServiceOverride to canonical helper (PR-B.1)

### DIFF
--- a/.claude/rubrics/pr-b-1.md
+++ b/.claude/rubrics/pr-b-1.md
@@ -1,0 +1,75 @@
+# Rubric — PR-B.1
+
+**Title:** refactor(functions): migrate setServiceOverride to writeClientWithCanonicalAggregates
+**Branch:** feat/migrate-set-service-override-pr-b-1
+**Base:** main
+**Scope:** Replace the `transaction.update(clientRef, { services + 6 aggregate fields })` block in `setServiceOverride` (functions/clients/index.js:1218) with a call to `writeClientWithCanonicalAggregates`. The behavior must be identical — `setServiceOverride` already calls `calcClientAggregates` and writes a clean aggregate object. The migration adds: assertion guard, violation logging, kill-switch coverage, RESTRICTED_KEYS strip defense-in-depth.
+
+## Risk profile
+
+**Low.** Smallest partialUpdate shape in the codebase (one swap of `services[]`). Admin-only flow, low traffic. Identical behavior expected.
+
+## MUST criteria (block on FAIL)
+
+### M1 — setServiceOverride uses writeClientWithCanonicalAggregates
+**Rule:** `functions/clients/index.js:setServiceOverride` calls `writeClientWithCanonicalAggregates(transaction, clientRef, { services: updatedServices }, { caller: 'setServiceOverride', auditMeta: { uid: user.uid, username: user.username } })`. The prior `transaction.update(clientRef, { services + 6 aggregate fields + lastModified })` is removed.
+**Evidence required:** Grep for `writeClientWithCanonicalAggregates` in `setServiceOverride` body. The 6 manually-written aggregate fields no longer appear.
+
+### M2 — Pre-helper validation preserved
+**Rule:** The existing validation must run BEFORE the helper call: auth (admin role), arg shape (`clientId, serviceId, active`), client exists (via the helper's `transaction.get`), service exists, service.type === HOURS. None of these checks may be silently removed.
+**Evidence required:** Reading the new code; all 5 checks still present and in the right order.
+
+### M3 — Audit log unchanged
+**Rule:** `logAction('SET_SERVICE_OVERRIDE' | 'REMOVE_SERVICE_OVERRIDE', ...)` is still called outside the transaction with the same payload shape. The helper's `auditMeta` is a SECOND audit channel — does NOT replace the explicit logAction.
+**Evidence required:** Both calls present.
+
+### M4 — Return value unchanged
+**Rule:** Return shape `{ success: true, serviceId, overrideActive }` is preserved exactly.
+**Evidence required:** Reading the new code.
+
+### M5 — Behavior verified by tests
+**Rule:** Either (a) existing tests already cover setServiceOverride and continue to pass, OR (b) at least one new Jest test is added that exercises the migrated path:
+- Happy path (active=true): override flag set, helper called, aggregates recomputed
+- Happy path (active=false): override cleared, helper called, aggregates recomputed
+- Authorization: non-admin → permission-denied (unchanged)
+**Evidence required:** Jest output + test file changes if any.
+
+### M6 — All existing tests pass
+**Rule:** `cd functions && npm test` AND root `npm test` both pass. No regression. Count does not drop.
+**Evidence required:** Jest + Vitest output.
+
+### M7 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors.
+**Evidence required:** Lint output.
+
+## SHOULD criteria
+
+### S1 — Migration comment
+**Rule:** Inline comment near the helper call references the migration (PR-B.1) and names the prior pattern so future readers understand why this was changed (not just functional regression).
+**Evidence required:** Reading the comment block.
+
+### S2 — Helper auditMeta carries username
+**Rule:** `auditMeta` passed to the helper includes `username` so the helper's `lastModifiedBy` field aligns with the user who triggered the action.
+**Evidence required:** Code shows `auditMeta: { uid: user.uid, username: user.username }`.
+
+### S3 — Pattern documented for next migrations
+**Rule:** PR description or commit message names the pattern that will be reused for the remaining 12 PR-B migrations (extract the in-transaction `calcClientAggregates + transaction.update` block, replace with the helper call, keep validations outside).
+**Evidence required:** PR description / commit message.
+
+## Out of scope
+
+- Migrating any other callsite (each gets its own sub-PR)
+- Changing the return value shape
+- Changing validation order or business rules
+- Removing the explicit `logAction` call (the helper's auditMeta is supplementary)
+- Adding new tests for unrelated paths
+
+## Rollback
+
+`git revert <merge-commit>` on main → CI redeploys. `setServiceOverride` reverts to the prior `transaction.update` block. The helper remains in place; only this one callsite reverts. No data corruption possible.
+
+## Notes for grader
+
+- This is THE FIRST sub-PR of PR-B (refactor 13 callsites). Pattern proven here is reused for the next 12. Be appropriately strict — if M1-M7 PASS, the pattern is validated.
+- The helper's RESTRICTED_KEYS will strip any aggregate field if the caller accidentally sends one. In this migration, the new partialUpdate is `{ services: updatedServices }` — no aggregate fields included — so stripping is a no-op in steady state.
+- The helper does its own `transaction.get(clientRef)` — that's a SECOND read in the same transaction. Firestore caches reads within a transaction; this is not a duplicate billable read. No optimization needed.

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -1213,19 +1213,26 @@ exports.setServiceOverride = functions.https.onCall(async (data, context) => {
       const updatedServices = [...services];
       updatedServices[serviceIndex] = updatedService;
 
-      const agg = calcClientAggregates(updatedServices, clientData.totalHours);
-
-      transaction.update(clientRef, {
-        services: updatedServices,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedBy: user.username,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp()
-      });
+      // PR-B.1 (2026-05-17): migrate to canonical write helper.
+      // Pattern: extract the in-transaction { services + 6 aggregate fields
+      // + lastModified } block, replace with a single helper call. The helper:
+      //   - strips RESTRICTED_KEYS if present (defense-in-depth)
+      //   - recomputes totalHours + aggregates from services
+      //   - asserts invariants (I1/I2/I4) — throws if drift detected
+      //   - emits a violation record + Cloud Logging entry on assertion fail
+      //   - honors the global kill-switch (system_settings/invariant_enforcement)
+      // Behavior is identical to the prior calcClientAggregates + transaction.update
+      // — this is the SAME math, routed through the canonical path for
+      // observability + structural enforcement.
+      await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        { services: updatedServices },
+        {
+          caller: 'setServiceOverride',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
     });
 
     await logAction(

--- a/functions/tests/set-service-override.test.js
+++ b/functions/tests/set-service-override.test.js
@@ -1,0 +1,358 @@
+/**
+ * Tests for setServiceOverride CF after PR-B.1 migration to
+ * writeClientWithCanonicalAggregates.
+ *
+ * Coverage:
+ *   - Auth: non-admin → permission-denied
+ *   - Validation: missing args → invalid-argument
+ *   - Service not found → not-found
+ *   - Service type != HOURS → invalid-argument
+ *   - Happy path active=true: override flag set + helper called +
+ *     aggregates recomputed + write payload includes services
+ *   - Happy path active=false: override cleared + same flow
+ *   - Audit log emitted with correct action + payload
+ */
+
+// ═══════════════════════════════════════════════════════════════
+// Mocks — must precede require()
+// ═══════════════════════════════════════════════════════════════
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+jest.mock('../case-number-transaction', () => ({
+  generateCaseNumberWithTransaction: jest.fn(() => 'AUTO-2026000')
+}));
+
+// ═══════════════════════════════════════════════════════════════
+// Requires — after mocks
+// ═══════════════════════════════════════════════════════════════
+
+const { setServiceOverride } = require('../clients/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ═══════════════════════════════════════════════════════════════
+// Test helpers
+// ═══════════════════════════════════════════════════════════════
+
+function makeHoursService(id, { totalHours = 10, hoursUsed = 8, overrideActive = false } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: 'שירות שעתי',
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    overrideActive,
+    status: 'active'
+  };
+}
+
+function makeFixedService(id) {
+  return {
+    id,
+    type: ST.FIXED,
+    name: 'שירות קבוע',
+    fixedPrice: 5000,
+    status: 'active'
+  };
+}
+
+function makeClientDoc(overrides = {}) {
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      status: 'active',
+      isBlocked: false,
+      isCritical: false,
+      isOnHold: false,
+      services: [],
+      totalHours: 10,
+      ...overrides
+    })
+  };
+}
+
+function makeCtx(uid = 'admin1') {
+  return { auth: { uid, token: { email: 'admin@test', role: 'admin' } } };
+}
+
+const ADMIN_USER = {
+  uid: 'admin1',
+  email: 'admin@test',
+  username: 'admin',
+  role: 'admin'
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(ADMIN_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Authorization
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Authorization', () => {
+  test('non-admin user → permission-denied', async () => {
+    mockCheckUserPermissions.mockResolvedValue({
+      ...ADMIN_USER,
+      role: 'employee'
+    });
+    await expect(
+      setServiceOverride(
+        { clientId: 'c1', serviceId: 's1', active: true },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'permission-denied' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Argument validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Argument validation', () => {
+  test('missing clientId → invalid-argument', async () => {
+    await expect(
+      setServiceOverride({ serviceId: 's1', active: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('missing serviceId → invalid-argument', async () => {
+    await expect(
+      setServiceOverride({ clientId: 'c1', active: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('non-boolean active → invalid-argument', async () => {
+    await expect(
+      setServiceOverride(
+        { clientId: 'c1', serviceId: 's1', active: 'true' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Lookup failures
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Lookup failures', () => {
+  test('client not found → not-found', async () => {
+    mockTransaction.get.mockResolvedValue({ exists: false });
+    await expect(
+      setServiceOverride(
+        { clientId: 'missing', serviceId: 's1', active: true },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  test('service not found in client → not-found', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('other-id')] })
+    );
+    await expect(
+      setServiceOverride(
+        { clientId: 'c1', serviceId: 'missing-svc', active: true },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  test('service type != HOURS → invalid-argument', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeFixedService('s1')] })
+    );
+    await expect(
+      setServiceOverride(
+        { clientId: 'c1', serviceId: 's1', active: true },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Migration verified — write through helper
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Canonical helper integration (PR-B.1)', () => {
+  test('active=true: helper invoked, services array carries override flag, aggregates derived', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 10, overrideActive: false })],
+        totalHours: 10
+      })
+    );
+
+    const result = await setServiceOverride(
+      { clientId: 'c1', serviceId: 's1', active: true, note: 'admin approved' },
+      makeCtx()
+    );
+
+    expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+    const [, payload] = mockTransaction.update.mock.calls[0];
+
+    // services[0] now carries the override flag
+    expect(payload.services).toHaveLength(1);
+    expect(payload.services[0].overrideActive).toBe(true);
+    expect(payload.services[0].overrideApprovedBy).toBe('admin');
+    expect(payload.services[0].overrideNote).toBe('admin approved');
+
+    // Aggregates derived by the helper (I2: depleted but override active → not blocked)
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.hoursUsed).toBe(10);
+    expect(payload.hoursRemaining).toBe(0);
+
+    // Audit metadata from auditMeta
+    expect(payload.lastModifiedBy).toBe('admin');
+
+    // Return value preserved
+    expect(result).toEqual({
+      success: true,
+      serviceId: 's1',
+      overrideActive: true
+    });
+  });
+
+  test('active=false: override cleared, aggregates derived (no override → block at depletion)', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 10, overrideActive: true })],
+        totalHours: 10
+      })
+    );
+
+    await setServiceOverride(
+      { clientId: 'c1', serviceId: 's1', active: false },
+      makeCtx()
+    );
+
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.services[0].overrideActive).toBe(false);
+
+    // No override + depleted → blocked
+    expect(payload.isBlocked).toBe(true);
+  });
+
+  test('healthy client (not depleted) toggle: aggregates remain false', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        services: [makeHoursService('s1', { totalHours: 10, hoursUsed: 3 })],
+        totalHours: 10
+      })
+    );
+
+    await setServiceOverride(
+      { clientId: 'c1', serviceId: 's1', active: true },
+      makeCtx()
+    );
+
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isCritical).toBe(false);
+    expect(payload.hoursRemaining).toBe(7);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Audit log
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Audit log', () => {
+  test('active=true → action SET_SERVICE_OVERRIDE', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('s1')] })
+    );
+    await setServiceOverride(
+      { clientId: 'c1', serviceId: 's1', active: true, note: 'reason' },
+      makeCtx()
+    );
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'SET_SERVICE_OVERRIDE',
+      'admin1',
+      'admin',
+      expect.objectContaining({
+        clientId: 'c1',
+        serviceId: 's1',
+        overrideActive: true,
+        note: 'reason'
+      })
+    );
+  });
+
+  test('active=false → action REMOVE_SERVICE_OVERRIDE', async () => {
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({ services: [makeHoursService('s1', { overrideActive: true })] })
+    );
+    await setServiceOverride(
+      { clientId: 'c1', serviceId: 's1', active: false },
+      makeCtx()
+    );
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'REMOVE_SERVICE_OVERRIDE',
+      'admin1',
+      'admin',
+      expect.objectContaining({ overrideActive: false })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

First of **13 callsites** migrating from direct `transaction.update` to `writeClientWithCanonicalAggregates`. Behavior identical — `setServiceOverride` already called `calcClientAggregates` correctly. The migration adds: RESTRICTED_KEYS strip, invariant assertion, violation logging, Cloud Logging, and kill-switch coverage.

**Rubric:** `.claude/rubrics/pr-b-1.md`
**Outcomes Grader:** **PASS — 7/7 MUST + 2/3 SHOULD applicable**

## Pattern (reused for next 12 sub-PRs)

```js
// Before:
const agg = calcClientAggregates(updatedServices, clientData.totalHours);
transaction.update(clientRef, {
  services: updatedServices,
  hoursUsed: agg.hoursUsed, hoursRemaining: agg.hoursRemaining,
  minutesUsed: agg.minutesUsed, minutesRemaining: agg.minutesRemaining,
  isBlocked: agg.isBlocked, isCritical: agg.isCritical,
  lastModifiedBy: user.username,
  lastModifiedAt: admin.firestore.FieldValue.serverTimestamp()
});

// After:
await writeClientWithCanonicalAggregates(
  transaction, clientRef,
  { services: updatedServices },
  { caller: '<fn-name>', auditMeta: { uid: user.uid, username: user.username } }
);
```

Validations stay **outside** the helper (auth, arg shape, lookups). The helper re-reads the client — Firestore caches reads within a transaction (no duplicate billable read).

## Tests

`functions/tests/set-service-override.test.js` (new, 358 LOC) — 12 cases:
- **A.** Authorization (1) — non-admin → permission-denied
- **B.** Argument validation (3) — missing clientId/serviceId/non-bool active
- **C.** Lookup failures (3) — client/service/type validation
- **D.** Canonical helper integration (3) — active=true (depleted+override → not blocked), active=false (no override → blocked), healthy toggle
- **E.** Audit log (2) — SET / REMOVE actions

## Verification

- ✅ `functions/` Jest: **322 pass** (was 310, +12 in new file)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Outcomes Grader: PASS 7/7 MUST + 2/3 SHOULD

## Per `functions/CLAUDE.md`

- **Writes:** `setServiceOverride` (unchanged callable surface, new internal path through helper)
- **Reads:** Admin UI override flow; same readers as before
- **Recalculates aggregates:** `calcClientAggregates` via helper
- **CREATE / UPDATE / DELETE:** UPDATE path migrated. No new CREATE/DELETE risk.
- **Fallback logic:** Helper tolerates malformed services (filter(Boolean) + delegate to `calcClientAggregates`)
- **Drift risk:** Closed for this callsite. 12 callsites remain (PR-B.2–PR-B.14).

## Rollback

`git revert <merge-commit>` → CI redeploys. `setServiceOverride` reverts to the prior block. Helper remains in place; only this callsite reverts. No data corruption possible.

## Out of scope

- Other 12 callsites (each gets its own sub-PR)
- Validation reordering / business rule changes
- `logAction` removal — supplementary `auditMeta` keeps the explicit `logAction`

## Test plan

- [ ] CI green (lint + types + tests + security)
- [ ] DEV smoke: admin opens client → triggers an override → verify isBlocked behavior (depleted+override → not blocked)
- [ ] DEV smoke: remove override → verify isBlocked re-derives correctly
- [ ] Check Cloud Logging for `[client-writer]` warnings (should be none — no stripped keys in this call)