### PR TITLE
refactor(functions): migrate closeCase to canonical helper + fix latent ReferenceError (PR-B.14)

### DIFF
--- a/.claude/rubrics/pr-b-14.md
+++ b/.claude/rubrics/pr-b-14.md
@@ -1,0 +1,162 @@
+# Rubric — PR-B.14
+
+**Title:** refactor(functions): migrate closeCase to canonical helper + fix latent ReferenceError
+**Branch:** feat/migrate-close-case-pr-b-14
+**Base:** main
+**File:** `functions/clients/index.js`
+**Scope:** Migration 14 of 14 (final). closeCase callable — archives client + completes all services. Special-case PR: also fixes a latent ReferenceError bug at lines 857-859 (`clientHoursUsed`/`clientHoursRemaining`/`clientMinutesRemaining` are undefined — function would throw on every call). Migration target lines = bug lines, so fix is co-located with migration.
+
+## Risk profile
+
+**Medium-high.** Two distinct changes in one PR:
+
+1. **Bug fix** — `closeCase` cannot currently complete successfully (transaction commits then function throws ReferenceError; caller sees `HttpsError 'internal'`). No tests existed; bug has been latent. Fix uses helperResult.aggregates.
+2. **Migration** — Phase 3 client write goes through `writeClientWithCanonicalAggregates`.
+
+## Behavioral change (must document)
+
+**Pre-PR-B.14:** archive forced `isBlocked: false` and `isCritical: false` regardless of canonical aggregates.
+**Post-PR-B.14:** helper computes both from `calcClientAggregates(services, totalHours)`. For archived clients with overdraft (`hoursRemaining <= 0` and no active override), `isBlocked` will now be `true` after archive. Most archived clients are not in overdraft and behavior is unchanged for them.
+
+**Impact analysis:**
+- UI: archived-client views filter by `status: 'inactive'` / `isArchived: true`, not `isBlocked`. No UI regression.
+- Invariants (I1): pre-migration forced-false violated I1 for overdraft archives. Migration makes archive consistent with I1.
+- Analytics: `isBlocked` post-archive now reflects historical reality at closure time rather than an artificial zero.
+
+This is a behavioral change per CLAUDE.md and MUST be called out in the PR description.
+
+## Equivalence analysis — verified before migration
+
+- Source `clientTotalHours` (line 826): `updatedServices.reduce((sum, s) => sum + (s.totalHours || 0), 0)` — sums ALL services including FIXED.
+- Helper `recomputeTotalHours`: excludes `ST.FIXED` + `legal_procedure` with `pricingType=fixed`.
+- For canonical clients (FIXED services with `totalHours=0`) identical. Helper corrects drift on touch.
+- `calcClientAggregates(updatedServices, totalHours)` identical input/output (aside from totalHours-from-DB vs totalHours-from-services).
+- The forced-false override is what differs (documented above).
+
+## MUST criteria (block on FAIL)
+
+### M1 — Client write replaced by helper
+**Rule:** `transaction.update(clientRef, {...})` at lines 832-847 replaced by:
+```js
+const helperResult = await writeClientWithCanonicalAggregates(
+  transaction, clientRef,
+  {
+    status: 'inactive',
+    isArchived: true,
+    archivedAt: now,
+    services: updatedServices,
+    totalServices,
+    activeServices
+  },
+  {
+    caller: 'closeCase',
+    auditMeta: { uid: user.uid, username: user.username }
+  }
+);
+```
+Manual aggregate fields removed from caller payload. `lastModifiedAt`/`lastModifiedBy` via auditMeta. Forced `isBlocked: false` and `isCritical: false` REMOVED — helper derives both canonically.
+
+**Evidence required:** Diff.
+
+### M2 — ReferenceError bug fixed
+**Rule:** Lines 857-859 reference `clientHoursUsed`/`clientHoursRemaining`/`clientMinutesRemaining` which are not defined anywhere in the function. After fix, return block sources values from `helperResult.aggregates`:
+```js
+aggregates: {
+  totalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+  hoursUsed: helperResult.aggregates.hoursUsed,
+  hoursRemaining: helperResult.aggregates.hoursRemaining,
+  minutesRemaining: helperResult.aggregates.minutesRemaining,
+  isBlocked: helperResult.aggregates.isBlocked,
+  isCritical: helperResult.aggregates.isCritical,
+  totalServices,
+  activeServices
+}
+```
+**Evidence required:** Diff confirms variables now reference defined values; test exercises full happy path without ReferenceError.
+
+### M3 — All input validation preserved
+**Rule:**
+- Auth (`checkUserPermissions` — admin-only enforced upstream)
+- `clientId` required, string
+- `note` trimmed, max 500 chars (optional)
+
+**Evidence required:** Reading the code.
+
+### M4 — Same-state guard preserved
+**Rule:** Lines 797-802: throw `failed-precondition` when already `status: 'inactive' && isArchived: true`. Unchanged.
+**Evidence required:** Reading the code.
+
+### M5 — Service-completion logic preserved
+**Rule:** Immutable `services.map` setting `status: 'completed'` + `completedAt: now` on non-completed services. Counters `servicesCompleted` / `servicesAlreadyCompleted` accurate.
+**Evidence required:** Reading the code.
+
+### M6 — Active-budget-tasks query preserved (outside transaction)
+**Rule:** Post-transaction count of `budget_tasks` where `clientId === data.clientId && status === 'פעיל'`. Result bubbles into audit log + return payload + message string.
+**Evidence required:** Reading the code.
+
+### M7 — Audit log preserved
+**Rule:** `logAction('CLOSE_CASE', uid, username, { clientId, clientName, previousStatus, servicesCompleted, servicesAlreadyCompleted, activeBudgetTasksRemaining, note })` post-transaction. Unchanged.
+**Evidence required:** Reading the code.
+
+### M8 — auditMeta `{ uid, username }` passed to helper
+**Rule:** Helper invocation includes `auditMeta: { uid: user.uid, username: user.username }`. Helper adds `lastModifiedAt: serverTimestamp()` + `lastModifiedBy`.
+**Evidence required:** Reading the code.
+
+### M9 — Default helper mode (no per-call override)
+**Rule:** Helper invocation has no `mode` option — uses global config (default `enforce`). closeCase is admin-only, low-frequency, and the invariant assertion now passes naturally (no more forced-false violation of I1).
+**Evidence required:** Reading the code.
+
+### M10 — Tests cover migrated path + bug fix
+**Rule:** New test file `functions/tests/close-case-canonical-helper.test.js`:
+- Happy path: helper called once with caller + auditMeta + non-aggregate fields only; return payload contains canonical aggregates (no ReferenceError thrown).
+- Service completion: completed-already vs newly-completed counters correct.
+- Same-state guard: already-archived client throws `failed-precondition`; helper NOT called.
+- Validation: missing clientId → throws `invalid-argument`; helper NOT called.
+- Behavioral change: archived client with overdraft → helper computes `isBlocked: true` (was forced false pre-PR).
+- Audit log: post-transaction `logAction` with full payload.
+
+**Evidence required:** New test file + Jest output.
+
+### M11 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Migration comment tagged PR-B.14 + bug-fix note + behavioral change note
+**Evidence required:** Inline comment above helper call documenting (a) migration, (b) ReferenceError fix, (c) `isBlocked/isCritical` now canonical.
+
+### S2 — PR description names PR-B.13 predecessor + final-batch label
+**Rule:** PR body states "Migration 14 of 14 — final regular migration". Acknowledges PR-B.12.1 (log_only cleanup) still pending separately.
+**Evidence required:** PR description.
+
+### S3 — PR description calls out behavioral change explicitly
+**Rule:** PR body has dedicated "Behavioral change" section explaining the `isBlocked`/`isCritical` semantic shift on archive + impact analysis (UI / invariants / analytics).
+**Evidence required:** PR description.
+
+### S4 — PR description calls out bug fix
+**Rule:** PR body has dedicated "Bug fix" section explaining the ReferenceError, why it was latent (no tests), and that the fix is bundled because the bug lines == migration lines.
+**Evidence required:** PR description.
+
+## Out of scope
+
+- B.12.1 log_only cleanup (separate)
+- Other closeCase semantics (locking flow, archival of budget_tasks, notifications) — not touched
+- Refactoring the active-budget-tasks query
+- Adding `note` field validation (e.g., min length)
+- Renaming `'פעיל'` Hebrew status enum
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Function reverts to:
+- Manual aggregate writes (incl. forced isBlocked/isCritical false)
+- ReferenceError bug returns (latent — only triggered on actual call)
+
+If forced-false-on-archive semantics is critical to a downstream consumer, the migration alone is reversible without re-introducing the bug — but that would require a separate hand-crafted revert.
+
+## Notes for grader
+
+- closeCase has TWO pre-existing characteristics worth treating as separate concerns: (1) latent ReferenceError bug, (2) forced isBlocked/isCritical false on archive. The bug fix is mandatory because the function is unusable otherwise; the behavioral change is the natural consequence of migration.
+- No tests existed for closeCase before this PR — the bug was latent. The new test file is also the FIRST test coverage for closeCase.
+- Admin-only callable. Low-traffic. UI: "Close case" button on client detail page (admin-only visible).
+- After PR-B.14, all 14 client-write callsites are migrated. Only PR-B.12.1 (24h soak cleanup) remains in the PR-B series.

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -9,7 +9,6 @@ const { generateCaseNumberWithTransaction } = require('../case-number-transactio
 const { SYSTEM_CONSTANTS, isValidServiceType, isValidPricingType } = require('../shared/constants');
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
-const { calcClientAggregates } = require('../shared/aggregates');
 const { writeClientWithCanonicalAggregates } = require('../shared/client-writer');
 
 const db = admin.firestore();
@@ -819,32 +818,43 @@ exports.closeCase = functions.https.onCall(async (data, context) => {
         };
       });
 
