### PR TITLE
refactor(functions): migrate addHoursPackageToStage to canonical helper (PR-B.13)

### DIFF
--- a/.claude/rubrics/pr-b-13.md
+++ b/.claude/rubrics/pr-b-13.md
@@ -1,0 +1,131 @@
+# Rubric — PR-B.13
+
+**Title:** refactor(functions): migrate addHoursPackageToStage to canonical helper
+**Branch:** feat/migrate-add-package-stage-pr-b-13
+**Base:** main
+**File:** `functions/services/index.js`
+**Scope:** Migration 13 of 13 (penultimate; closeCase = B.14, special). Callable for purchasing an additional hours package onto an existing legal_procedure stage. Replace client write at lines 706-717 with `writeClientWithCanonicalAggregates`. Preserve nested stage/service aggregate recomputation (helper only touches client-level), audit log, monitoring on audit-failure.
+
+## Risk profile
+
+**Medium.** Single callable used by Admin Panel (lawyer triggers it from UI). Lower traffic than B.12 trigger. Nested updates to stage.packages → stage aggregates → service aggregates → client aggregates. Existing code does the stage+service rollup manually (not RESTRICTED — nested fields, helper doesn't touch). Helper replaces only the client-level aggregate write.
+
+## Equivalence analysis — verified before migration
+
+Identical to prior PR-B migrations:
+- Source clientTotalHours (line 701-702): `services.reduce((sum, s) => sum + (s.totalHours || 0), 0)` — sums ALL services including FIXED.
+- Helper `recomputeTotalHours`: excludes ST.FIXED + legal_procedure with pricingType=fixed.
+- For drift-free clients (FIXED services with totalHours=0 — the canonical shape) the two yield identical results. Helper corrects drift on touch.
+- `calcClientAggregates(services, totalHours)` identical inputs → identical outputs (aside from totalHours-from-DB vs totalHours-from-services).
+
+## MUST criteria (block on FAIL)
+
+### M1 — Client write replaced by helper
+**Rule:** `transaction.update(clientRef, { services, totalHours, hoursUsed, hoursRemaining, minutesUsed, minutesRemaining, isBlocked, isCritical, lastModifiedAt, lastModifiedBy })` at line 706-717 replaced by:
+```js
+const helperResult = await writeClientWithCanonicalAggregates(
+  transaction, clientRef,
+  { services },
+  { caller: 'addHoursPackageToStage', auditMeta: { uid: user.uid, username: user.username } }
+);
+```
+Manual aggregate fields removed from caller payload. `lastModifiedAt`/`lastModifiedBy` provided via `auditMeta` (helper handles them).
+
+**Evidence required:** Diff.
+
+### M2 — Nested aggregate recomputation preserved
+**Rule:** Stage-level aggregates (lines 673-680) and service-level aggregates (lines 688-695) still recomputed manually before helper call. RESTRICTED_KEYS applies only to top-level client fields — nested `stage.totalHours`, `service.totalHours` pass through inside `services[]`.
+
+**Evidence required:** Reading the code; lines 673-695 unchanged.
+
+### M3 — Helper return used for response payload
+**Rule:** Function still returns `client.totalHours / hoursUsed / hoursRemaining` to the caller for UI display. After migration these values come from `helperResult.aggregates` (canonical) instead of locally-computed `agg`.
+
+**Evidence required:** Reading the return statement; values match helper output.
+
+### M4 — Audit log preserved
+**Rule:** `logAction('ADD_PACKAGE_TO_STAGE', ...)` post-transaction, with `caseId/stageId/stageName/packageId/hours/reason/procedureName/stageStatusWasCompleted` — unchanged.
+
+**Evidence required:** Reading the code.
+
+### M5 — Monitoring on audit failure preserved
+**Rule:** On `auditError`, write to `monitoring/audit_failures` with `count/lastFailure/lastError/lastFunction/lastCaseId` — unchanged.
+
+**Evidence required:** Reading the code.
+
+### M6 — All input validation preserved
+**Rule:**
+- Auth (`checkUserPermissions`)
+- caseId required, string
+- stageId in VALID_STAGE_IDS
+- hours: positive number, ≤ 500
+- reason: trimmed, 3-500 chars, sanitized
+- purchaseDate: parseable, not future, warning if >1y old
+
+**Evidence required:** Reading the code; none touched by migration.
+
+### M7 — IDs generated outside transaction
+**Rule:** `packageId` + `now` + `purchaseDate` (default) computed BEFORE `db.runTransaction` — preserves consistency across transaction retries.
+
+**Evidence required:** Reading the code.
+
+### M8 — Completed-stage warning preserved
+**Rule:** `if (targetStage.status === 'completed') console.warn(...)` plus `stageWasCompleted` flag bubbled to audit log.
+
+**Evidence required:** Reading the code.
+
+### M9 — auditMeta carries `{ uid, username }`
+**Rule:** Helper invocation passes `auditMeta: { uid: user.uid, username: user.username }`. Helper adds `lastModifiedAt: serverTimestamp()` + `lastModifiedBy: user.username` to final payload.
+
+**Evidence required:** Reading the code.
+
+### M10 — Tests cover migrated path
+**Rule:** New test file `functions/tests/add-hours-package-to-stage-canonical-helper.test.js`:
+- Helper invoked once with caller `addHoursPackageToStage` + `auditMeta`
+- Payload contains `services` only (no manual aggregates)
+- Helper called inside transaction (not before/after)
+- Stage-level aggregates recomputed correctly (sum from packages)
+- Service-level aggregates recomputed correctly (sum from stages)
+- Returned client.totalHours/hoursUsed/hoursRemaining from helper result
+- Validation failures (missing caseId, bad stageId, hours <1, hours >500) → helper NOT called
+
+**Evidence required:** New test file + Jest output.
+
+### M11 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.13 + pattern source PR-B.12
+**Evidence required:** Inline comment above helper call.
+
+### S2 — Default mode (no per-call override)
+**Rule:** Unlike PR-B.12 trigger soak, this callable uses helper's default mode (global config — `enforce`). Lower-traffic, user-initiated, idempotent in the failure-then-retry sense.
+**Evidence required:** Helper invocation has no `mode` option.
+
+### S3 — PR description names PR-B.12 predecessor + 13/13 (last regular) + equivalence + note on B.14 closeCase as final special-case PR
+**Evidence required:** PR description.
+
+### S4 — Final-batch reminder in PR body
+**Rule:** PR description states "this is the last 'regular' migration in PR-B; PR-B.14 (closeCase) follows as a special case (different write semantics)".
+**Evidence required:** PR description.
+
+## Out of scope
+
+- B.14 closeCase migration
+- B.12.1 log_only override removal (separate cleanup PR after 24h soak)
+- Nested aggregate recomputation refactor
+- Audit log structure changes
+- Monitoring schema changes
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to manual aggregate writes. Audit, monitoring, validation, IDs all unchanged. No data corruption.
+
+## Notes for grader
+
+- Callable used from Admin Panel "Add hours package to legal procedure stage" flow. Lower traffic than B.12 (UI-triggered, lawyer action).
+- Three levels of aggregate rollup: package → stage → service → client. Helper handles ONLY client level. Stage + service level remain manual (nested fields are not RESTRICTED).
+- `clientTotalHours` (line 701-702) in source code is no longer needed — helper recomputes from services. Local variable can be removed OR kept for the audit return (cleaner: use helper's return).
+- After PR-B.13 merges, only PR-B.14 (closeCase) remains. closeCase is special: it does extra things beyond aggregate writes (status change, locking, archival), and deserves its own rubric.

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -9,7 +9,7 @@ const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
 const { logAction } = require('../shared/audit');
 const { sanitizeString } = require('../shared/validators');
 
-const { calcClientAggregates, round2, isFixedService } = require('../shared/aggregates');
+const { round2, isFixedService } = require('../shared/aggregates');
 const { writeClientWithCanonicalAggregates } = require('../shared/client-writer');
 
 const db = admin.firestore();
@@ -696,25 +696,24 @@ exports.addHoursPackageToStage = functions.https.onCall(async (data, context) =>
 
       services[legalProcedureIndex] = legalProcedure;
 
-      // 🔄 Step 8: עדכון ה-client
-      // ✅ CRITICAL: חישוב aggregates של client מחדש מכל ה-services (Single Source of Truth!)
-      const clientTotalHours = services.reduce((sum, service) =>
-        sum + (service.totalHours || 0), 0);
-      const agg = calcClientAggregates(services, clientTotalHours);
-
-      // 💾 Step 9: שמירה אטומית
-      transaction.update(clientRef, {
-        services: services,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,
-        hoursRemaining: agg.hoursRemaining,
-        minutesUsed: agg.minutesUsed,
-        minutesRemaining: agg.minutesRemaining,
-        isBlocked: agg.isBlocked,
-        isCritical: agg.isCritical,
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // 🔄 Step 8: עדכון ה-client via canonical helper
+      // PR-B.13 (2026-05-18): replaces manual aggregate write. Helper
+      // recomputes totalHours/hoursUsed/hoursRemaining/minutesUsed/
+      // minutesRemaining/isBlocked/isCritical canonically from services
+      // array. Stage- and service-level aggregates above (lines 673-695)
+      // are nested inside services[] — NOT in RESTRICTED_KEYS — and pass
+      // through unchanged. lastModifiedAt + lastModifiedBy added by helper
+      // via auditMeta.
+      // Pattern source: PR-B.12 (no per-call mode — uses global config).
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        { services },
+        {
+          caller: 'addHoursPackageToStage',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
       // ✅ Step 10: החזרת נתונים ל-audit log
       return {
@@ -722,9 +721,9 @@ exports.addHoursPackageToStage = functions.https.onCall(async (data, context) =>
         newPackage,
         targetStage,
         legalProcedure,
-        clientTotalHours,
-        clientHoursUsed: agg.hoursUsed,
-        clientHoursRemaining: agg.hoursRemaining,
+        clientTotalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+        clientHoursUsed: helperResult.aggregates.hoursUsed,
+        clientHoursRemaining: helperResult.aggregates.hoursRemaining,
         stageWasCompleted
       };
     });

--- a/functions/tests/add-hours-package-to-stage-canonical-helper.test.js
+++ b/functions/tests/add-hours-package-to-stage-canonical-helper.test.js
@@ -1,0 +1,367 @@
+/**
+ * Tests for addHoursPackageToStage CF after PR-B.13 migration.
+ *
+ * Coverage:
+ *   A. Helper integration — happy path (package appended to stage)
+ *   B. Stage + service nested aggregates recomputed correctly
+ *   C. Return values sourced from helperResult (canonical)
+ *   D. Validation failures → helper NOT called
+ *   E. Completed-stage warning + stageWasCompleted flag
+ *   F. Audit log called post-transaction
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+  })),
+  runTransaction: mockRunTransaction,
+  batch: jest.fn(() => ({ update: jest.fn(), commit: jest.fn().mockResolvedValue(undefined) }))
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s)
+}));
+
+// Spy on helper — call-through is critical because the function uses
+// helperResult.aggregates in the return value. Wrap real helper.
+const realHelper = jest.requireActual('../shared/client-writer');
+const mockHelper = jest.fn(realHelper.writeClientWithCanonicalAggregates);
+jest.mock('../shared/client-writer', () => ({
+  writeClientWithCanonicalAggregates: (...args) => mockHelper(...args),
+  RESTRICTED_KEYS: jest.requireActual('../shared/client-writer').RESTRICTED_KEYS
+}));
+
+const { addHoursPackageToStage } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeLegalProcedureService(stages) {
+  return {
+    id: 'lp1',
+    type: ST.LEGAL_PROCEDURE,
+    name: 'הליך משפטי',
+    pricingType: 'hourly',
+    stages,
+    totalHours: stages.reduce((s, st) => s + (st.totalHours || 0), 0),
+    hoursUsed: stages.reduce((s, st) => s + (st.hoursUsed || 0), 0),
+    hoursRemaining: stages.reduce((s, st) => s + (st.hoursRemaining || 0), 0),
+    status: 'active'
+  };
+}
+
+function makeStage(id, { totalHours = 10, hoursUsed = 0, status = 'active' } = {}) {
+  return {
+    id,
+    name: `שלב ${id}`,
+    status,
+    pricingType: 'hourly',
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    packages: [
+      {
+        id: `${id}_pkg_1`,
+        type: 'initial',
+        hours: totalHours,
+        hoursUsed,
+        hoursRemaining: totalHours - hoursUsed,
+        status: 'active'
+      }
+    ]
+  };
+}
+
+function makeClientDoc(services, totalHours = null) {
+  return {
+    exists: true,
+    data: () => ({
+      fullName: 'לקוח טסט',
+      services,
+      totalHours: totalHours ?? services.reduce((s, svc) => s + (svc.totalHours || 0), 0)
+    })
+  };
+}
+
+function makeCtx() {
+  return { auth: { uid: 'user1', token: { email: 'user@test' } } };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue({
+    uid: 'user1',
+    email: 'user@test',
+    username: 'user',
+    role: 'admin'
+  });
+  mockLogAction.mockResolvedValue(undefined);
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Helper integration — happy path
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Helper integration — happy path', () => {
+  test('helper called once with services + caller + auditMeta, no manual aggregates', async () => {
+    const stage = makeStage('stage_a', { totalHours: 10, hoursUsed: 3 });
+    const lp = makeLegalProcedureService([stage]);
+    const clientDoc = makeClientDoc([lp]);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)     // CF read
+      .mockResolvedValueOnce(clientDoc);    // helper internal read
+
+    const result = await addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 20, reason: 'דיונים נוספים' },
+      makeCtx()
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockHelper).toHaveBeenCalledTimes(1);
+
+    const [tx, ref, payload, options] = mockHelper.mock.calls[0];
+    expect(tx).toBe(mockTransaction);
+    expect(ref.id).toBe('c1');
+
+    // Payload: services only — NO manual top-level aggregates
+    expect(Array.isArray(payload.services)).toBe(true);
+    expect(payload.totalHours).toBeUndefined();
+    expect(payload.hoursUsed).toBeUndefined();
+    expect(payload.hoursRemaining).toBeUndefined();
+    expect(payload.minutesUsed).toBeUndefined();
+    expect(payload.minutesRemaining).toBeUndefined();
+    expect(payload.isBlocked).toBeUndefined();
+    expect(payload.isCritical).toBeUndefined();
+    expect(payload.lastModifiedAt).toBeUndefined();  // helper adds via auditMeta
+    expect(payload.lastModifiedBy).toBeUndefined();  // helper adds via auditMeta
+
+    // Options
+    expect(options.caller).toBe('addHoursPackageToStage');
+    expect(options.auditMeta).toEqual({ uid: 'user1', username: 'user' });
+    expect(options.mode).toBeUndefined();  // default mode (no soak override)
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Stage + service nested aggregates
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Stage + service nested aggregates', () => {
+  test('stage.totalHours = initial + added; service.totalHours = sum of stages', async () => {
+    const stageA = makeStage('stage_a', { totalHours: 10, hoursUsed: 3 });
+    const stageB = makeStage('stage_b', { totalHours: 5, hoursUsed: 1 });
+    const lp = makeLegalProcedureService([stageA, stageB]);
+    const clientDoc = makeClientDoc([lp]);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    await addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 20, reason: 'דיונים נוספים' },
+      makeCtx()
+    );
+
+    const [, , payload] = mockHelper.mock.calls[0];
+    const updatedLp = payload.services.find(s => s.id === 'lp1');
+    const updatedStageA = updatedLp.stages.find(s => s.id === 'stage_a');
+    const updatedStageB = updatedLp.stages.find(s => s.id === 'stage_b');
+
+    // stage_a: initial 10h + new 20h = 30h
+    expect(updatedStageA.totalHours).toBe(30);
+    expect(updatedStageA.hoursUsed).toBe(3);
+    expect(updatedStageA.hoursRemaining).toBe(27);
+    expect(updatedStageA.packages).toHaveLength(2);
+    expect(updatedStageA.packages[1].hours).toBe(20);
+    expect(updatedStageA.packages[1].type).toBe('additional');
+
+    // stage_b unchanged
+    expect(updatedStageB.totalHours).toBe(5);
+
+    // service: 30 + 5 = 35
+    expect(updatedLp.totalHours).toBe(35);
+    expect(updatedLp.hoursUsed).toBe(4);
+    expect(updatedLp.hoursRemaining).toBe(31);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Return values from helperResult
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Return values sourced from helperResult', () => {
+  test('client.totalHours / hoursUsed / hoursRemaining come from helper canonical aggregates', async () => {
+    const stage = makeStage('stage_a', { totalHours: 10, hoursUsed: 3 });
+    const lp = makeLegalProcedureService([stage]);
+    const clientDoc = makeClientDoc([lp]);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 20, reason: 'דיונים נוספים' },
+      makeCtx()
+    );
+
+    // After adding 20h to stage_a: client totalHours = 30, hoursUsed = 3, hoursRemaining = 27
+    expect(result.client.totalHours).toBe(30);
+    expect(result.client.hoursUsed).toBe(3);
+    expect(result.client.hoursRemaining).toBe(27);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Validation failures → helper NOT called
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Validation failures → helper NOT called', () => {
+  test('missing caseId throws', async () => {
+    await expect(addHoursPackageToStage(
+      { stageId: 'stage_a', hours: 10, reason: 'בדיקה' },
+      makeCtx()
+    )).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+
+  test('invalid stageId throws', async () => {
+    await expect(addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_z', hours: 10, reason: 'בדיקה' },
+      makeCtx()
+    )).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+
+  test('hours < 1 throws', async () => {
+    await expect(addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 0, reason: 'בדיקה' },
+      makeCtx()
+    )).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+
+  test('hours > 500 throws', async () => {
+    await expect(addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 501, reason: 'בדיקה' },
+      makeCtx()
+    )).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+
+  test('reason too short throws', async () => {
+    await expect(addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 10, reason: 'ab' },
+      makeCtx()
+    )).rejects.toMatchObject({ code: 'invalid-argument' });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Completed-stage warning + stageWasCompleted flag
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Completed-stage warning preserved', () => {
+  test('completed stage → still allows package; audit log carries stageWasCompleted: true', async () => {
+    const stage = makeStage('stage_a', { totalHours: 10, hoursUsed: 10, status: 'completed' });
+    const lp = makeLegalProcedureService([stage]);
+    const clientDoc = makeClientDoc([lp]);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 10, reason: 'דיונים נוספים' },
+      makeCtx()
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'ADD_PACKAGE_TO_STAGE',
+      'user1',
+      'user',
+      expect.objectContaining({ stageStatusWasCompleted: true })
+    );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Audit log post-transaction
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Audit log post-transaction', () => {
+  test('logAction called once with ADD_PACKAGE_TO_STAGE + full payload', async () => {
+    const stage = makeStage('stage_a', { totalHours: 10, hoursUsed: 3 });
+    const lp = makeLegalProcedureService([stage]);
+    const clientDoc = makeClientDoc([lp]);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    await addHoursPackageToStage(
+      { caseId: 'c1', stageId: 'stage_a', hours: 20, reason: 'דיונים נוספים' },
+      makeCtx()
+    );
+
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'ADD_PACKAGE_TO_STAGE',
+      'user1',
+      'user',
+      expect.objectContaining({
+        caseId: 'c1',
+        stageId: 'stage_a',
+        hours: 20,
+        reason: 'דיונים נוספים',
+        stageStatusWasCompleted: false
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Migration **13 of 13** in PR-B series (last regular migration). Routes `addHoursPackageToStage` callable through `writeClientWithCanonicalAggregates`. Replaces manual top-level aggregate write with helper-derived canonical aggregates.

Predecessor: #294 (PR-B.12 — onTimesheetEntryChanged trigger).

After this PR merges, only **PR-B.14 (closeCase)** remains. closeCase is a **special case** — it carries additional semantics beyond aggregate writes (status change, locking, archival) and will get its own rubric + PR.

## What changed

- `functions/services/index.js` — Phase 3 client write inside the transaction migrated to helper. Manual top-level aggregate fields removed. Removed unused `calcClientAggregates` import.
- `.claude/rubrics/pr-b-13.md` — new rubric (11 MUST + 4 SHOULD).
- `functions/tests/add-hours-package-to-stage-canonical-helper.test.js` — new test file (10 tests across 6 describe blocks).

## Equivalence analysis

- Source `clientTotalHours`: `services.reduce((s, svc) => s + (svc.totalHours || 0), 0)` — sums all services including FIXED.
- Helper `recomputeTotalHours`: excludes `ST.FIXED` + `legal_procedure` with `pricingType=fixed`.
- For canonical clients (FIXED services with `totalHours=0`) the two yield identical results. Helper corrects drift on touch — same cleanup-on-touch property carried in all prior PR-B migrations.

## Preservation guarantees

- **Stage-level aggregate rollup** (lines 673-680) — preserved (nested fields, not RESTRICTED).
- **Service-level aggregate rollup** (lines 688-695) — preserved (nested fields, not RESTRICTED).
- **All input validation** — caseId, stageId in VALID_STAGE_IDS, hours 1-500, reason 3-500 + sanitize, purchaseDate parse/future/>1y warn — all intact.
- **IDs generated outside transaction** — `packageId`, `now`, default `purchaseDate` computed before `runTransaction` for retry consistency.
- **Completed-stage warning + flag** — `stageWasCompleted` bubbled into audit log payload.
- **Audit log** — `logAction('ADD_PACKAGE_TO_STAGE', ...)` post-transaction.
- **Monitoring on audit failure** — writes to `monitoring/audit_failures` with full diagnostic context.
- **Return shape** — `result.client.totalHours/hoursUsed/hoursRemaining` now sourced from `helperResult.aggregates` (canonical).
- **No per-call mode override** — uses helper default (global config). UI-triggered, lower-traffic than the B.12 trigger.

## Test plan

- [x] functions/ Jest green (453 pass, +10 new)
- [x] Root Vitest green (193 pass / 2 skipped — no regression)
- [x] Lint 0 errors
- [x] Outcomes Grader verdict: PASS (11/11 MUST + 2/2 code-level SHOULD; S3/S4 satisfied by this PR description)

## Rollback

`git revert <merge-commit>` → CI redeploys. Function reverts to prior manual aggregate writes. Audit, monitoring, validation, IDs, nested rollups all unchanged across revert. No data corruption.

## What's next after merge

- **PR-B.14** — closeCase migration (special case).
- **PR-B.12.1** — remove `mode: 'log_only'` override on trigger (after 24h soak with zero `invariant_violation_log_only` events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)