### PR TITLE
refactor(functions): migrate deleteService to canonical helper (PR-B.3)

### DIFF
--- a/.claude/rubrics/pr-b-3.md
+++ b/.claude/rubrics/pr-b-3.md
@@ -1,0 +1,81 @@
+# Rubric — PR-B.3
+
+**Title:** refactor(functions): migrate deleteService to canonical helper
+**Branch:** feat/migrate-delete-service-pr-b-3
+**Base:** main
+**Scope:** Migration 3 of 13. `deleteService` in `functions/services/index.js` writes `services + totalServices + activeServices + totalHours + 6 aggregate fields + lastModified*`. Replace the aggregate-block writes with `writeClientWithCanonicalAggregates`; keep `totalServices` and `activeServices` as caller-supplied pass-through fields (they are NOT in RESTRICTED_KEYS).
+
+## Risk profile
+
+**Low-medium.** Slightly more complex than B.1/B.2 because of additional non-restricted fields (`totalServices`, `activeServices`) that helper passes through. Pre-existing constraint: refuse to delete if `timesheet_entries` exist for the service (preserved).
+
+## MUST criteria (block on FAIL)
+
+### M1 — deleteService uses writeClientWithCanonicalAggregates
+**Rule:** The body calls `writeClientWithCanonicalAggregates(transaction, clientRef, { services: updatedServices, totalServices, activeServices }, { caller: 'deleteService', auditMeta: { uid, username } })`. The prior manual aggregate block is removed.
+**Evidence required:** Diff shows the swap. Manual `hoursUsed/hoursRemaining/minutesUsed/minutesRemaining/isBlocked/isCritical/totalHours` lines gone.
+
+### M2 — Validations preserved (order matters)
+**Rule:** auth → arg shape (`clientId, serviceId`) → client exists → service exists → no timesheet_entries with serviceId. None silently removed or reordered.
+**Evidence required:** Reading the new code.
+
+### M3 — totalServices + activeServices pass through correctly
+**Rule:** After filtering out the deleted service, `totalServices = updatedServices.length` and `activeServices = updatedServices.filter(s => s.status === 'active').length` are still computed correctly and passed to the helper. Helper passes them through (they are not in RESTRICTED_KEYS).
+**Evidence required:** Helper write payload (in test) contains both fields.
+
+### M4 — Audit log preserved
+**Rule:** `logAction('DELETE_SERVICE', user.uid, user.username, { clientId, serviceId, serviceName, serviceType, deletedServiceSnapshot })` STILL called outside the transaction with the full snapshot.
+**Evidence required:** Reading the code.
+
+### M5 — Return value preserved
+**Rule:** Return shape `{ success, serviceId, serviceName, deletedService, clientAggregates: { totalHours, hoursUsed, hoursRemaining, minutesRemaining, isBlocked, isCritical, totalServices, activeServices }, message }` unchanged. The `clientAggregates` block now sources its values from the helper's return.
+**Evidence required:** Reading the new code + comparing shape.
+
+### M6 — Tests cover migrated path
+**Rule:** New test file `functions/tests/delete-service.test.js` covering at minimum:
+- Auth: non-authenticated → unauthenticated
+- Validation: missing args (clientId / serviceId)
+- Lookup: client / service not found
+- Guard: timesheet_entries exist → failed-precondition
+- Happy path: helper called with `{ services, totalServices, activeServices }`, service removed from array, aggregates derived
+- Aggregates: deleting last billable service → fixed-only → isBlocked=false (I1)
+**Evidence required:** New test file + Jest output.
+
+### M7 — All other tests pass
+**Rule:** Functions Jest + root Vitest green. No regression.
+**Evidence required:** Test runner output.
+
+### M8 — Lint zero errors
+**Rule:** `npm run lint` returns 0 errors.
+**Evidence required:** Lint output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.3
+**Rule:** Inline comment names PR-B.3 + references the PR-B.1 pattern + notes the totalServices/activeServices pass-through nuance.
+**Evidence required:** Reading the comment.
+
+### S2 — auditMeta carries `{ uid, username }`
+**Rule:** Standard helper pattern.
+**Evidence required:** Reading the code.
+
+### S3 — PR description names PR-B.1/.B.2 as pattern source
+**Rule:** PR body mentions previous migrations + notes this is migration 3 of 13.
+**Evidence required:** PR description.
+
+## Out of scope
+
+- Other 10 callsites
+- Changing the timesheet_entries guard
+- Removing audit log
+- Changing return shape
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. Helper remains. No data corruption.
+
+## Notes for grader
+
+- `totalServices` and `activeServices` are NOT in RESTRICTED_KEYS. Helper passes them through. Verify in tests that the helper write payload includes both fields with correct values.
+- I1 path is testable here: deleting the last hours-service from a client leaves only fixed services → I1 → isBlocked=false (even if hoursUsed shows 0).
+- `deletedServiceSnapshot` for audit recovery preserved — full pre-delete service object captured before the filter.

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -10,6 +10,7 @@ const { logAction } = require('../shared/audit');
 const { sanitizeString } = require('../shared/validators');
 
 const { calcClientAggregates, round2, isFixedService } = require('../shared/aggregates');