-      // Recalculate client-level aggregates via canonical calcClientAggregates.
-      // (Previously: manual reduce over ALL services including fixed — fixed
-      // services have hoursUsed > 0 for internal tracking, which leaked into
-      // client.hoursUsed and caused drift. Fixed 2026-05-13.)
-      const clientTotalHours = updatedServices.reduce((sum, s) => sum + (s.totalHours || 0), 0);
-      const agg = calcClientAggregates(updatedServices, clientTotalHours);
       const totalServices = updatedServices.length;
       const activeServices = 0;
 
-      // ── Phase 3: WRITE ──
-      transaction.update(clientRef, {
-        status: 'inactive',
-        isArchived: true,
-        isBlocked: false,         // forced false on archive (always)
-        isCritical: false,        // forced false on archive (always)
-        archivedAt: now,
-        services: updatedServices,
-        totalServices: totalServices,
-        activeServices: activeServices,
-        totalHours: clientTotalHours,
-        hoursUsed: agg.hoursUsed,                 // canonical: excludes fixed
-        hoursRemaining: agg.hoursRemaining,       // canonical
-        minutesRemaining: agg.minutesRemaining,   // canonical
-        lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
-        lastModifiedBy: user.username
-      });
+      // ── Phase 3: WRITE via canonical helper ──
+      // PR-B.14 (2026-05-18): final migration in PR-B series.
+      // Two changes bundled because they touch the same lines:
+      //   (1) Migration — helper recomputes totalHours/hoursUsed/
+      //       hoursRemaining/minutesUsed/minutesRemaining/isBlocked/
+      //       isCritical canonically from services. lastModifiedAt/By
+      //       added via auditMeta.
+      //   (2) ReferenceError fix — the prior return block referenced
+      //       `clientHoursUsed`/`clientHoursRemaining`/`clientMinutes­min­ing`
+      //       which were never defined; closeCase would throw on every
+      //       call after the transaction committed. Now sourced from
+      //       helperResult.aggregates.
+      //
+      // Behavioral change: pre-migration forced isBlocked: false and
+      // isCritical: false on archive. Helper derives both canonically.
+      // For archived clients in overdraft, isBlocked may now be true.
+      // No UI impact (archived views filter by status/isArchived, not
+      // isBlocked). Brings archive in line with invariant I1.
+      const helperResult = await writeClientWithCanonicalAggregates(
+        transaction,
+        clientRef,
+        {
+          status: 'inactive',
+          isArchived: true,
+          archivedAt: now,
+          services: updatedServices,
+          totalServices,
+          activeServices
+        },
+        {
+          caller: 'closeCase',
+          auditMeta: { uid: user.uid, username: user.username }
+        }
+      );
 
       return {
         clientName: clientData.fullName || clientData.clientName,
@@ -853,14 +863,14 @@ exports.closeCase = functions.https.onCall(async (data, context) => {
         servicesAlreadyCompleted,
         closedAt: now,
         aggregates: {
-          totalHours: clientTotalHours,
-          hoursUsed: clientHoursUsed,
-          hoursRemaining: clientHoursRemaining,
-          minutesRemaining: clientMinutesRemaining,
-          isBlocked: false,
-          isCritical: false,
-          totalServices: totalServices,
-          activeServices: activeServices
+          totalHours: helperResult.aggregates.totalHours ?? helperResult.written.totalHours,
+          hoursUsed: helperResult.aggregates.hoursUsed,
+          hoursRemaining: helperResult.aggregates.hoursRemaining,
+          minutesRemaining: helperResult.aggregates.minutesRemaining,
+          isBlocked: helperResult.aggregates.isBlocked,
+          isCritical: helperResult.aggregates.isCritical,
+          totalServices,
+          activeServices
         }
       };
     });

