### PR TITLE
refactor(functions): migrate addServiceToClient to canonical helper (PR-B.6)

### DIFF
--- a/.claude/rubrics/pr-b-6.md
+++ b/.claude/rubrics/pr-b-6.md
@@ -1,0 +1,85 @@
+# Rubric — PR-B.6
+
+**Title:** refactor(functions): migrate addServiceToClient to canonical helper
+**Branch:** feat/migrate-add-service-to-client-pr-b-6
+**Base:** main
+**Scope:** Migration 6 of 13. `addServiceToClient` is the first CF in PR-B series that ADDS a service (vs mutating one). Validates 3 service-type variants (`hours`, `legal_procedure`, `fixed`), builds the new service object (with packages/stages/work-tracker per type), appends to `services[]`, then writes the manual aggregate block. Replace the aggregate block with `writeClientWithCanonicalAggregates`.
+
+## Risk profile
+
+**Medium.** Three branches of service construction (hours/legal_procedure/fixed). Append-not-replace pattern. The helper handles aggregate computation regardless of which branch built the new service.
+
+## MUST criteria (block on FAIL)
+
+### M1 — addServiceToClient uses writeClientWithCanonicalAggregates
+**Rule:** Body calls `writeClientWithCanonicalAggregates(transaction, clientRef, { services, totalServices, activeServices }, { caller: 'addServiceToClient', auditMeta: { uid, username } })`. Manual aggregate block removed.
+**Evidence required:** Diff confirms swap. No `hoursUsed/hoursRemaining/minutesUsed/minutesRemaining/isBlocked/isCritical/totalHours/lastModifiedAt/lastModifiedBy` in this CF anymore.
+
+### M2 — All pre-transaction validations preserved
+**Rule:** auth → clientId → serviceType (via `isValidServiceType`) → serviceName (min 2 chars) → type-specific (hours requires `data.hours > 0`; legal_procedure requires `data.stages.length === 3` + valid pricingType; fixed requires `data.fixedPrice >= 0`).
+**Evidence required:** Reading the new code; all checks in order.
+
+### M3 — Service construction branches preserved
+**Rule:** Each of 3 service types builds its expected shape:
+- `hours`: with initial `packages[0]` (type='initial'), totalHours/hoursUsed/hoursRemaining
+- `legal_procedure` (hourly): 3 stages with packages, currentStage = first stage id, totalHours summed across stages
+- `legal_procedure` (fixed): 3 stages with `fixedPrice` + `paid:false`, totalPrice summed
+- `fixed`: `fixedPrice`, `work: { totalMinutesWorked: 0, entriesCount: 0 }`, `completedAt: null`
+**Evidence required:** Tests for each variant assert the constructed shape.
+
+### M4 — Services array appended (not replaced)
+**Rule:** `services = [...(clientData.services || []), newService]`. Prior services preserved. New service added at end.
+**Evidence required:** Test with N existing services → length is N+1, prior IDs preserved.
+
+### M5 — Audit log preserved
+**Rule:** `logAction('ADD_SERVICE_TO_CLIENT', user.uid, user.username, { clientId, caseNumber, serviceId, serviceType, serviceName })` outside transaction.
+**Evidence required:** Reading the code.
+
+### M6 — Return value preserved
+**Rule:** Return shape `{ success, serviceId, service, message }` unchanged. The `service` field is the full newly-constructed service object.
+**Evidence required:** Reading the code.
+
+### M7 — Tests cover migrated path
+**Rule:** New test file `functions/tests/add-service-to-client.test.js`:
+- Auth + validation (5): auth-error, missing clientId, invalid serviceType, short serviceName, type-specific validation (hours/legal_procedure/fixed each)
+- Lookup (1): client not found
+- Service construction (4): hours / legal_procedure hourly / legal_procedure fixed / fixed — each asserts the built shape
+- Append (1): client with N prior services → length N+1 + prior IDs preserved
+- Helper integration (2):
+  - hours added to empty client → helper called, aggregates derived (totalHours=N, hoursRemaining=N)
+  - fixed added to empty client → I1 → isBlocked=false derived
+- Audit log (1): ADD_SERVICE_TO_CLIENT payload shape
+- Return shape (1)
+**Evidence required:** New test file + Jest output.
+
+### M8 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.6 + pattern source
+**Evidence required:** Comment block.
+
+### S2 — auditMeta carries `{ uid, username }`
+**Evidence required:** Reading the code.
+
+### S3 — PR description names PR-B.5 predecessor + 6/13
+**Evidence required:** PR description.
+
+## Out of scope
+
+- Other 7 callsites
+- Changing service-type construction logic
+- Adding new service types
+- Changing the `services[]` append-at-end ordering
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. No data corruption.
+
+## Notes for grader
+
+- This is the FIRST CF in PR-B that ADDS a service rather than mutating one. The helper handles append the same way as mutate — passed services[] is wholesale. Verify the new service is at the end of the array post-helper write.
+- 3 service-type branches are non-trivial. Construction logic must remain intact — that's not the migration's job to refactor.
+- The `serviceId = srv_${Date.now()}` outside the transaction is intentional (uniqueness). Don't move it inside.

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -191,24 +191,29 @@ exports.addServiceToClient = functions.https.onCall(async (data, context) => {
       // הוספת השירות למערך services[]
       const services = [...(clientData.services || []), newService];
 
-      // עדכון הלקוח
-      const clientTotalHours = services.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-      const agg = calcClientAggregates(services, clientTotalHours);
+      // Compute non-aggregate derived counts (helper does NOT manage these)
+      const totalServices = services.length;
+      const activeServices = services.filter(s => s.status === 'active').length;
 
-      transaction.update(clientRef, {
-        services: services,
-        totalServices: services.length,
-        activeServices: services.filter(s => s.status === 'active').length,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // PR-B.6 (2026-05-17): migrate to canonical helper.
+      // Pattern from PR-B.1-B.5 (#283-#287). First CF in PR-B that ADDS
+      // a service (vs mutating). Helper handles append-at-end the same
+      // way as wholesale-replace — services[] passed in full to the
+      // helper which recomputes totalHours + aggregates from the
+      // (now N+1)-element array.
+      await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          services,
+          totalServices,
+          activeServices
+        },
+        {
+          caller: 'addServiceToClient',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
       return { newService };
     });

--- a/functions/tests/add-service-to-client.test.js
+++ b/functions/tests/add-service-to-client.test.js
@@ -1,0 +1,442 @@
+/**
+ * Tests for addServiceToClient CF after PR-B.6 migration.
+ *
+ * Coverage:
+ *   A. Auth + validation (auth-error, missing args, invalid serviceType,
+ *      short serviceName, per-type validation)
+ *   B. Lookup failures
+ *   C. Service construction by type (hours, legal_procedure hourly/fixed, fixed)
+ *   D. Append behavior (preserves prior services)
+ *   E. Canonical helper integration:
+ *      - hours added to empty client → helper derives correct aggregates
+ *      - fixed added to empty client → I1 → isBlocked=false
+ *   F. Audit log
+ *   G. Return shape
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+const { addServiceToClient } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeClientDoc(services = []) {
+  const totalHours = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.totalHours || 0), 0);
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      status: 'active',
+      services,
+      totalHours,
+      totalServices: services.length,
+      activeServices: services.filter(s => s.status === 'active').length
+    })
+  };
+}
+
+const VALID_USER = {
+  uid: 'user1',
+  email: 'test@test',
+  username: 'testuser',
+  role: 'manager'
+};
+
+function makeCtx(uid = 'user1') {
+  return { auth: { uid, token: { email: 'test@test' } } };
+}
+
+function setupTxMocks(clientDoc) {
+  mockTransaction.get.mockReset();
+  mockTransaction.get
+    .mockResolvedValueOnce(clientDoc)  // CF body
+    .mockResolvedValueOnce(clientDoc); // helper internal
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Auth + validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Auth + validation', () => {
+  test('propagates auth errors', async () => {
+    const functions = require('firebase-functions');
+    mockCheckUserPermissions.mockRejectedValue(
+      new functions.https.HttpsError('unauthenticated', 'אין הרשאה')
+    );
+    await expect(
+      addServiceToClient(
+        { clientId: 'c1', serviceType: 'hours', serviceName: 'X', hours: 10 },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'unauthenticated' });
+  });
+
+  test('missing clientId → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        { serviceType: 'hours', serviceName: 'X', hours: 10 },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('invalid serviceType → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        { clientId: 'c1', serviceType: 'bogus', serviceName: 'X' },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('serviceName too short → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        { clientId: 'c1', serviceType: 'hours', serviceName: 'X', hours: 10 },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('hours: missing/zero hours → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        { clientId: 'c1', serviceType: 'hours', serviceName: 'שירות שעות', hours: 0 },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('legal_procedure: stages must be array of length 3', async () => {
+    await expect(
+      addServiceToClient(
+        {
+          clientId: 'c1',
+          serviceType: 'legal_procedure',
+          serviceName: 'הליך משפטי',
+          pricingType: 'hourly',
+          stages: [{ hours: 10 }, { hours: 5 }] // only 2 — invalid
+        },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('legal_procedure: invalid pricingType → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        {
+          clientId: 'c1',
+          serviceType: 'legal_procedure',
+          serviceName: 'הליך משפטי',
+          pricingType: 'monthly', // invalid
+          stages: [{ hours: 5 }, { hours: 5 }, { hours: 5 }]
+        },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+
+  test('fixed: negative fixedPrice → invalid-argument', async () => {
+    await expect(
+      addServiceToClient(
+        {
+          clientId: 'c1',
+          serviceType: 'fixed',
+          serviceName: 'פיקס',
+          fixedPrice: -100
+        },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Lookup failures
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Lookup failures', () => {
+  test('client not found → not-found', async () => {
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce({ exists: false });
+    await expect(
+      addServiceToClient(
+        { clientId: 'missing', serviceType: 'hours', serviceName: 'שירות', hours: 10 },
+        makeCtx()
+      )
+    ).rejects.toMatchObject({ code: 'not-found' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Service construction by type
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Service construction', () => {
+  test('hours: builds with initial package, totalHours/hoursUsed/hoursRemaining', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      { clientId: 'c1', serviceType: 'hours', serviceName: 'תוכנית שעות', hours: 20 },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services[payload.services.length - 1];
+    expect(svc.type).toBe('hours');
+    expect(svc.totalHours).toBe(20);
+    expect(svc.hoursUsed).toBe(0);
+    expect(svc.hoursRemaining).toBe(20);
+    expect(svc.status).toBe('active');
+    expect(svc.packages).toHaveLength(1);
+    expect(svc.packages[0]).toMatchObject({
+      type: 'initial',
+      hours: 20,
+      hoursUsed: 0,
+      hoursRemaining: 20,
+      status: 'active'
+    });
+  });
+
+  test('legal_procedure hourly: 3 stages with packages, totalHours summed', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      {
+        clientId: 'c1',
+        serviceType: 'legal_procedure',
+        serviceName: 'תביעה',
+        pricingType: 'hourly',
+        stages: [{ hours: 5 }, { hours: 10 }, { hours: 3 }]
+      },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services[payload.services.length - 1];
+    expect(svc.type).toBe('legal_procedure');
+    expect(svc.pricingType).toBe('hourly');
+    expect(svc.stages).toHaveLength(3);
+    expect(svc.totalHours).toBe(18); // 5+10+3
+    expect(svc.hoursRemaining).toBe(18);
+    expect(svc.currentStage).toBe(SYSTEM_CONSTANTS.VALID_STAGE_IDS[0]);
+    // First stage active, others pending
+    expect(svc.stages[0].status).toBe('active');
+    expect(svc.stages[1].status).toBe('pending');
+    expect(svc.stages[2].status).toBe('pending');
+  });
+
+  test('legal_procedure fixed: 3 stages with fixedPrice + paid:false, totalPrice summed', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      {
+        clientId: 'c1',
+        serviceType: 'legal_procedure',
+        serviceName: 'הליך פיקס',
+        pricingType: 'fixed',
+        stages: [{ fixedPrice: 1000 }, { fixedPrice: 2000 }, { fixedPrice: 500 }]
+      },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services[payload.services.length - 1];
+    expect(svc.pricingType).toBe('fixed');
+    expect(svc.stages).toHaveLength(3);
+    expect(svc.totalPrice).toBe(3500);
+    expect(svc.totalPaid).toBe(0);
+    svc.stages.forEach(stage => {
+      expect(stage.paid).toBe(false);
+      expect(stage.fixedPrice).toBeGreaterThan(0);
+    });
+  });
+
+  test('fixed: builds with fixedPrice, work tracker, completedAt=null', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      {
+        clientId: 'c1',
+        serviceType: 'fixed',
+        serviceName: 'שירות קבוע',
+        fixedPrice: 5000
+      },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = payload.services[payload.services.length - 1];
+    expect(svc.type).toBe('fixed');
+    expect(svc.fixedPrice).toBe(5000);
+    expect(svc.work).toEqual({ totalMinutesWorked: 0, entriesCount: 0 });
+    expect(svc.completedAt).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Append behavior
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Append behavior', () => {
+  test('preserves prior services + appends new at end', async () => {
+    const prior = [
+      { id: 'old1', type: 'hours', name: 'ישן 1', status: 'active', totalHours: 10, hoursUsed: 0 },
+      { id: 'old2', type: 'fixed', name: 'ישן 2', status: 'active', fixedPrice: 1000 }
+    ];
+    setupTxMocks(makeClientDoc(prior));
+    await addServiceToClient(
+      { clientId: 'c1', serviceType: 'fixed', serviceName: 'חדש', fixedPrice: 500 },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    expect(payload.services).toHaveLength(3);
+    expect(payload.services[0].id).toBe('old1');
+    expect(payload.services[1].id).toBe('old2');
+    expect(payload.services[2].name).toBe('חדש');
+    expect(payload.totalServices).toBe(3);
+    expect(payload.activeServices).toBe(3); // all active
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Canonical helper integration (PR-B.6)
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Canonical helper integration', () => {
+  test('hours added to empty client → aggregates derived', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      { clientId: 'c1', serviceType: 'hours', serviceName: 'שירות', hours: 25 },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    // Helper derived totalHours=25, hoursRemaining=25, isBlocked=false
+    expect(payload.totalHours).toBe(25);
+    expect(payload.hoursRemaining).toBe(25);
+    expect(payload.hoursUsed).toBe(0);
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isCritical).toBe(false);
+  });
+
+  test('fixed-only service → I1 → isBlocked=false', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      { clientId: 'c1', serviceType: 'fixed', serviceName: 'פיקס', fixedPrice: 5000 },
+      makeCtx()
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    // No billable hours → I1 → isBlocked=false
+    expect(payload.isBlocked).toBe(false);
+    expect(payload.isCritical).toBe(false);
+    expect(payload.totalHours).toBe(0); // fixed doesn't contribute to totalHours
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Audit log
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Audit log', () => {
+  test('ADD_SERVICE_TO_CLIENT emitted with full payload', async () => {
+    setupTxMocks(makeClientDoc([]));
+    await addServiceToClient(
+      { clientId: 'c1', serviceType: 'hours', serviceName: 'שירות חדש', hours: 10 },
+      makeCtx()
+    );
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'ADD_SERVICE_TO_CLIENT',
+      'user1',
+      'testuser',
+      expect.objectContaining({
+        clientId: 'c1',
+        caseNumber: 'c1',
+        serviceId: expect.stringMatching(/^srv_/),
+        serviceType: 'hours',
+        serviceName: 'שירות חדש'
+      })
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// G. Return value
+// ═══════════════════════════════════════════════════════════════
+
+describe('G. Return value', () => {
+  test('returns { success, serviceId, service, message }', async () => {
+    setupTxMocks(makeClientDoc([]));
+    const result = await addServiceToClient(
+      { clientId: 'c1', serviceType: 'fixed', serviceName: 'שירות', fixedPrice: 1000 },
+      makeCtx()
+    );
+    expect(result).toMatchObject({
+      success: true,
+      serviceId: expect.stringMatching(/^srv_/),
+      service: expect.objectContaining({
+        name: 'שירות',
+        type: 'fixed',
+        fixedPrice: 1000
+      }),
+      message: expect.stringContaining('נוסף')
+    });
+  });
+});

--- a/functions/tests/serviceId-validation.test.js
+++ b/functions/tests/serviceId-validation.test.js
@@ -488,14 +488,17 @@ describe('createTimesheetEntry_v2 — serviceId validation GATEs (logic verifica
 describe('addServiceToClient — transaction wrapping verification', () => {
 
   /**
-   * The key change: addServiceToClient was refactored to use db.runTransaction.
-   * Before: clientRef.get() → services.push(newService) → clientRef.update()
-   * After:  db.runTransaction → transaction.get(clientRef) → transaction.update(clientRef)
+   * History:
+   *   - Original refactor: clientRef.get/update → db.runTransaction + transaction.get/update.
+   *   - PR-B.6 (2026-05-17): the `transaction.update(clientRef, ...)` write was
+   *     delegated to writeClientWithCanonicalAggregates (single canonical write
+   *     path for the clients collection). The transaction still wraps the
+   *     read+write; the write is just inside the helper now.
    *
    * We verify:
    * 1. db.runTransaction is called (not direct read/update)
    * 2. Inside transaction: transaction.get is used for reads
-   * 3. Inside transaction: transaction.update is used for writes
+   * 3. Inside transaction: writeClientWithCanonicalAggregates is called for writes
    * 4. Immutable array: services = [...existing, newService] (not push)
    */
 
@@ -523,8 +526,14 @@ describe('addServiceToClient — transaction wrapping verification', () => {
     expect(fnBlock).toContain('transaction.get(clientRef)');
   });
 
-  test('addServiceToClient uses transaction.update inside transaction', () => {
-    expect(fnBlock).toContain('transaction.update(clientRef');
+  test('addServiceToClient delegates write to writeClientWithCanonicalAggregates (PR-B.6)', () => {
+    // PR-B.6: the direct `transaction.update(clientRef, ...)` was replaced
+    // by a call to the canonical write helper. The helper itself issues
+    // the transaction.update internally.
+    expect(fnBlock).toContain('writeClientWithCanonicalAggregates');
+    expect(fnBlock).toContain("caller: 'addServiceToClient'");
+    // Must NOT contain a direct transaction.update(clientRef, ...) anymore
+    expect(fnBlock).not.toMatch(/transaction\.update\(clientRef[\s\S]{0,200}hoursUsed/);
   });
 
   test('addServiceToClient uses immutable spread for services array', () => {


### PR DESCRIPTION
## Summary

Migration **6 of 13** in PR-B series. **FIRST CF in series that ADDS a service** (vs mutating one). Pattern from [PR-B.5 / #287](https://github.com/Chaim2045/law-office-system/pull/287).

**Rubric:** `.claude/rubrics/pr-b-6.md`
**Outcomes Grader verdict:** **PASS** — 8/8 MUST + 2/3 SHOULD applicable

## What changed

`addServiceToClient` validates 3 service-type variants (hours / legal_procedure / fixed), builds the new service object with type-specific fields, appends to `services[]`, then previously wrote the manual aggregate block. Now routed through `writeClientWithCanonicalAggregates`.

## 3 construction branches preserved

| Type | Built fields |
|------|--------------|
| `hours` | initial package + totalHours / hoursUsed / hoursRemaining |
| `legal_procedure` (hourly) | 3 stages with packages, totalHours summed across stages |
| `legal_procedure` (fixed) | 3 stages with fixedPrice + paid:false, totalPrice summed |
| `fixed` | fixedPrice + work tracker + completedAt:null |

## Key preservations

- **Append pattern:** `services = [...prior, newService]` (immutable, not push)
- All pre-transaction validations in order
- Per-type validation: `hours > 0`, `stages.length === 3` + valid `pricingType`, `fixedPrice >= 0`
- `serviceId` generated outside transaction (uniqueness)
- Return shape unchanged: `{ success, serviceId, service, message }`

## Updated test

`functions/tests/serviceId-validation.test.js` had a stale assertion checking for direct `transaction.update(clientRef, ...)` (which is gone after migration). Updated to verify the canonical pattern (`writeClientWithCanonicalAggregates`, `caller: 'addServiceToClient'`).

## Per `functions/CLAUDE.md` mental model

- **Writes:** `addServiceToClient` callable surface — unchanged
- **Reads:** Admin UI "add service" flow
- **Recalculates aggregates:** via canonical helper now
- **CREATE/UPDATE/DELETE:** CREATE migrated (first CREATE in PR-B). Helper handles append same as wholesale-replace.
- **Fallback:** helper tolerates malformed services. Pre-helper validation preserved.
- **Drift risk:** closed for this callsite. 7 callsites remain.

## Verification

- ✅ functions/ Jest: **391 pass** (was 373, +18 new in `add-service-to-client.test.js`)
- ✅ Root Vitest: 193 / 2 skipped (no regression)
- ✅ Lint: 0 errors
- ✅ Grader: PASS 8/8 MUST + 2/3 SHOULD applicable

## Test plan

- [ ] CI green
- [ ] After merge → smoke DEV: add hours service → verify initial package + aggregates
- [ ] Smoke: add legal_procedure hourly → verify 3 stages, currentStage = first
- [ ] Smoke: add legal_procedure fixed → verify totalPrice summed, paid:false on all stages
- [ ] Smoke: add fixed service to client with no other services → verify isBlocked=false (I1)

## Rollback

`git revert <merge-commit>` → CI redeploys. Function reverts to prior block. Helper remains. No data corruption possible.