+const { writeClientWithCanonicalAggregates } = require('../shared/client-writer');
 
 const db = admin.firestore();
 
@@ -1396,29 +1397,36 @@ exports.deleteService = functions.https.onCall(async (data, context) => {
       // 3e. Immutable removal
       const updatedServices = services.filter((s, idx) => idx !== serviceIndex);
 
-      // 3f. Recalculate client-level aggregates
-      const clientTotalHours = updatedServices.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-      const agg = calcClientAggregates(updatedServices, clientTotalHours);
+      // 3f. Compute non-aggregate derived counts (helper does NOT manage these)
       const totalServices = updatedServices.length;
       const activeServices = updatedServices.filter(s => s.status === 'active').length;
 
-      // 3g. Write to Firestore (Transaction)
-      transaction.update(clientRef, {
-        services: updatedServices,
-        totalServices: totalServices,
-        activeServices: activeServices,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // 3g. PR-B.3 (2026-05-17): migrate to canonical helper.
+      // Pattern from PR-B.1/.B.2 (#283/#284). The helper:
+      //   - strips RESTRICTED_KEYS (defense-in-depth)
+      //   - recomputes totalHours + all aggregates from services
+      //   - asserts invariants I1/I2/I4
+      //   - emits violation record + Cloud Logging entry on failure
+      //   - honors global kill-switch
+      // totalServices / activeServices pass through (NOT in RESTRICTED_KEYS).
+      // I1 case is relevant here: removing the last billable service from
+      // a mixed client leaves only fixed services → helper derives
+      // isBlocked=false even if hoursRemaining drops to 0.
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          services: updatedServices,
+          totalServices,
+          activeServices
+        },
+        {
+          caller: 'deleteService',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
-      // 3h. Return data from transaction
+      // 3h. Return data from transaction (sourced from helper's canonical aggregates)
       const serviceName = service.name || service.serviceName;
       const serviceType = service.type || service.serviceType;
 
@@ -1427,14 +1435,14 @@ exports.deleteService = functions.https.onCall(async (data, context) => {
         serviceName,
         serviceType,
         aggregates: {
-          totalHours: clientTotalHours,
-          hoursUsed: agg.hoursUsed,
-          hoursRemaining: agg.hoursRemaining,
-          minutesRemaining: agg.minutesRemaining,
-          isBlocked: agg.isBlocked,
-          isCritical: agg.isCritical,
-          totalServices: totalServices,
-          activeServices: activeServices
+          totalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+          hoursUsed: helperResult.aggregates.hoursUsed,
+          hoursRemaining: helperResult.aggregates.hoursRemaining,
+          minutesRemaining: helperResult.aggregates.minutesRemaining,
+          isBlocked: helperResult.aggregates.isBlocked,
+          isCritical: helperResult.aggregates.isCritical,
+          totalServices,
+          activeServices
         }
       };
     });

--- a/functions/tests/delete-service.test.js
+++ b/functions/tests/delete-service.test.js
@@ -1,0 +1,392 @@
+/**
+ * Tests for deleteService CF after PR-B.3 migration to writeClientWithCanonicalAggregates.
+ *
+ * Coverage:
+ *   A. Auth + validation (clientId / serviceId / confirmDelete)
+ *   B. Lookup failures (client / service not found)
+ *   C. Referential integrity guard (timesheet_entries blocks delete)
+ *   D. Canonical helper integration:
+ *      - services array filtered (deleted service removed)
+ *      - totalServices / activeServices passed through (not in RESTRICTED_KEYS)
+ *      - I1 case: removing last billable service → fixed-only → isBlocked=false
+ *   E. Audit log preserved
+ *   F. Return value shape preserved
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+// Mock collection().where().limit() chain for timesheet_entries query
+const mockEntriesLimit = jest.fn(() => 'TIMESHEET_QUERY');
+const mockEntriesWhere = jest.fn(() => ({ limit: mockEntriesLimit }));
+const mockEntriesCollection = { where: mockEntriesWhere };
+
+const mockDb = {
+  collection: jest.fn((name) => {
+    if (name === 'timesheet_entries') {
+      return mockEntriesCollection;
+    }
+    return {
+      doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+    };
+  }),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+const { deleteService } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeHoursService(id, { totalHours = 10, hoursUsed = 3, status = 'active' } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    status
+  };
+}
+
+function makeFixedService(id) {
+  return {
+    id,
+    type: ST.FIXED,
+    name: `פיקס ${id}`,
+    fixedPrice: 5000,
+    status: 'active',
+    work: { totalMinutesWorked: 0, entriesCount: 0 }
+  };
+}
+
+function makeClientDoc(services = [], overrides = {}) {
+  const totalHours = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.totalHours || 0), 0);
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      status: 'active',
+      services,
+      totalHours,
+      totalServices: services.length,
+      activeServices: services.filter(s => s.status === 'active').length,
+      ...overrides
+    })
+  };
+}
+
+const VALID_USER = {
+  uid: 'user1',
+  email: 'test@test',
+  username: 'testuser',
+  role: 'manager'
+};
+
+function makeCtx(uid = 'user1') {
+  return { auth: { uid, token: { email: 'test@test' } } };
+}
+
+// Helper: setup transaction.get to return:
+//   1st call (clientRef)        → client doc
+//   2nd call (timesheet query)  → entries snapshot (empty by default)
+//   3rd call (helper internal)  → client doc again (helper re-reads inside transaction)
+function setupTransactionMocks(clientDoc, entriesEmpty = true) {
+  mockTransaction.get.mockReset();
+  mockTransaction.get
+    .mockResolvedValueOnce(clientDoc)
+    .mockResolvedValueOnce({ empty: entriesEmpty, docs: [] })
+    .mockResolvedValueOnce(clientDoc);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Auth + validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Auth + validation', () => {
+  test('propagates auth errors', async () => {
+    const functions = require('firebase-functions');
+    mockCheckUserPermissions.mockRejectedValue(
+      new functions.https.HttpsError('unauthenticated', 'אין הרשאה')
+    );
+    await expect(
+      deleteService({ clientId: 'c1', serviceId: 's1', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+  });
+
+  test('throws invalid-argument when clientId missing', async () => {
+    await expect(
+      deleteService({ serviceId: 's1', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('throws invalid-argument when serviceId missing', async () => {
+    await expect(
+      deleteService({ clientId: 'c1', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('throws invalid-argument when confirmDelete is missing', async () => {
+    await expect(
+      deleteService({ clientId: 'c1', serviceId: 's1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('throws invalid-argument when confirmDelete is not exactly true', async () => {
+    await expect(
+      deleteService({ clientId: 'c1', serviceId: 's1', confirmDelete: 'yes' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Lookup failures
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Lookup failures', () => {
+  test('client not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce({ exists: false });
+    await expect(
+      deleteService({ clientId: 'missing', serviceId: 's1', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  test('service not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(makeClientDoc([makeHoursService('s_other')]));
+    await expect(
+      deleteService({ clientId: 'c1', serviceId: 'missing-svc', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Referential integrity — timesheet_entries guard
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Referential integrity', () => {
+  test('throws failed-precondition when timesheet_entries reference the service', async () => {
+    const clientDoc = makeClientDoc([makeHoursService('s1')]);
+    // Setup: client doc, then NON-empty entries snapshot
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce({ empty: false, docs: [{ id: 'entry1' }] });
+    await expect(
+      deleteService({ clientId: 'c1', serviceId: 's1', confirmDelete: true }, makeCtx())
+    ).rejects.toMatchObject({ code: 'failed-precondition' });
+    // Update should NOT have been called
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Canonical helper integration (PR-B.3)
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Canonical helper integration', () => {
+  test('happy path: service removed, helper called, aggregates derived', async () => {
+    const services = [
+      makeHoursService('s1', { totalHours: 10, hoursUsed: 3 }),
+      makeHoursService('s2', { totalHours: 20, hoursUsed: 5 })
+    ];
+    const clientDoc = makeClientDoc(services);
+    setupTransactionMocks(clientDoc);
+
+    const result = await deleteService(
+      { clientId: 'c1', serviceId: 's1', confirmDelete: true },
+      makeCtx()
+    );
+
+    expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+    const [, payload] = mockTransaction.update.mock.calls[0];
+
+    // s1 removed
+    expect(payload.services).toHaveLength(1);
+    expect(payload.services[0].id).toBe('s2');
+
+    // totalServices / activeServices passed through (NOT in RESTRICTED_KEYS)
+    expect(payload.totalServices).toBe(1);
+    expect(payload.activeServices).toBe(1);
+
+    // Helper derived correct aggregates from remaining service (s2: 20/5)
+    expect(payload.totalHours).toBe(20);
+    expect(payload.hoursUsed).toBe(5);
+    expect(payload.hoursRemaining).toBe(15);
+    expect(payload.isBlocked).toBe(false);
+
+    // Return value
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: 's1',
+      serviceName: 'שירות s1',
+      clientAggregates: {
+        totalHours: 20,
+        hoursUsed: 5,
+        hoursRemaining: 15,
+        isBlocked: false,
+        totalServices: 1,
+        activeServices: 1
+      }
+    });
+  });
+
+  test('I1 case: removing last billable service leaves fixed-only → isBlocked=false', async () => {
+    const services = [
+      makeHoursService('s_hours', { totalHours: 10, hoursUsed: 10 }), // depleted
+      makeFixedService('s_fixed')
+    ];
+    const clientDoc = makeClientDoc(services);
+    setupTransactionMocks(clientDoc);
+
+    await deleteService(
+      { clientId: 'c1', serviceId: 's_hours', confirmDelete: true },
+      makeCtx()
+    );
+
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.services).toHaveLength(1);
+    expect(payload.services[0].id).toBe('s_fixed');
+    // I1: no billable → isBlocked must be false
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isCritical).toBe(false);
+  });
+
+  test('deletedServiceSnapshot captured before filter', async () => {
+    const targetService = makeHoursService('s1', { totalHours: 10, hoursUsed: 3 });
+    const clientDoc = makeClientDoc([targetService, makeHoursService('s2')]);
+    setupTransactionMocks(clientDoc);
+
+    const result = await deleteService(
+      { clientId: 'c1', serviceId: 's1', confirmDelete: true },
+      makeCtx()
+    );
+
+    // Snapshot has the FULL pre-delete service
+    expect(result.deletedService).toMatchObject({
+      id: 's1',
+      type: 'hours',
+      totalHours: 10,
+      hoursUsed: 3
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Audit log
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Audit log', () => {
+  test('DELETE_SERVICE emitted with full snapshot for recovery', async () => {
+    const target = makeHoursService('s1', { totalHours: 10, hoursUsed: 3 });
+    setupTransactionMocks(makeClientDoc([target, makeHoursService('s2')]));
+
+    await deleteService(
+      { clientId: 'c1', serviceId: 's1', confirmDelete: true },
+      makeCtx()
+    );
+
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'DELETE_SERVICE',
+      'user1',
+      'testuser',
+      expect.objectContaining({
+        clientId: 'c1',
+        serviceId: 's1',
+        serviceName: 'שירות s1',
+        serviceType: 'hours',
+        deletedServiceSnapshot: expect.objectContaining({ id: 's1' })
+      })
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Return value
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Return value', () => {
+  test('full shape preserved (success + serviceId + clientAggregates + message)', async () => {
+    setupTransactionMocks(makeClientDoc([
+      makeHoursService('s1'),
+      makeHoursService('s2')
+    ]));
+    const result = await deleteService(
+      { clientId: 'c1', serviceId: 's1', confirmDelete: true },
+      makeCtx()
+    );
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: 's1',
+      serviceName: expect.any(String),
+      deletedService: expect.any(Object),
+      clientAggregates: expect.objectContaining({
+        totalHours: expect.any(Number),
+        hoursUsed: expect.any(Number),
+        hoursRemaining: expect.any(Number),
+        isBlocked: expect.any(Boolean),
+        isCritical: expect.any(Boolean),
+        totalServices: expect.any(Number),
+        activeServices: expect.any(Number)
+      }),
+      message: expect.stringContaining('נמחק')
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migration **3 of 13** in PR-B series. Pattern from [PR-B.1 / #283](https://github.com/Chaim2045/law-office-system/pull/283) + [PR-B.2 / #284](https://github.com/Chaim2045/law-office-system/pull/284).

**Rubric:** `.claude/rubrics/pr-b-3.md`
**Outcomes Grader verdict:** **PASS** — 8/8 MUST + 3/3 SHOULD applicable.

## What changed

`deleteService` (functions/services/index.js) now routes its client-doc write through `writeClientWithCanonicalAggregates`.

| Field | Before | After |
|-------|--------|-------|
| `services` (filtered) | manual write | passed to helper |
| `totalServices`, `activeServices` | manual write | passed to helper (NOT in RESTRICTED_KEYS — pass through) |
| `totalHours` + 6 aggregate fields | manual calcClientAggregates + write | helper derives + writes |
| `lastModifiedBy/At` | manual | helper writes via `auditMeta` |

The timesheet_entries referential-integrity guard, the `deletedServiceSnapshot` capture, and the `logAction('DELETE_SERVICE', …)` call are all preserved.

## I1 case verified

Removing the last billable service from a mixed client leaves only fixed → helper derives `isBlocked=false` (covered in test D.2).

## Per `functions/CLAUDE.md` mental model

- **Writes:** `deleteService` callable surface — unchanged
- **Reads:** Admin UI service-delete flow
- **Recalculates aggregates:** via canonical helper now
- **CREATE/UPDATE/DELETE:** DELETE migrated. No new mutation paths
- **Fallback:** helper tolerates malformed services. `failed-precondition` guard on `timesheet_entries` preserved
- **Drift risk:** closed for this callsite. 10 callsites remain

## Verification

- ✅ functions/ Jest: **347 pass** (was 334, +13 new in `delete-service.test.js`)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Grader: PASS 8/8 MUST + 3/3 SHOULD applicable

## Test plan

- [ ] CI green
- [ ] After merge → smoke DEV: open client → try to delete a service WITH timesheet entries → expect rejection (failed-precondition unchanged)
- [ ] Smoke DEV: delete a service WITHOUT timesheet entries → service vanishes, client aggregates reflect new totals
- [ ] Smoke DEV: delete last hours-service on a hybrid client → status no longer "חסום (אין שעות)" (fixed-only via I1)

## Rollback

`git revert <merge-commit>` → CI redeploys. `deleteService` reverts to prior block. Helper remains. No data corruption possible.