--- a/functions/tests/close-case-canonical-helper.test.js
+++ b/functions/tests/close-case-canonical-helper.test.js
@@ -1,0 +1,335 @@
+/**
+ * Tests for closeCase CF after PR-B.14 migration.
+ *
+ * Coverage:
+ *   A. Helper integration — happy path (no ReferenceError; canonical aggregates returned)
+ *   B. Service completion (counters, immutability)
+ *   C. Same-state guard (already archived → throws; helper NOT called)
+ *   D. Validation (missing clientId → throws; helper NOT called)
+ *   E. Behavioral change — overdraft archive: isBlocked computed canonically (true), not forced false
+ *   F. Audit log post-transaction
+ *
+ * This file is also the FIRST test coverage for closeCase — the prior
+ * implementation had a latent ReferenceError (clientHoursUsed et al.
+ * undefined) that prevented any successful call. PR-B.14 fixes the bug
+ * inline with the migration since both touch the same return block.
+ */
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+// Active-budget-tasks query chain: db.collection('budget_tasks').where().where().get()
+const mockBudgetTasksGet = jest.fn().mockResolvedValue({ size: 0 });
+const mockBudgetTasksQuery = {
+  where: jest.fn().mockReturnThis(),
+  get: mockBudgetTasksGet
+};
+
+const mockDb = {
+  collection: jest.fn((name) => {
+    if (name === 'budget_tasks') {
+      return mockBudgetTasksQuery;
+    }
+    return {
+      doc: jest.fn((id) => ({ id: id || 'auto_id' }))
+    };
+  }),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({
+  logAction: mockLogAction
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true)
+}));
+
+// Spy on helper — call-through is critical since closeCase reads helperResult.aggregates
+const mockHelper = jest.fn((...args) =>
+  jest.requireActual('../shared/client-writer').writeClientWithCanonicalAggregates(...args)
+);
+jest.mock('../shared/client-writer', () => ({
+  writeClientWithCanonicalAggregates: (...args) => mockHelper(...args),
+  RESTRICTED_KEYS: jest.requireActual('../shared/client-writer').RESTRICTED_KEYS
+}));
+
+const { closeCase } = require('../clients/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeHoursService(id, { totalHours = 10, hoursUsed = 3, status = 'active' } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    packages: [],
+    status
+  };
+}
+
+function makeClientDoc(services, overrides = {}) {
+  const data = {
+    fullName: 'לקוח טסט',
+    clientName: 'לקוח טסט',
+    status: 'active',
+    isArchived: false,
+    services,
+    totalHours: services.reduce((s, svc) => s + (svc.totalHours || 0), 0),
+    ...overrides
+  };
+  return { exists: true, data: () => data };
+}
+
+function makeCtx() {
+  return { auth: { uid: 'admin1', token: { email: 'admin@test' } } };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue({
+    uid: 'admin1',
+    email: 'admin@test',
+    username: 'admin',
+    role: 'admin'
+  });
+  mockLogAction.mockResolvedValue(undefined);
+  mockBudgetTasksGet.mockResolvedValue({ size: 0 });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. Helper integration — happy path
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. Helper integration — happy path', () => {
+  test('helper called once with non-aggregate payload + caller + auditMeta; canonical aggregates returned', async () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const clientDoc = makeClientDoc(services);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)   // CF read
+      .mockResolvedValueOnce(clientDoc);  // helper internal read
+
+    const result = await closeCase({ clientId: 'c1', note: 'תיק הסתיים' }, makeCtx());
+
+    expect(result.success).toBe(true);
+    expect(mockHelper).toHaveBeenCalledTimes(1);
+
+    const [tx, ref, payload, options] = mockHelper.mock.calls[0];
+    expect(tx).toBe(mockTransaction);
+    expect(ref.id).toBe('c1');
+
+    // Payload: status/isArchived/archivedAt/services + counts — NO aggregates
+    expect(payload.status).toBe('inactive');
+    expect(payload.isArchived).toBe(true);
+    expect(payload.archivedAt).toBeDefined();
+    expect(Array.isArray(payload.services)).toBe(true);
+    expect(payload.totalServices).toBe(1);
+    expect(payload.activeServices).toBe(0);
+    expect(payload.totalHours).toBeUndefined();
+    expect(payload.hoursUsed).toBeUndefined();
+    expect(payload.hoursRemaining).toBeUndefined();
+    expect(payload.minutesRemaining).toBeUndefined();
+    expect(payload.isBlocked).toBeUndefined();
+    expect(payload.isCritical).toBeUndefined();
+    expect(payload.lastModifiedAt).toBeUndefined();  // helper adds via auditMeta
+    expect(payload.lastModifiedBy).toBeUndefined();  // helper adds via auditMeta
+
+    expect(options.caller).toBe('closeCase');
+    expect(options.auditMeta).toEqual({ uid: 'admin1', username: 'admin' });
+    expect(options.mode).toBeUndefined();
+
+    // No ReferenceError — return aggregates block accessible
+    expect(result.clientAggregates.totalHours).toBe(10);
+    expect(result.clientAggregates.hoursUsed).toBe(3);
+    expect(result.clientAggregates.hoursRemaining).toBe(7);
+    expect(result.clientAggregates.isBlocked).toBe(false);
+    expect(result.clientAggregates.isCritical).toBe(false);
+    expect(result.clientAggregates.totalServices).toBe(1);
+    expect(result.clientAggregates.activeServices).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. Service completion
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. Service completion logic', () => {
+  test('mixed active + completed services → counters accurate; non-completed set to completed', async () => {
+    const services = [
+      makeHoursService('svc1', { totalHours: 10, hoursUsed: 3, status: 'active' }),
+      makeHoursService('svc2', { totalHours: 5, hoursUsed: 5, status: 'completed' }),
+      makeHoursService('svc3', { totalHours: 8, hoursUsed: 2, status: 'active' })
+    ];
+    const clientDoc = makeClientDoc(services);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await closeCase({ clientId: 'c1' }, makeCtx());
+
+    expect(result.servicesCompleted).toBe(2);
+    expect(result.servicesAlreadyCompleted).toBe(1);
+
+    const [, , payload] = mockHelper.mock.calls[0];
+    expect(payload.services.every(s => s.status === 'completed')).toBe(true);
+    expect(payload.services.filter(s => s.completedAt).length).toBe(2);  // newly completed
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Same-state guard
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Same-state guard', () => {
+  test('already inactive + isArchived → throws failed-precondition; helper NOT called', async () => {
+    const services = [makeHoursService('svc1')];
+    const clientDoc = makeClientDoc(services, { status: 'inactive', isArchived: true });
+    mockTransaction.get.mockReset();
+    mockTransaction.get.mockResolvedValueOnce(clientDoc);
+
+    await expect(closeCase({ clientId: 'c1' }, makeCtx())).rejects.toMatchObject({
+      code: 'failed-precondition'
+    });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Validation
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Validation', () => {
+  test('missing clientId → throws invalid-argument; helper NOT called', async () => {
+    await expect(closeCase({}, makeCtx())).rejects.toMatchObject({
+      code: 'invalid-argument'
+    });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+
+  test('non-string clientId → throws invalid-argument; helper NOT called', async () => {
+    await expect(closeCase({ clientId: 123 }, makeCtx())).rejects.toMatchObject({
+      code: 'invalid-argument'
+    });
+    expect(mockHelper).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Behavioral change — overdraft archive
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Behavioral change — overdraft archive', () => {
+  test('client in overdraft on archive → isBlocked: true (was forced false pre-PR-B.14)', async () => {
+    // Service with hoursUsed > totalHours → overdraft
+    const overdraftSvc = makeHoursService('svc1', { totalHours: 10, hoursUsed: 15 });
+    const services = [overdraftSvc];
+    const clientDoc = makeClientDoc(services);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await closeCase({ clientId: 'c1' }, makeCtx());
+
+    // Canonical: hoursRemaining = -5, no override → isBlocked: true
+    expect(result.clientAggregates.hoursRemaining).toBe(-5);
+    expect(result.clientAggregates.isBlocked).toBe(true);
+    // isCritical only when hoursRemaining > 0 — depleted = not critical
+    expect(result.clientAggregates.isCritical).toBe(false);
+  });
+
+  test('client with hours remaining on archive → isBlocked: false, isCritical reflects threshold', async () => {
+    // 3h remaining → critical threshold (hours > 0 && <= 5)
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 7 })];
+    const clientDoc = makeClientDoc(services);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+
+    const result = await closeCase({ clientId: 'c1' }, makeCtx());
+
+    expect(result.clientAggregates.hoursRemaining).toBe(3);
+    expect(result.clientAggregates.isBlocked).toBe(false);
+    expect(result.clientAggregates.isCritical).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Audit log post-transaction
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Audit log post-transaction', () => {
+  test('logAction called once with CLOSE_CASE + full payload', async () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const clientDoc = makeClientDoc(services);
+    mockTransaction.get.mockReset();
+    mockTransaction.get
+      .mockResolvedValueOnce(clientDoc)
+      .mockResolvedValueOnce(clientDoc);
+    mockBudgetTasksGet.mockResolvedValueOnce({ size: 2 });
+
+    await closeCase({ clientId: 'c1', note: 'הערה' }, makeCtx());
+
+    expect(mockLogAction).toHaveBeenCalledWith(
+      'CLOSE_CASE',
+      'admin1',
+      'admin',
+      expect.objectContaining({
+        clientId: 'c1',
+        clientName: 'לקוח טסט',
+        previousStatus: 'active',
+        servicesCompleted: 1,
+        servicesAlreadyCompleted: 0,
+        activeBudgetTasksRemaining: 2,
+        note: 'הערה'
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**Migration 14 of 14 — final regular migration in PR-B series.** Routes `closeCase` callable through `writeClientWithCanonicalAggregates`. Also fixes a latent `ReferenceError` bug whose lines coincide with the migration target.

Predecessor: #295 (PR-B.13 — addHoursPackageToStage).

After this PR merges, all 14 client-write callsites are migrated. Only **PR-B.12.1** (remove `log_only` trigger override after 24h soak) remains in PR-B.

## Bug fix (bundled — same lines as migration)

Pre-fix lines 857-859 referenced **undefined** variables:

```js
aggregates: {
  hoursUsed: clientHoursUsed,          // ← undefined
  hoursRemaining: clientHoursRemaining,    // ← undefined
  minutesRemaining: clientMinutesRemaining,  // ← undefined
  ...
}
```

Verified with Node: `({ x: undefVar })` throws `ReferenceError`. Every call to `closeCase` would commit the archive transaction, then throw on the return statement — caller saw `HttpsError 'internal'` while the client doc was already archived. Bug was latent because **no tests existed** for `closeCase`.

This PR fixes the bug **inline** with the migration because the bug lines are the same lines being modified for the migration. The new test file is also the first test coverage for `closeCase`.

## Behavioral change

| Field | Pre-PR-B.14 | Post-PR-B.14 |
|---|---|---|
| `isBlocked` on archive | Forced `false` | Canonical (helper-computed) |
| `isCritical` on archive | Forced `false` | Canonical (helper-computed) |

Most archived clients are NOT in overdraft — behavior unchanged for them. For archived clients with `hoursRemaining <= 0` and no active override, `isBlocked` is now `true` post-archive.

**Impact analysis:**
- **UI:** archived-client views filter by `status: 'inactive'` / `isArchived: true`, not by `isBlocked`. No regression.
- **Invariants:** the previous forced-false violated I1 for overdraft archives. Migration makes archive consistent with I1.
- **Analytics:** `isBlocked` post-archive now reflects historical reality at closure rather than an artificial zero.

## What changed

- `functions/clients/index.js` — Phase 3 client write migrated to helper. Manual aggregate fields removed. Forced `isBlocked: false` / `isCritical: false` removed (canonical now). Return aggregates block sourced from `helperResult.aggregates` (fixes ReferenceError). Removed unused `calcClientAggregates` import.
- `.claude/rubrics/pr-b-14.md` — new rubric (11 MUST + 4 SHOULD).
- `functions/tests/close-case-canonical-helper.test.js` — new test file, 8 tests across 6 describe blocks. First coverage for `closeCase`.

## Preservation guarantees

- **Auth + validation** — `checkUserPermissions`, `clientId` required+string, `note` trimmed+max-500 — all intact.
- **Same-state guard** — already-archived clients still throw `failed-precondition`.
- **Service completion** — immutable `services.map` setting `status: 'completed'` + `completedAt`; counters accurate.
- **Active-budget-tasks query** — post-transaction count; bubbles into audit + return + message.
- **Audit log** — `logAction('CLOSE_CASE', ...)` with full payload.
- **No per-call mode override** — uses helper default (`enforce`). closeCase is admin-only, low-frequency, and invariant assertion passes naturally now.

## Test plan

- [x] functions/ Jest green (461 pass, +8 new — first-ever coverage for `closeCase`)
- [x] Root Vitest green (193 pass / 2 skipped — no regression)
- [x] Lint 0 errors
- [x] Outcomes Grader verdict: PASS (11/11 MUST + 1/1 verifiable SHOULD; S2-S4 covered by this PR description)

## Rollback

`git revert <merge-commit>` → CI redeploys. Reverts both the migration AND the bug fix. ReferenceError returns latent. If the forced-false-on-archive semantics turns out to be critical to a downstream consumer, the migration alone is reversible without re-introducing the bug — would require a separate hand-crafted revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)