### PR TITLE
refactor(functions): migrate completeService to canonical helper (PR-B.4)

### DIFF
--- a/.claude/rubrics/pr-b-4.md
+++ b/.claude/rubrics/pr-b-4.md
@@ -1,0 +1,78 @@
+# Rubric — PR-B.4
+
+**Title:** refactor(functions): migrate completeService to canonical helper
+**Branch:** feat/migrate-complete-service-pr-b-4
+**Base:** main
+**Scope:** Migration 4 of 13. `completeService` marks a service `status: 'completed'` + `completedAt: <iso>` and writes the manual aggregate block. Replace the aggregate block with `writeClientWithCanonicalAggregates`. Same pattern as PR-B.3 — `totalServices` / `activeServices` pass through as non-restricted fields.
+
+## Risk profile
+
+**Low.** Smaller shape than PR-B.3 (no timesheet_entries guard, no full snapshot for audit). Toggle is one-way (`active` → `completed`).
+
+## MUST criteria (block on FAIL)
+
+### M1 — completeService uses writeClientWithCanonicalAggregates
+**Rule:** Body calls `writeClientWithCanonicalAggregates(transaction, clientRef, { services, totalServices, activeServices }, { caller: 'completeService', auditMeta: { uid, username } })`. Manual aggregate block removed.
+**Evidence required:** Diff confirms swap. No more `hoursUsed/hoursRemaining/minutesUsed/minutesRemaining/isBlocked/isCritical/totalHours/lastModifiedAt/lastModifiedBy` in this CF.
+
+### M2 — Validations preserved (auth → clientId → serviceId → client exists → service exists → not-already-completed)
+**Rule:** All 6 checks in the right order. `failed-precondition` for already-completed status preserved.
+**Evidence required:** Reading the new code.
+
+### M3 — Service mutation preserved
+**Rule:** `updatedService = { ...service, status: 'completed', completedAt: <iso> }`. Immutable `services.map()` replacement. `completedAt` is an ISO string (not serverTimestamp).
+**Evidence required:** Reading the code.
+
+### M4 — totalServices + activeServices pass through correctly
+**Rule:** Computed AFTER the service is marked completed: `totalServices = updatedServices.length`, `activeServices = updatedServices.filter(s => s.status === 'active').length`. Note the just-completed service drops out of activeServices count.
+**Evidence required:** Test asserts the count.
+
+### M5 — Audit log preserved
+**Rule:** `logAction('COMPLETE_SERVICE', user.uid, user.username, { clientId, caseNumber, serviceId, serviceName, serviceType, completedAt })` outside transaction.
+**Evidence required:** Reading the code.
+
+### M6 — Return value preserved
+**Rule:** Return shape `{ success, serviceId, serviceName, serviceType, completedAt, clientAggregates: { totalHours, hoursRemaining, minutesRemaining, isBlocked, isCritical, totalServices, activeServices }, message }`. `clientAggregates` now sourced from helper's return.
+**Evidence required:** Reading the new code.
+
+### M7 — Tests cover migrated path
+**Rule:** New test file `functions/tests/complete-service.test.js`:
+- Auth + validation (4): auth-error, missing clientId, missing serviceId
+- Lookup (2): client / service not found
+- Guard (1): already-completed → failed-precondition + no write
+- Helper integration (3): happy path (helper called, status=completed, completedAt set), activeServices count decreases by 1, last-billable-completed → I1 (isBlocked=false even if hours depleted)
+- Audit log (1)
+- Return shape (1)
+**Evidence required:** New test file + Jest output.
+
+### M8 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.4 + references pattern from PR-B.3
+**Rule:** Inline comment names PR-B.4 + the 3 prior migrations as pattern source.
+**Evidence required:** Comment block.
+
+### S2 — auditMeta carries `{ uid, username }`
+**Evidence required:** Reading the code.
+
+### S3 — PR description names PR-B.3 as immediate predecessor + migration 4/13
+**Evidence required:** PR description.
+
+## Out of scope
+
+- Other 9 callsites
+- Changing "already completed" guard
+- Changing completedAt format (ISO string preserved)
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. No data corruption.
+
+## Notes for grader
+
+- This is the closest twin of PR-B.3 yet — same shape, same `totalServices`/`activeServices` pass-through pattern.
+- The just-completed service drops from `activeServices` count — test must assert the count decreases (e.g., 2 services, complete 1 → activeServices=1).
+- I1 case is relevant if completing the last billable service while a fixed-only remains → isBlocked=false derived.

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -1049,41 +1049,48 @@ exports.completeService = functions.https.onCall(async (data, context) => {
       const updatedService = { ...service, status: 'completed', completedAt: now };
       const updatedServices = services.map((s, idx) => idx === serviceIndex ? updatedService : s);
 
-      // 3e. Recalculate client-level aggregates
-      const clientTotalHours = updatedServices.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-      const agg = calcClientAggregates(updatedServices, clientTotalHours);
+      // 3e. Compute non-aggregate derived counts (helper does NOT manage these)
+      // NOTE: activeServices decreases by 1 because the just-completed service
+      // drops out of the `status === 'active'` filter.
       const totalServices = updatedServices.length;
       const activeServices = updatedServices.filter(s => s.status === 'active').length;
 
-      // 3f. Write to Firestore (Transaction)
-      transaction.update(clientRef, {
-        services: updatedServices,
-        totalServices: totalServices,
-        activeServices: activeServices,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // 3f. PR-B.4 (2026-05-17): migrate to canonical helper.
+      // Pattern from PR-B.1/B.2/B.3 (#283/#284/#285). The helper:
+      //   - strips RESTRICTED_KEYS (defense-in-depth)
+      //   - recomputes totalHours + all aggregates from services
+      //   - asserts invariants I1/I2/I4
+      //   - emits violation record + Cloud Logging entry on failure
+      //   - honors global kill-switch
+      // I1 relevant: completing the last billable service while a fixed-only
+      // remains → helper derives isBlocked=false even if hours depleted.
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          services: updatedServices,
+          totalServices,
+          activeServices
+        },
+        {
+          caller: 'completeService',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
-      // 3g. Return data from transaction
+      // 3g. Return data from transaction (aggregates sourced from helper)
       return {
         serviceName: service.name || service.serviceName,
         serviceType: service.type || service.serviceType,
         completedAt: now,
         aggregates: {
-          totalHours: clientTotalHours,
-          hoursRemaining: agg.hoursRemaining,
-          minutesRemaining: agg.minutesRemaining,
-          isBlocked: agg.isBlocked,
-          isCritical: agg.isCritical,
-          totalServices: totalServices,
-          activeServices: activeServices
+          totalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+          hoursRemaining: helperResult.aggregates.hoursRemaining,
+          minutesRemaining: helperResult.aggregates.minutesRemaining,
+          isBlocked: helperResult.aggregates.isBlocked,
+          isCritical: helperResult.aggregates.isCritical,
+          totalServices,
+          activeServices
         }
       };
     });

--- a/functions/tests/complete-service.test.js
+++ b/functions/tests/complete-service.test.js
@@ -1,0 +1,346 @@
+/**
+ * Tests for completeService CF after PR-B.4 migration to writeClientWithCanonicalAggregates.
+ *
+ * Coverage:
+ *   A. Auth + validation (auth-error, missing clientId, missing serviceId)
+ *   B. Lookup failures (client / service not found)
+ *   C. Guard (already-completed → failed-precondition, no write)
+ *   D. Canonical helper integration (happy path, activeServices count, I1)
+ *   E. Audit log preserved
+ *   F. Return value shape preserved
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+const { completeService } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+function makeHoursService(id, { totalHours = 10, hoursUsed = 3, status = 'active' } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    status
+  };
+}
+
+function makeFixedService(id, { status = 'active' } = {}) {
+  return {
+    id,
+    type: ST.FIXED,
+    name: `פיקס ${id}`,
+    fixedPrice: 5000,
+    status,
+    work: { totalMinutesWorked: 0, entriesCount: 0 }
+  };
+}
+
+function makeClientDoc(services = []) {
+  const totalHours = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.totalHours || 0), 0);
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      status: 'active',
+      services,
+      totalHours,
+      totalServices: services.length,
+      activeServices: services.filter(s => s.status === 'active').length
+    })
+  };
+}
+
+const VALID_USER = {
+  uid: 'user1',
+  email: 'test@test',
+  username: 'testuser',
+  role: 'manager'
+};
+
+function makeCtx(uid = 'user1') {
+  return { auth: { uid, token: { email: 'test@test' } } };
+}
+
+// completeService calls transaction.get ONCE for client; helper calls it AGAIN
+// internally (Firestore caches within transaction). Wire both calls to same doc.
+function setupTxMocks(clientDoc) {
+  mockTransaction.get.mockReset();
+  mockTransaction.get
+    .mockResolvedValueOnce(clientDoc)  // 1st: completeService body
+    .mockResolvedValueOnce(clientDoc); // 2nd: helper internal
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Auth + validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Auth + validation', () => {
+  test('propagates auth errors', async () => {
+    const functions = require('firebase-functions');
+    mockCheckUserPermissions.mockRejectedValue(
+      new functions.https.HttpsError('unauthenticated', 'אין הרשאה')
+    );
+    await expect(
+      completeService({ clientId: 'c1', serviceId: 's1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+  });
+
+  test('throws invalid-argument when clientId missing', async () => {
+    await expect(
+      completeService({ serviceId: 's1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('throws invalid-argument when serviceId missing', async () => {
+    await expect(
+      completeService({ clientId: 'c1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Lookup failures
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Lookup failures', () => {
+  test('client not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce({ exists: false });
+    await expect(
+      completeService({ clientId: 'missing', serviceId: 's1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  test('service not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(
+      makeClientDoc([makeHoursService('s_other')])
+    );
+    await expect(
+      completeService({ clientId: 'c1', serviceId: 'missing-svc' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Already-completed guard
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Already-completed guard', () => {
+  test('throws failed-precondition; transaction.update NOT called', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(
+      makeClientDoc([makeHoursService('s1', { status: 'completed' })])
+    );
+    await expect(
+      completeService({ clientId: 'c1', serviceId: 's1' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'failed-precondition' });
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Canonical helper integration (PR-B.4)
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Canonical helper integration', () => {
+  test('happy path: service marked completed, completedAt set, helper called', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { totalHours: 10, hoursUsed: 3 }),
+      makeHoursService('s2', { totalHours: 20, hoursUsed: 5 })
+    ]));
+
+    const result = await completeService(
+      { clientId: 'c1', serviceId: 's1' },
+      makeCtx()
+    );
+
+    expect(mockTransaction.update).toHaveBeenCalledTimes(1);
+    const [, payload] = mockTransaction.update.mock.calls[0];
+
+    // services array carries the mutated service
+    const completedSvc = payload.services.find(s => s.id === 's1');
+    expect(completedSvc.status).toBe('completed');
+    expect(completedSvc.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // counts updated: totalServices unchanged (2), activeServices -1 (was 2 → 1)
+    expect(payload.totalServices).toBe(2);
+    expect(payload.activeServices).toBe(1);
+
+    // helper derived aggregates from remaining active (s2: 20/5)
+    expect(payload.hoursUsed).toBe(8); // both still in totalHours sum (s1.hoursUsed=3 + s2.hoursUsed=5)
+    expect(payload.isBlocked).toBe(false);
+
+    // Return value
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: 's1',
+      serviceName: 'שירות s1',
+      serviceType: 'hours',
+      completedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/)
+    });
+  });
+
+  test('activeServices count drops by exactly 1 when one of N completes', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { status: 'active' }),
+      makeHoursService('s2', { status: 'active' }),
+      makeHoursService('s3', { status: 'active' })
+    ]));
+
+    await completeService({ clientId: 'c1', serviceId: 's2' }, makeCtx());
+
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.totalServices).toBe(3);
+    expect(payload.activeServices).toBe(2); // was 3, completed 1
+  });
+
+  test('completing service does NOT remove it from billable accounting (status-agnostic)', async () => {
+    // calcClientAggregates classifies billable by TYPE, not STATUS — a completed
+    // hours service still counts in totalHours / hoursUsed. This documents the
+    // canonical behavior: completing ≠ deleting from the books.
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { totalHours: 10, hoursUsed: 10 }) // depleted hours
+    ]));
+
+    await completeService({ clientId: 'c1', serviceId: 's1' }, makeCtx());
+
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    // Even after completion, the hours service is in billable → I3 fires → isBlocked=true.
+    expect(payload.isBlocked).toBe(true);
+    expect(payload.hoursRemaining).toBe(0);
+    // But status correctly flipped to 'completed' in services array.
+    expect(payload.services[0].status).toBe('completed');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Audit log
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Audit log', () => {
+  test('COMPLETE_SERVICE emitted with clientId/caseNumber/serviceId/serviceName/serviceType', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1'),
+      makeHoursService('s2')
+    ]));
+
+    await completeService({ clientId: 'c1', serviceId: 's1' }, makeCtx());
+
+    // Audit payload omits completedAt (separately surfaced in return value).
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'COMPLETE_SERVICE',
+      'user1',
+      'testuser',
+      expect.objectContaining({
+        clientId: 'c1',
+        caseNumber: 'c1',
+        serviceId: 's1',
+        serviceName: 'שירות s1',
+        serviceType: 'hours'
+      })
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Return value
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Return value', () => {
+  test('full shape preserved', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1'),
+      makeHoursService('s2')
+    ]));
+
+    const result = await completeService(
+      { clientId: 'c1', serviceId: 's1' },
+      makeCtx()
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: 's1',
+      serviceName: expect.any(String),
+      serviceType: expect.any(String),
+      completedAt: expect.any(String),
+      clientAggregates: expect.objectContaining({
+        totalHours: expect.any(Number),
+        hoursRemaining: expect.any(Number),
+        minutesRemaining: expect.any(Number),
+        isBlocked: expect.any(Boolean),
+        isCritical: expect.any(Boolean),
+        totalServices: expect.any(Number),
+        activeServices: expect.any(Number)
+      }),
+      message: expect.stringContaining('הושלם')
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migration **4 of 13** in PR-B series. Pattern from [PR-B.3 / #285](https://github.com/Chaim2045/law-office-system/pull/285) (immediate predecessor).

**Rubric:** `.claude/rubrics/pr-b-4.md`
**Outcomes Grader verdict:** **PASS** — 8/8 MUST + 2/3 SHOULD applicable.

## What changed

`completeService` (functions/services/index.js) marks a service `{ status: 'completed', completedAt: <iso> }` and previously wrote the manual aggregate block. Now routed through `writeClientWithCanonicalAggregates`.

| Field | Before | After |
|-------|--------|-------|
| `services` (with mutated service) | manual write | passed to helper |
| `totalServices`, `activeServices` | manual write | passed to helper (NOT in RESTRICTED_KEYS) |
| 7 aggregate fields + lastModifiedBy/At | manual calcClientAggregates + write | helper derives + writes |

## Canonical clarification (documented in tests)

`calcClientAggregates` classifies billable by **TYPE**, not **STATUS**. A completed hours service IS still billable in the accounting:

- `status='completed'` on a depleted hours service → still `isBlocked=true` via I3 (hoursRemaining=0)
- Completing ≠ removing from the books

This is the correct accounting model. Test D.3 explicitly documents this behavior.

## Per `functions/CLAUDE.md` mental model

- **Writes:** `completeService` callable surface — unchanged
- **Reads:** Admin UI "complete service" flow
- **Recalculates aggregates:** via canonical helper now
- **CREATE/UPDATE/DELETE:** UPDATE migrated. No new mutation paths
- **Fallback:** helper tolerates malformed services. Pre-helper guards (auth, validation, already-completed) all preserved in order
- **Drift risk:** closed for this callsite. 9 callsites remain

## Verification

- ✅ functions/ Jest: **358 pass** (was 347, +11 new in `complete-service.test.js`)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Grader: PASS 8/8 MUST + 2/3 SHOULD applicable

## Test plan

- [ ] CI green
- [ ] After merge → smoke DEV: open service → mark as completed → verify status badge updates + service moves out of "active" filter
- [ ] Smoke: try to complete an already-completed service → expect rejection (`failed-precondition` unchanged)
- [ ] Smoke: complete the only active service → verify activeServices count reflects 0

## Rollback

`git revert <merge-commit>` → CI redeploys. `completeService` reverts to prior block. Helper remains. No data corruption possible.