### PR TITLE
feat(functions): add I1-I4 aggregate drift check to dailyInvariantCheck (PR-C.1)

### DIFF
--- a/.claude/rubrics/pr-c-1.md
+++ b/.claude/rubrics/pr-c-1.md
@@ -1,0 +1,100 @@
+# Rubric — PR-C.1
+
+**Title:** feat(functions): add I1-I4 aggregate drift check to dailyInvariantCheck (PR-C.1)
+**Branch:** feat/add-i1-i4-to-daily-invariant-check-pr-c-1
+**Base:** main
+**File:** `functions/scheduled/index.js`
+**Scope:** Extend the existing `dailyInvariantCheck` (cron at 06:00 Asia/Jerusalem) to include a sixth check: per-client comparison of stored client-aggregate fields vs canonical (`recomputeTotalHours` + `calcClientAggregates`). Drift entries written to `system_health_checks` alongside the existing 5 checks. **Automation companion** to PR-D's on-demand audit — same comparison logic, same tolerance, but runs nightly without manual trigger.
+
+## Why this is small
+
+- `dailyInvariantCheck` already iterates `clientsSnapshot.docs`. Sixth check piggybacks on the existing loop (or runs as its own loop — minor stylistic choice).
+- Same `clients` collection read used by checks 1, 2, 5. No new query.
+- Discrepancy format mirrors the existing 5 — `discrepancies.push({ type: 'aggregate_drift', clientId, clientName, driftFields })`.
+- No new dependencies, no new modules, no new scheduled jobs.
+
+## Risk profile
+
+**Low.** Read-only addition to an existing read-only cron. New `type: 'aggregate_drift'` entries appear in `system_health_checks`. Failure mode: false positives if `calcClientAggregates` ever diverges from the helper's internal use — same risk PR-D already carries.
+
+## MUST criteria (block on FAIL)
+
+### M1 — New imports
+**Rule:** `functions/scheduled/index.js` imports `calcClientAggregates` from `../shared/aggregates` and `_recomputeTotalHours` from `../shared/client-writer`. Same pattern PR-D uses.
+**Evidence required:** Diff.
+
+### M2 — Check 6 added to `dailyInvariantCheck`
+**Rule:** New block inside `dailyInvariantCheck` that, for each client doc not in `SKIP_CLIENTS`, computes canonical aggregates (recomputeTotalHours + calcClientAggregates) and compares against stored fields. Drift entries pushed to `discrepancies` with `type: 'aggregate_drift'`.
+**Evidence required:** Code block.
+
+### M3 — Tolerance + fields covered
+**Rule:** Numeric fields (`totalHours`, `hoursUsed`, `hoursRemaining`, `minutesUsed`, `minutesRemaining`) compared with tolerance 0.02 (matches PR-D + the existing `TOLERANCE` constant in the cron). Boolean fields (`isBlocked`, `isCritical`) strict equality.
+**Evidence required:** Reading the code; same constant reused (`TOLERANCE`).
+
+### M4 — SKIP_CLIENTS respected
+**Rule:** Sixth check skips the same clients as the rest of the cron (`SKIP_CLIENTS` defined locally — currently `['2025003']`). No new exemption list.
+**Evidence required:** Reading the code.
+
+### M5 — Discrepancy shape compatible with existing 5
+**Rule:** Each drift entry has `type: 'aggregate_drift'` plus `clientId`, `clientName`, `driftFields: [{ field, current, canonical, diff? }]`. Pattern mirrors `package_drift` and `task_actualHours_actualMinutes_drift`.
+**Evidence required:** Reading the code; test asserts shape.
+
+### M6 — Empty-services clients skipped
+**Rule:** Clients with `services.length === 0` should NOT be flagged (canonical aggregates for empty services = all zeros / isBlocked=false; if the doc happens to have stale non-zero values for some legacy reason, that's a different bug class). Match the existing cron pattern (Check 1 skips clients with zero services).
+**Evidence required:** Reading the code.
+
+### M7 — Tests cover Check 6
+**Rule:** New test file `functions/tests/daily-invariant-check-i1-i4.test.js`:
+- Drifted client → drift entry pushed with correct fields
+- Clean client → no drift entry
+- Multiple drift fields → all reported in `driftFields` array
+- Empty-services client → no drift entry
+- SKIP_CLIENTS exempted
+
+Note: existing dailyInvariantCheck has no dedicated test file — the structure makes it hard to unit-test the whole cron in isolation. To keep the test surface narrow, expose the new Check 6 logic as a pure function (`detectAggregateDrift(clientData)`) exported via `module.exports._test` (mirror the pattern used in `timesheet-trigger.js`). Tests target the pure function.
+
+**Evidence required:** Test file + Jest output.
+
+### M8 — Cron still runs end-to-end
+**Rule:** Adding Check 6 must not break existing cron flow. Existing 5 checks unchanged. `system_health_checks` write at the end aggregates all discrepancies (existing + new).
+**Evidence required:** Code diff is purely additive to the discrepancies array; status/save logic untouched.
+
+### M9 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Inline comment tagged PR-C.1
+**Evidence required:** Comment block above the new check.
+
+### S2 — Comment explains relationship to PR-D
+**Rule:** Inline comment notes: "Companion to PR-D's on-demand audit. Same logic, nightly automation. Drift entries surface in `system_health_checks` for review."
+**Evidence required:** Comment.
+
+### S3 — PR description names PR-D predecessor + monitoring narrative
+**Evidence required:** PR body.
+
+### S4 — Output sample shown in PR description
+**Rule:** PR body shows what a drifted-client entry looks like inside the resulting `system_health_checks` document.
+**Evidence required:** PR body.
+
+## Out of scope
+
+- WhatsApp alert on drift (PR-C.2)
+- Admin dashboard for `system_health_checks` (PR-C.3)
+- Promoting `_recomputeTotalHours` to a public name (separate cleanup PR)
+- New cron job dedicated to I1-I4 (this PR piggybacks on the existing 06:00 cron)
+- Auto-repair on detection (out of scope; admin runs `repairClientAggregates` from PR-D on review)
+- Twilio SMS on drift (TODO in existing cron, separate concern)
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Sixth check disappears. The other 5 checks unchanged. No data corruption.
+
+## Notes for grader
+
+- This PR is intentionally tiny. The cron infrastructure was already built (5 checks running daily). PR-C.1 only adds a sixth check using the same patterns.
+- After this merges + 24h elapses, the next 06:00 cron run will produce the first nightly drift report. Haim sees it under `system_health_checks` (most recent doc).
+- PR-C.2 (WhatsApp alert) is the next natural step — but only valuable once C.1 has produced a few clean reports and Haim understands the baseline.
+- After PR-D + PR-C.1, the original 23-victim incident is fully addressed: detection (nightly + on-demand), repair (on-demand), and prevention (PR-A + PR-B closed the architectural gap).

--- a/functions/scheduled/index.js
+++ b/functions/scheduled/index.js
@@ -7,7 +7,78 @@ const { SYSTEM_CONSTANTS } = require('../shared/constants');
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
 const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
 
+// PR-C.1 (2026-05-18): nightly companion to PR-D's on-demand audit.
+const { calcClientAggregates } = require('../shared/aggregates');
+const { _recomputeTotalHours } = require('../shared/client-writer');
+
 const db = admin.firestore();
+
+// PR-C.1: aggregate-drift tolerance for client-level invariants.
+// Matches `dailyInvariantCheck`'s internal TOLERANCE and PR-D's audit.
+const AGG_DRIFT_TOLERANCE = 0.02;
+
+/**
+ * Pure helper — detect drift between stored client aggregates and the
+ * canonical computation. Used by `dailyInvariantCheck` (Check 6) and
+ * exposed via `_test` for unit testing.
+ *
+ * Returns an array of { field, current, canonical, diff? } entries.
+ * Empty array means the client is canonical (no drift).
+ *
+ * Empty-services clients return [] regardless of stored values — those
+ * are flagged by other checks (or by Haim manually) since they may
+ * represent a different bug class (e.g. data loss).
+ */
+function detectAggregateDrift(clientData) {
+  const services = Array.isArray(clientData && clientData.services)
+    ? clientData.services.filter(Boolean)
+    : [];
+  if (services.length === 0) {
+    return [];
+  }
+
+  const canonicalTotalHours = _recomputeTotalHours(services);
+  const canonical = calcClientAggregates(services, canonicalTotalHours);
+
+  const drifts = [];
+  const numericFields = [
+    { key: 'totalHours', expected: canonicalTotalHours },
+    { key: 'hoursUsed', expected: canonical.hoursUsed },
+    { key: 'hoursRemaining', expected: canonical.hoursRemaining },
+    { key: 'minutesUsed', expected: canonical.minutesUsed },
+    { key: 'minutesRemaining', expected: canonical.minutesRemaining }
+  ];
+
+  for (const { key, expected } of numericFields) {
+    const stored = typeof clientData[key] === 'number' ? clientData[key] : 0;
+    const diff = Math.abs(stored - expected);
+    if (diff > AGG_DRIFT_TOLERANCE) {
+      drifts.push({
+        field: key,
+        current: parseFloat(stored.toFixed(2)),
+        canonical: parseFloat(expected.toFixed(2)),
+        diff: parseFloat(diff.toFixed(2))
+      });
+    }
+  }
+
+  const booleanFields = [
+    { key: 'isBlocked', expected: canonical.isBlocked },
+    { key: 'isCritical', expected: canonical.isCritical }
+  ];
+  for (const { key, expected } of booleanFields) {
+    const stored = clientData[key] === true;
+    if (stored !== (expected === true)) {
+      drifts.push({
+        field: key,
+        current: stored,
+        canonical: expected === true
+      });
+    }
+  }
+
+  return drifts;
+}
 
 /**
  * formatDate - פורמט תאריך לתצוגה בעברית
@@ -416,6 +487,27 @@ const dailyInvariantCheck = onSchedule({
       });
     });
 
+    // Check 6: client-aggregate drift (PR-C.1 — I1-I4 invariants).
+    // Companion to PR-D's on-demand audit (admin/repair-aggregates.js).
+    // Same comparison logic, same tolerance — nightly automation so any
+    // drift introduced before the PR-B migrations (or by a future
+    // architectural regression) surfaces in `system_health_checks`
+    // without requiring Haim to trigger an audit manually.
+    clientsSnapshot.docs.forEach(clientDoc => {
+      const clientId = clientDoc.id;
+      if (SKIP_CLIENTS.includes(clientId)) return;
+      const data = clientDoc.data();
+      const driftFields = detectAggregateDrift(data);
+      if (driftFields.length > 0) {
+        discrepancies.push({
+          type: 'aggregate_drift',
+          clientId,
+          clientName: data.fullName || data.clientName || data.name || clientId,
+          driftFields
+        });
+      }
+    });
+
     // Save result to system_health_checks
     if (discrepancies.length > 0) {
       await db.collection('system_health_checks').add({
@@ -456,4 +548,13 @@ const dailyInvariantCheck = onSchedule({
   }
 });
 
-module.exports = { dailyTaskReminders, dailyBudgetWarnings, dailyInvariantCheck };
+module.exports = {
+  dailyTaskReminders,
+  dailyBudgetWarnings,
+  dailyInvariantCheck,
+  // Exported for unit testing only (PR-C.1).
+  _test: {
+    detectAggregateDrift,
+    AGG_DRIFT_TOLERANCE
+  }
+};

--- a/functions/tests/daily-invariant-check-i1-i4.test.js
+++ b/functions/tests/daily-invariant-check-i1-i4.test.js
@@ -1,0 +1,174 @@
+/**
+ * Tests for the I1-I4 aggregate-drift detector added to dailyInvariantCheck
+ * in PR-C.1.
+ *
+ * The cron itself is integration-heavy (Firestore queries, time scheduler).
+ * To keep the unit-test surface small we test the pure detector exported via
+ * `_test.detectAggregateDrift`. The cron loop is a thin wrapper that pushes
+ * the detector's output into `discrepancies` — verified by reading the code.
+ */
+
+jest.mock('firebase-admin', () => ({
+  initializeApp: jest.fn(),
+  firestore: Object.assign(() => ({ collection: jest.fn() }), {
+    FieldValue: { serverTimestamp: jest.fn(), increment: jest.fn() },
+    Timestamp: { now: jest.fn() }
+  })
+}));
+
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((config, fn) => fn)
+}));
+
+const { _test } = require('../scheduled');
+const { detectAggregateDrift, AGG_DRIFT_TOLERANCE } = _test;
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// ─── helpers ────────────────────────────────────────────────────
+
+function makeHoursService(id, { totalHours = 10, hoursUsed = 0 } = {}) {
+  return {
+    id,
+    type: ST.HOURS,
+    name: `שירות ${id}`,
+    totalHours,
+    hoursUsed,
+    hoursRemaining: totalHours - hoursUsed,
+    packages: [],
+    status: 'active'
+  };
+}
+
+function makeClientData(services, overrides = {}) {
+  const totalHours = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.totalHours || 0), 0);
+  const hoursUsed = services
+    .filter(s => s.type === ST.HOURS)
+    .reduce((sum, s) => sum + (s.hoursUsed || 0), 0);
+  const hoursRemaining = totalHours - hoursUsed;
+  return {
+    fullName: 'לקוח טסט',
+    services,
+    totalHours,
+    hoursUsed,
+    hoursRemaining,
+    minutesUsed: hoursUsed * 60,
+    minutesRemaining: hoursRemaining * 60,
+    isBlocked: hoursRemaining <= 0,
+    isCritical: hoursRemaining > 0 && hoursRemaining <= 5,
+    ...overrides
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════
+// detectAggregateDrift
+// ═══════════════════════════════════════════════════════════════
+
+describe('detectAggregateDrift (PR-C.1)', () => {
+  test('AGG_DRIFT_TOLERANCE matches PR-D + cron baseline (0.02)', () => {
+    expect(AGG_DRIFT_TOLERANCE).toBe(0.02);
+  });
+
+  test('clean client → empty drift array', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services);
+    expect(detectAggregateDrift(data)).toEqual([]);
+  });
+
+  test('client with isBlocked drift → reported', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services, { isBlocked: true });  // canonical: false
+    const drifts = detectAggregateDrift(data);
+    expect(drifts).toHaveLength(1);
+    expect(drifts[0]).toEqual({ field: 'isBlocked', current: true, canonical: false });
+  });
+
+  test('client with numeric drift → reported with diff', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services, { hoursUsed: 5 });  // canonical: 3
+    const drifts = detectAggregateDrift(data);
+    const hoursUsedDrift = drifts.find(d => d.field === 'hoursUsed');
+    expect(hoursUsedDrift).toEqual({
+      field: 'hoursUsed',
+      current: 5,
+      canonical: 3,
+      diff: 2
+    });
+  });
+
+  test('multiple drift fields → all reported', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services, {
+      isBlocked: true,
+      isCritical: true,
+      hoursUsed: 8
+    });
+    const drifts = detectAggregateDrift(data);
+    const fields = drifts.map(d => d.field);
+    expect(fields).toContain('isBlocked');
+    expect(fields).toContain('isCritical');
+    expect(fields).toContain('hoursUsed');
+  });
+
+  test('empty-services client → no drift (different bug class)', () => {
+    const data = makeClientData([], {
+      // Stale stored values shouldn't be flagged for empty-services
+      totalHours: 50,
+      hoursUsed: 30,
+      isBlocked: true
+    });
+    expect(detectAggregateDrift(data)).toEqual([]);
+  });
+
+  test('missing services array → treated as empty → no drift', () => {
+    const data = { fullName: 'x', totalHours: 5 };  // services field absent
+    expect(detectAggregateDrift(data)).toEqual([]);
+  });
+
+  test('drift below tolerance (0.01) → not flagged', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services, { hoursUsed: 3.01 });  // diff = 0.01 ≤ 0.02
+    expect(detectAggregateDrift(data)).toEqual([]);
+  });
+
+  test('drift just above tolerance (0.03) → flagged', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 })];
+    const data = makeClientData(services, { hoursUsed: 3.03 });  // diff = 0.03 > 0.02
+    const drifts = detectAggregateDrift(data);
+    expect(drifts.find(d => d.field === 'hoursUsed')).toBeDefined();
+  });
+
+  test('fixed service: hoursUsed nonzero stored but canonical excludes fixed → drift flagged', () => {
+    const fixedSvc = {
+      id: 'fxd1',
+      type: ST.FIXED,
+      totalHours: 0,
+      hoursUsed: 5,
+      hoursRemaining: 0,
+      work: { totalMinutesWorked: 300, entriesCount: 3 }
+    };
+    const hoursSvc = makeHoursService('svc1', { totalHours: 10, hoursUsed: 3 });
+    // Stored hoursUsed sums both (8); canonical excludes fixed → 3
+    const data = makeClientData([hoursSvc, fixedSvc], { hoursUsed: 8 });
+    const drifts = detectAggregateDrift(data);
+    const hoursUsedDrift = drifts.find(d => d.field === 'hoursUsed');
+    expect(hoursUsedDrift).toEqual({
+      field: 'hoursUsed',
+      current: 8,
+      canonical: 3,
+      diff: 5
+    });
+  });
+
+  test('returns numeric drift values rounded to 2 decimals', () => {
+    const services = [makeHoursService('svc1', { totalHours: 10, hoursUsed: 3.123 })];
+    const data = makeClientData(services, { hoursUsed: 5.789 });
+    const drifts = detectAggregateDrift(data);
+    const d = drifts.find(x => x.field === 'hoursUsed');
+    expect(d.current).toBe(5.79);
+    expect(d.canonical).toBe(3.12);
+    expect(typeof d.diff).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

Nightly automation companion to PR-D's on-demand audit. Extends the existing `dailyInvariantCheck` cron (06:00 Asia/Jerusalem) with a **sixth check**: per-client comparison of stored aggregates vs canonical. Drift entries surface in `system_health_checks` alongside the existing 5 checks — no new cron, no new query, no new dependencies.

Predecessor: #297 (PR-D — on-demand audit + repair callables).

## What changed

- `functions/scheduled/index.js`:
  - Imports `calcClientAggregates` + `_recomputeTotalHours`
  - New pure function `detectAggregateDrift(clientData)` (testable surface)
  - Check 6 block inside `dailyInvariantCheck` — iterates `clientsSnapshot.docs`, skips `SKIP_CLIENTS`, pushes `type: 'aggregate_drift'` entries to discrepancies
  - `module.exports._test` exposes the detector + tolerance constant
- `functions/tests/daily-invariant-check-i1-i4.test.js` — 11 tests on the pure detector
- `.claude/rubrics/pr-c-1.md` — rubric (9 MUST + 4 SHOULD)

## Discrepancy entry shape

When drift is detected, the entry looks like:

```js
{
  type: 'aggregate_drift',
  clientId: '2025007',
  clientName: 'אבן שתיה',
  driftFields: [
    { field: 'isBlocked', current: true, canonical: false },
    { field: 'hoursUsed', current: 102.5, canonical: 100.0, diff: 2.5 }
  ]
}
```

Pattern mirrors existing `package_drift` and `task_actualHours_actualMinutes_drift`. Stored in the next `system_health_checks` document at 06:00.

## Detection logic

For each client (not in `SKIP_CLIENTS`):
1. Recompute canonical `totalHours` from `services[]` (excludes `ST.FIXED` + `legal_procedure+fixed`)
2. Run `calcClientAggregates(services, totalHours)` → canonical 6-field aggregate
3. Compare stored vs canonical for:
   - Numeric: `totalHours`, `hoursUsed`, `hoursRemaining`, `minutesUsed`, `minutesRemaining` (tolerance 0.02)
   - Boolean: `isBlocked`, `isCritical` (strict)
4. Drifted fields → push to `discrepancies`

Empty-services clients return no drift (different bug class).

## Test plan

- [x] functions/ Jest green (487 pass, +11 new)
- [x] Root Vitest green (193 pass / 2 skipped — no regression)
- [x] Lint 0 errors
- [x] Outcomes Grader verdict: PASS (9/9 MUST + 2/2 verifiable SHOULD; S3/S4 covered by this description)
- [ ] Post-merge: wait for next 06:00 cron tick (Asia/Jerusalem). Read newest `system_health_checks` doc. Expect either status: 'PASS' or a list of `aggregate_drift` entries to triage with PR-D's `repairClientAggregates`.

## Rollback

`git revert <merge-commit>` → CI redeploys. Sixth check disappears. Existing 5 checks unchanged. No data corruption.

## Where this fits in the bigger picture

After PR-A (architecture) + PR-B (14 migrations) + PR-D (on-demand audit/repair) + PR-C.1 (nightly automation), the original 23-victim incident is fully addressed:
- **Prevention**: every write goes through canonical helper (PR-A + PR-B).
- **Detection on-demand**: `auditClientAggregates` returns drift list when invoked (PR-D).
- **Detection nightly**: `dailyInvariantCheck` Check 6 runs the same comparison automatically (this PR).
- **Repair**: `repairClientAggregates` fixes one client at a time (PR-D).

Next natural steps: PR-C.2 (WhatsApp alert on drift detection — depends on this PR's `aggregate_drift` entries), PR-C.3 (admin dashboard for `system_health_checks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)