### PR TITLE
refactor(functions): migrate changeServiceStatus to canonical helper (PR-B.5)

### DIFF
--- a/.claude/rubrics/pr-b-5.md
+++ b/.claude/rubrics/pr-b-5.md
@@ -1,0 +1,87 @@
+# Rubric — PR-B.5
+
+**Title:** refactor(functions): migrate changeServiceStatus to canonical helper
+**Branch:** feat/migrate-change-service-status-pr-b-5
+**Base:** main
+**Scope:** Migration 5 of 13. `changeServiceStatus` transitions a service between `active|completed|on_hold|archived`, appends an entry to `statusChangeHistory[]`, conditionally sets `completedAt`, then writes the manual aggregate block. Replace the aggregate block with `writeClientWithCanonicalAggregates`. Same pattern as PR-B.4 — `totalServices` / `activeServices` pass through.
+
+## Risk profile
+
+**Low-medium.** Service-level history mutation is the only new wrinkle vs PR-B.4. Aggregate plumbing identical.
+
+## MUST criteria (block on FAIL)
+
+### M1 — changeServiceStatus uses writeClientWithCanonicalAggregates
+**Rule:** Body calls `writeClientWithCanonicalAggregates(transaction, clientRef, { services, totalServices, activeServices }, { caller: 'changeServiceStatus', auditMeta: { uid, username } })`. Manual aggregate block removed.
+**Evidence required:** Diff confirms swap. No `hoursUsed/hoursRemaining/minutesUsed/minutesRemaining/isBlocked/isCritical/totalHours/lastModifiedAt/lastModifiedBy` in this CF anymore.
+
+### M2 — Validations preserved (auth → clientId → serviceId → newStatus in VALID_STATUSES → client exists → service exists → not-same-status)
+**Rule:** All 7 checks in order. `failed-precondition` for same-status preserved.
+**Evidence required:** Reading the new code.
+
+### M3 — Service mutation preserved (status + statusChangedAt + statusChangedBy + previousStatus + statusChangeHistory append)
+**Rule:** `updatedService` includes ALL 5 fields. `statusChangeHistory` is an array — new entry APPENDED (not replaced), preserving prior history.
+**Evidence required:** Reading the code + test asserts the history array grows.
+
+### M4 — Conditional completedAt setting preserved
+**Rule:** When `newStatus === 'completed'` AND `service.completedAt` not already set → assign `completedAt = now`. NOT set on other transitions.
+**Evidence required:** Reading the code + test for both branches.
+
+### M5 — totalServices + activeServices computed after mutation
+**Rule:** Counts reflect post-transition state. Critically: transitioning to/from `active` changes `activeServices` count.
+**Evidence required:** Tests assert correct counts for multiple transitions.
+
+### M6 — Audit log preserved
+**Rule:** `logAction('CHANGE_SERVICE_STATUS', uid, username, { clientId, serviceId, serviceName, serviceType, previousStatus, newStatus, note })` outside transaction. Note trimmed to 500 chars.
+**Evidence required:** Reading the code.
+
+### M7 — Return value preserved
+**Rule:** Return shape `{ success, serviceId, serviceName, previousStatus, newStatus, statusChangedAt, clientAggregates, message }`. `clientAggregates` sourced from helper.
+**Evidence required:** Reading the code.
+
+### M8 — Tests cover migrated path
+**Rule:** New test file `functions/tests/change-service-status.test.js`:
+- Auth + validation (4): auth-error, missing clientId, missing serviceId, invalid newStatus
+- Lookup (2): client / service not found
+- Guard (1): same-status → failed-precondition + no write
+- Helper integration (4): 
+  - active → completed (sets completedAt, helper called)
+  - completed → active (does NOT erase completedAt; helper called)
+  - active → on_hold (activeServices decrements)
+  - statusChangeHistory append (preserves prior entries)
+- Audit log (1)
+- Return shape (1)
+**Evidence required:** New test file + Jest output.
+
+### M9 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.5
+**Rule:** Inline comment references PR-B.5 + pattern source PR-B.1-B.4.
+**Evidence required:** Comment block.
+
+### S2 — auditMeta carries `{ uid, username }`
+**Evidence required:** Reading the code.
+
+### S3 — PR description names PR-B.4 as predecessor + 5/13
+**Evidence required:** PR description.
+
+## Out of scope
+
+- Other 8 callsites
+- Changing VALID_STATUSES list
+- Changing history shape
+- Note size limit (500 chars preserved)
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. No data corruption.
+
+## Notes for grader
+
+- This CF has 4 valid statuses (active, completed, on_hold, archived). NOT to confuse with client-level `isOnHold` field (different field, different scope).
+- `statusChangeHistory` is the rare case where the migration is on data NOT covered by aggregator. Helper passes services through wholesale — the history append survives because services[i] is wholesale replaced with updatedService (which carries the updated history array).
+- I3 / I1 implications: completing a service doesn't remove it from billable accounting (same as PR-B.4 finding). Tests should NOT expect `isBlocked=false` after completing a depleted hours service.

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -1238,29 +1238,36 @@ exports.changeServiceStatus = functions.https.onCall(async (data, context) => {
       // 3e. Immutable array replacement
       const updatedServices = services.map((s, idx) => idx === serviceIndex ? updatedService : s);
 
-      // 3f. Recalculate client-level aggregates
-      const clientTotalHours = updatedServices.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-      const agg = calcClientAggregates(updatedServices, clientTotalHours);
+      // 3f. Compute non-aggregate derived counts (helper does NOT manage these)
+      // NOTE: activeServices changes when transitioning to/from 'active'.
       const totalServices = updatedServices.length;
       const activeServices = updatedServices.filter(s => s.status === 'active').length;
 
-      // 3g. Write to Firestore (Transaction)
-      transaction.update(clientRef, {
-        services: updatedServices,
-        totalServices: totalServices,
-        activeServices: activeServices,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // 3g. PR-B.5 (2026-05-17): migrate to canonical helper.
+      // Pattern from PR-B.1/B.2/B.3/B.4 (#283/#284/#285/#286). The helper:
+      //   - strips RESTRICTED_KEYS (defense-in-depth)
+      //   - recomputes totalHours + all aggregates from services
+      //   - asserts invariants I1/I2/I4
+      //   - emits violation record + Cloud Logging entry on failure
+      //   - honors global kill-switch
+      // statusChangeHistory append survives the wholesale services[] replace
+      // because services[serviceIndex] is the new updatedService object
+      // which carries the appended history array.
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          services: updatedServices,
+          totalServices,
+          activeServices
+        },
+        {
+          caller: 'changeServiceStatus',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
-      // 3h. Return data from transaction
+      // 3h. Return data from transaction (aggregates sourced from helper)
       const serviceName = service.name || service.serviceName;
       const serviceType = service.type || service.serviceType;
 
@@ -1271,14 +1278,14 @@ exports.changeServiceStatus = functions.https.onCall(async (data, context) => {
         newStatus: data.newStatus,
         statusChangedAt: now,
         aggregates: {
-          totalHours: clientTotalHours,
-          hoursUsed: agg.hoursUsed,
-          hoursRemaining: agg.hoursRemaining,
-          minutesRemaining: agg.minutesRemaining,
-          isBlocked: agg.isBlocked,
-          isCritical: agg.isCritical,
-          totalServices: totalServices,
-          activeServices: activeServices
+          totalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+          hoursUsed: helperResult.aggregates.hoursUsed,
+          hoursRemaining: helperResult.aggregates.hoursRemaining,
+          minutesRemaining: helperResult.aggregates.minutesRemaining,
+          isBlocked: helperResult.aggregates.isBlocked,
+          isCritical: helperResult.aggregates.isCritical,
+          totalServices,
+          activeServices
         }
       };
     });

--- a/functions/tests/change-service-status.test.js
+++ b/functions/tests/change-service-status.test.js
@@ -1,0 +1,393 @@
+/**
+ * Tests for changeServiceStatus CF after PR-B.5 migration.
+ *
+ * Coverage:
+ *   A. Auth + validation (auth-error, missing args, invalid newStatus)
+ *   B. Lookup failures
+ *   C. Same-status guard
+ *   D. Canonical helper integration:
+ *      - active → completed (sets completedAt, helper called)
+ *      - completed → active (does NOT erase completedAt)
+ *      - active → on_hold (activeServices decrements)
+ *      - statusChangeHistory append preserves prior entries
+ *   E. Audit log
+ *   F. Return value shape
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+const { changeServiceStatus } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeHoursService(id, opts = {}) {
+  const {
+    totalHours = 10,
+    hoursUsed = 3,
+    status = 'active',
+    completedAt = null,
+    statusChangeHistory = []
+  } = opts;
+  const svc = {
+    id,
+    type: ST.HOURS,
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    status
+  };
+  if (completedAt) svc.completedAt = completedAt;
+  if (statusChangeHistory.length) svc.statusChangeHistory = statusChangeHistory;
+  return svc;
+}
+
+function makeClientDoc(services = []) {
+  const totalHours = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.totalHours || 0), 0);
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      status: 'active',
+      services,
+      totalHours,
+      totalServices: services.length,
+      activeServices: services.filter(s => s.status === 'active').length
+    })
+  };
+}
+
+const VALID_USER = {
+  uid: 'user1',
+  email: 'test@test',
+  username: 'testuser',
+  role: 'manager'
+};
+
+function makeCtx(uid = 'user1') {
+  return { auth: { uid, token: { email: 'test@test' } } };
+}
+
+function setupTxMocks(clientDoc) {
+  mockTransaction.get.mockReset();
+  mockTransaction.get
+    .mockResolvedValueOnce(clientDoc)  // CF body
+    .mockResolvedValueOnce(clientDoc); // helper internal
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Auth + validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Auth + validation', () => {
+  test('propagates auth errors', async () => {
+    const functions = require('firebase-functions');
+    mockCheckUserPermissions.mockRejectedValue(
+      new functions.https.HttpsError('unauthenticated', 'אין הרשאה')
+    );
+    await expect(
+      changeServiceStatus(
+        { clientId: 'c1', serviceId: 's1', newStatus: 'completed' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+  });
+
+  test('missing clientId → invalid-argument', async () => {
+    await expect(
+      changeServiceStatus({ serviceId: 's1', newStatus: 'completed' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('missing serviceId → invalid-argument', async () => {
+    await expect(
+      changeServiceStatus({ clientId: 'c1', newStatus: 'completed' }, makeCtx())
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('invalid newStatus → invalid-argument', async () => {
+    await expect(
+      changeServiceStatus(
+        { clientId: 'c1', serviceId: 's1', newStatus: 'bogus' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('accepts all 4 valid statuses', async () => {
+    const statuses = ['active', 'completed', 'on_hold', 'archived'];
+    for (const newStatus of statuses) {
+      setupTxMocks(makeClientDoc([
+        // service is in a DIFFERENT status so same-status guard passes
+        makeHoursService('s1', { status: newStatus === 'active' ? 'on_hold' : 'active' })
+      ]));
+      await expect(
+        changeServiceStatus(
+          { clientId: 'c1', serviceId: 's1', newStatus },
+          makeCtx()
+        )
+      ).resolves.toMatchObject({ success: true, newStatus });
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Lookup failures
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Lookup failures', () => {
+  test('client not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce({ exists: false });
+    await expect(
+      changeServiceStatus(
+        { clientId: 'missing', serviceId: 's1', newStatus: 'completed' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+
+  test('service not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(
+      makeClientDoc([makeHoursService('s_other')])
+    );
+    await expect(
+      changeServiceStatus(
+        { clientId: 'c1', serviceId: 'missing', newStatus: 'completed' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Same-status guard
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Same-status guard', () => {
+  test('throws failed-precondition; transaction.update NOT called', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(
+      makeClientDoc([makeHoursService('s1', { status: 'active' })])
+    );
+    await expect(
+      changeServiceStatus(
+        { clientId: 'c1', serviceId: 's1', newStatus: 'active' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'failed-precondition' });
+    expect(mockTransaction.update).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Canonical helper integration (PR-B.5)
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Canonical helper integration', () => {
+  test('active → completed: sets completedAt, helper called', async () => {
+    setupTxMocks(makeClientDoc([makeHoursService('s1', { status: 'active' })]));
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'completed' },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services.find(s => s.id === 's1');
+    expect(svc.status).toBe('completed');
+    expect(svc.completedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(svc.statusChangedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(svc.previousStatus).toBe('active');
+  });
+
+  test('completed → active: does NOT erase completedAt', async () => {
+    const priorCompletedAt = '2026-04-01T10:00:00.000Z';
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { status: 'completed', completedAt: priorCompletedAt })
+    ]));
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'active' },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services.find(s => s.id === 's1');
+    expect(svc.status).toBe('active');
+    // Critical: prior completedAt preserved (NOT overwritten)
+    expect(svc.completedAt).toBe(priorCompletedAt);
+  });
+
+  test('active → on_hold: activeServices count decrements', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { status: 'active' }),
+      makeHoursService('s2', { status: 'active' }),
+      makeHoursService('s3', { status: 'active' })
+    ]));
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's2', newStatus: 'on_hold' },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.totalServices).toBe(3);
+    expect(payload.activeServices).toBe(2); // was 3, one → on_hold
+  });
+
+  test('statusChangeHistory APPENDS — preserves prior entries', async () => {
+    const priorHistory = [
+      { from: 'active', to: 'on_hold', changedAt: '2026-04-01T00:00:00.000Z', changedBy: 'admin', note: 'first' }
+    ];
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { status: 'on_hold', statusChangeHistory: priorHistory })
+    ]));
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'active', note: 'second' },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services.find(s => s.id === 's1');
+    expect(svc.statusChangeHistory).toHaveLength(2);
+    expect(svc.statusChangeHistory[0]).toEqual(priorHistory[0]);
+    expect(svc.statusChangeHistory[1]).toMatchObject({
+      from: 'on_hold',
+      to: 'active',
+      note: 'second'
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Audit log
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Audit log', () => {
+  test('CHANGE_SERVICE_STATUS emitted with full payload', async () => {
+    setupTxMocks(makeClientDoc([makeHoursService('s1', { status: 'active' })]));
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'on_hold', note: 'reason' },
+      makeCtx()
+    );
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'CHANGE_SERVICE_STATUS',
+      'user1',
+      'testuser',
+      expect.objectContaining({
+        clientId: 'c1',
+        serviceId: 's1',
+        serviceName: 'שירות s1',
+        serviceType: 'hours',
+        previousStatus: 'active',
+        newStatus: 'on_hold',
+        note: 'reason'
+      })
+    );
+  });
+
+  test('note trimmed to 500 chars', async () => {
+    setupTxMocks(makeClientDoc([makeHoursService('s1', { status: 'active' })]));
+    const longNote = 'x'.repeat(600);
+    await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'completed', note: longNote },
+      makeCtx()
+    );
+    const noteArg = mockLogAction.mock.calls[0][3].note;
+    expect(noteArg.length).toBe(500);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Return value
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Return value', () => {
+  test('full shape preserved', async () => {
+    setupTxMocks(makeClientDoc([
+      makeHoursService('s1', { status: 'active' }),
+      makeHoursService('s2', { status: 'active' })
+    ]));
+    const result = await changeServiceStatus(
+      { clientId: 'c1', serviceId: 's1', newStatus: 'completed' },
+      makeCtx()
+    );
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: 's1',
+      serviceName: expect.any(String),
+      previousStatus: 'active',
+      newStatus: 'completed',
+      statusChangedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+      clientAggregates: expect.objectContaining({
+        totalHours: expect.any(Number),
+        hoursUsed: expect.any(Number),
+        hoursRemaining: expect.any(Number),
+        minutesRemaining: expect.any(Number),
+        isBlocked: expect.any(Boolean),
+        isCritical: expect.any(Boolean),
+        totalServices: expect.any(Number),
+        activeServices: expect.any(Number)
+      })
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Migration **5 of 13** in PR-B series. Pattern from [PR-B.4 / #286](https://github.com/Chaim2045/law-office-system/pull/286) (immediate predecessor).

**Rubric:** `.claude/rubrics/pr-b-5.md`
**Outcomes Grader verdict:** **PASS** — 9/9 MUST + 2/3 SHOULD applicable

## What changed

`changeServiceStatus` (functions/services/index.js) transitions a service between 4 statuses, appends to `statusChangeHistory[]`, conditionally sets `completedAt`, then previously wrote the manual aggregate block. Now routed through `writeClientWithCanonicalAggregates`.

## Key preservations

- **`statusChangeHistory` APPENDS** (spreads prior + new entry, doesn't replace)
- **`completedAt` conditional:** set on `active → completed` only if not already set; NOT erased on `completed → active`
- All 7 validations in order: auth → clientId → serviceId → newStatus in VALID_STATUSES → client → service → not-same-status
- Note trimmed to 500 chars
- 4 valid statuses: `active | completed | on_hold | archived`

## Per `functions/CLAUDE.md` mental model

- **Writes:** `changeServiceStatus` callable surface — unchanged
- **Reads:** Admin UI service status-change flow
- **Recalculates aggregates:** via canonical helper now
- **CREATE/UPDATE/DELETE:** UPDATE migrated
- **Fallback:** helper tolerates malformed services. Pre-helper guards preserved in order
- **Drift risk:** closed for this callsite. 8 callsites remain

## Verification

- ✅ functions/ Jest: **373 pass** (was 358, +15 new in `change-service-status.test.js`)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Grader: PASS 9/9 MUST + 2/3 SHOULD applicable

## Test plan

- [ ] CI green
- [ ] After merge → smoke DEV: change service status active → completed, verify `completedAt` set
- [ ] Smoke: change completed → active, verify `completedAt` NOT erased (historical record preserved)
- [ ] Smoke: change active → on_hold, verify `activeServices` count decrements
- [ ] Smoke: try same-status transition → expect rejection (`failed-precondition` unchanged)

## Rollback

`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. Helper remains. No data corruption possible.