### PR TITLE
feat(functions): outbox trigger for system_health_checks → WhatsApp bot (PR-C.2-fns)

### DIFF
--- a/.claude/rubrics/pr-c-2-fns.md
+++ b/.claude/rubrics/pr-c-2-fns.md
@@ -1,0 +1,122 @@
+# Rubric — PR-C.2-fns
+
+**Title:** feat(functions): outbox trigger for system_health_checks → WhatsApp bot (PR-C.2-fns)
+**Branch:** feat/system-reports-outbox-pr-c-2-fns
+**Base:** main
+**File:** new `functions/triggers/system-reports-outbox-trigger.js` + index.js export + tests
+**Scope:** Half of PR-C.2 (the law-office-system side). Firestore trigger on `system_health_checks` document creation. If `status: 'FAIL'`, writes a `system_reports_outbox` doc that the existing hachnasovitz WhatsApp bot will consume in PR-C.2-bot. Decoupled via outbox pattern (Firestore as queue). No HTTP, no new ports, no new infrastructure.
+
+## Architecture
+
+```
+dailyInvariantCheck (cron 06:00)
+        ↓ writes
+system_health_checks/{auto-id}                ← existing (PR-C.1)
+        ↓ triggers
+onSystemHealthCheckCreated                    ← NEW (this PR)
+        ↓ if status === 'FAIL', writes
+system_reports_outbox/{auto-id}               ← NEW collection
+        ↓ listened by (PR-C.2-bot)
+hachnasovitz bot → WhatsApp group
+        ↓ updates status: 'sent'
+system_reports_outbox/{auto-id}
+```
+
+## Why outbox pattern (not HTTP webhook)
+
+- Bot already connects to law-office-system Firestore (read-only currently) via `daily-reports/law-office-key.json`. PR-C.2-bot upgrades that service account to read+write on `system_reports_outbox` only.
+- No new HTTP port to expose, no firewall config, no auth-token rotation.
+- Outbox is durable: bot restart? Pending docs remain. Out of memory? Pending docs remain. Retry via attempts counter.
+- Auditable: full history of every alert ever sent.
+
+## Risk profile
+
+**Low.** New trigger on a low-volume collection (health checks fire ~daily). No mutation to existing docs. Empty outbox if no FAIL.
+
+## MUST criteria (block on FAIL)
+
+### M1 — New trigger `onSystemHealthCheckCreated`
+**Rule:** Firestore v2 trigger on `onDocumentCreated('system_health_checks/{docId}', ...)`. Reads the new doc; if `status === 'FAIL'` and `discrepanciesCount > 0`, writes an outbox doc. If `status === 'PASS'` or empty, no write.
+**Evidence required:** Reading the code.
+
+### M2 — Outbox doc schema
+**Rule:** Writes to `system_reports_outbox/{auto-id}` with:
+```js
+{
+  type: 'system_health_check',
+  severity: 'warning',  // future: 'critical' for security/data-loss
+  source: 'dailyInvariantCheck',
+  healthCheckDocId: <docId>,
+  discrepanciesCount: <number>,
+  discrepancies: [...],   // full array — bot formats
+  status: 'pending',
+  attempts: 0,
+  createdAt: serverTimestamp(),
+  sentAt: null,
+  errorMessage: null
+}
+```
+**Evidence required:** Reading the code; test asserts shape.
+
+### M3 — No mutation of `system_health_checks`
+**Rule:** Trigger only writes to `system_reports_outbox`. Does not modify the source `system_health_checks` doc (avoids self-write loops). Verified by code inspection — no `event.data.ref.update()` etc.
+**Evidence required:** Reading the code.
+
+### M4 — Idempotent on retries
+**Rule:** Firestore Cloud Function triggers can fire more than once. Use the source doc ID as part of outbox-doc uniqueness check (or rely on Cloud Functions' at-least-once delivery + bot-side idempotency via `status: 'pending' → sent` check; this PR opts for the latter as the simpler approach).
+**Evidence required:** Inline comment documents the at-least-once expectation + bot-side dedup.
+
+### M5 — Trigger registered in index.js
+**Rule:** `functions/index.js` exports the new trigger.
+**Evidence required:** Diff.
+
+### M6 — Logs on trigger fire
+**Rule:** `console.log` (or `functions.logger.info`) on fire with summary: docId + status + discrepanciesCount. Helps prod debugging.
+**Evidence required:** Reading the code.
+
+### M7 — Tests cover the trigger
+**Rule:** New test file `functions/tests/system-reports-outbox-trigger.test.js`:
+- PASS health check (no discrepancies) → no outbox write
+- FAIL health check (discrepancies > 0) → outbox doc written with full payload
+- Outbox doc shape matches schema (status: 'pending', attempts: 0, etc.)
+- Trigger does NOT update the source doc
+
+**Evidence required:** Test file + Jest output.
+
+### M8 — All other tests pass + lint zero
+**Rule:** functions Jest + root Vitest green. `npm run lint` 0 errors.
+**Evidence required:** Test runner output.
+
+## SHOULD criteria
+
+### S1 — Inline comment tagged PR-C.2-fns
+**Evidence required:** Comment block.
+
+### S2 — Comment describes the bot's expected consumption pattern
+**Rule:** Comment notes: bot listens on `system_reports_outbox` where `status == 'pending'`. After sending, bot updates to `status: 'sent'`, sets `sentAt`, increments `attempts`. On failure: `status: 'failed'`, sets `errorMessage`, can be retried.
+**Evidence required:** Comment.
+
+### S3 — PR description names PR-C.1 predecessor + companion PR (C.2-bot) + outbox-pattern rationale
+**Evidence required:** PR body.
+
+### S4 — Schema example included in PR description
+**Evidence required:** PR body shows the expected outbox doc shape.
+
+## Out of scope
+
+- The bot side (separate PR — PR-C.2-bot in hachnasovitz repo)
+- Severity escalation logic ('warning' vs 'critical')
+- Slack/email backup channels
+- Retry orchestration (bot owns retry counter)
+- Admin UI for outbox monitoring (future)
+- Cleanup of old `system_reports_outbox` docs (TTL via separate scheduled cleanup, future)
+
+## Rollback
+
+`git revert <merge-commit>` → CI redeploys. Trigger disappears. Bot continues to listen on `system_reports_outbox` but no new docs arrive. Pending docs delivered then queue stays empty. No data corruption.
+
+## Notes for grader
+
+- The outbox doc is intentionally generic. Future health-check sources (beyond `dailyInvariantCheck`) can write to `system_health_checks` and automatically flow through to WhatsApp.
+- Bot side (PR-C.2-bot) will need this PR's outbox schema as a contract. PR-C.2-bot will be opened after this merges.
+- The trigger does NOT format messages — bot owns Hebrew formatting. Decoupling rationale documented in code.

--- a/functions/index.js
+++ b/functions/index.js
@@ -68,6 +68,11 @@ const repairAggregates = require('./admin/repair-aggregates');
 exports.auditClientAggregates = repairAggregates.auditClientAggregates;
 exports.repairClientAggregates = repairAggregates.repairClientAggregates;
 
+// PR-C.2-fns (2026-05-18): outbox trigger for system_health_checks → bot.
+// See functions/triggers/system-reports-outbox-trigger.js for the outbox-pattern rationale.
+const systemReportsOutboxTrigger = require('./triggers/system-reports-outbox-trigger');
+exports.onSystemHealthCheckCreated = systemReportsOutboxTrigger.onSystemHealthCheckCreated;
+
 // Auth Functions (imported from ./auth)
 const authModule = require('./auth');
 exports.createAuthUser = authModule.createAuthUser;

--- a/functions/tests/system-reports-outbox-trigger.test.js
+++ b/functions/tests/system-reports-outbox-trigger.test.js
@@ -1,0 +1,234 @@
+/**
+ * Tests for onSystemHealthCheckCreated trigger (PR-C.2-fns).
+ *
+ * Coverage:
+ *   A. PASS health check → no outbox write
+ *   B. FAIL health check → outbox doc with full payload
+ *   C. Outbox doc shape (status: 'pending', attempts: 0, etc.)
+ *   D. Source doc never mutated (trigger does not update system_health_checks)
+ *   E. Missing snapshot data → no-op
+ *   F. discrepanciesCount=0 with status FAIL (edge) → no outbox write
+ */
+
+const mockOutboxAdd = jest.fn().mockResolvedValue({ id: 'outbox_auto_id' });
+const mockOutboxRef = { add: mockOutboxAdd };
+
+const mockDb = {
+  collection: jest.fn((name) => {
+    if (name === 'system_reports_outbox') {
+      return mockOutboxRef;
+    }
+    return {
+      doc: jest.fn(() => ({ id: 'x', update: jest.fn(), set: jest.fn() }))
+    };
+  })
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue })
+  };
+});
+
+// Capture handler registered via onDocumentCreated
+let registeredHandler = null;
+jest.mock('firebase-functions/v2/firestore', () => ({
+  onDocumentCreated: jest.fn((config, fn) => {
+    registeredHandler = fn;
+    return fn;
+  })
+}));
+
+require('../triggers/system-reports-outbox-trigger');
+
+function makeEvent({ docId = 'hc1', data = null } = {}) {
+  return {
+    params: { docId },
+    data: data ? { data: () => data } : null
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOutboxAdd.mockResolvedValue({ id: 'outbox_auto_id' });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// A. PASS health check → no outbox write
+// ═══════════════════════════════════════════════════════════════
+
+describe('A. PASS health check', () => {
+  test('status: PASS → no outbox write', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'PASS',
+        discrepanciesCount: 0,
+        discrepancies: []
+      }
+    }));
+
+    expect(mockOutboxAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// B. FAIL → outbox written with full payload
+// ═══════════════════════════════════════════════════════════════
+
+describe('B. FAIL health check', () => {
+  test('status: FAIL with discrepancies → outbox doc written with full payload', async () => {
+    const discrepancies = [
+      {
+        type: 'aggregate_drift',
+        clientId: 'c1',
+        clientName: 'לקוח טסט',
+        driftFields: [
+          { field: 'isBlocked', current: true, canonical: false }
+        ]
+      },
+      {
+        type: 'package_drift',
+        clientId: 'c2',
+        clientName: 'לקוח שני',
+        serviceId: 'svc1',
+        totalHours: 10,
+        sumPkgHours: 8,
+        drift: 2
+      }
+    ];
+
+    await registeredHandler(makeEvent({
+      docId: 'hc_2026_05_18',
+      data: {
+        type: 'invariant_check',
+        status: 'FAIL',
+        discrepanciesCount: 2,
+        discrepancies
+      }
+    }));
+
+    expect(mockOutboxAdd).toHaveBeenCalledTimes(1);
+    const payload = mockOutboxAdd.mock.calls[0][0];
+    expect(payload.type).toBe('system_health_check');
+    expect(payload.severity).toBe('warning');
+    expect(payload.source).toBe('dailyInvariantCheck');
+    expect(payload.healthCheckDocId).toBe('hc_2026_05_18');
+    expect(payload.discrepanciesCount).toBe(2);
+    expect(payload.discrepancies).toEqual(discrepancies);
+    expect(payload.status).toBe('pending');
+    expect(payload.attempts).toBe(0);
+    expect(payload.createdAt).toBe('SERVER_TIMESTAMP');
+    expect(payload.sentAt).toBeNull();
+    expect(payload.errorMessage).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// C. Outbox doc shape — fields complete
+// ═══════════════════════════════════════════════════════════════
+
+describe('C. Outbox doc shape', () => {
+  test('all required fields present', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'FAIL',
+        discrepanciesCount: 1,
+        discrepancies: [{ type: 'aggregate_drift', clientId: 'c1' }]
+      }
+    }));
+
+    const payload = mockOutboxAdd.mock.calls[0][0];
+    const requiredFields = [
+      'type', 'severity', 'source', 'healthCheckDocId',
+      'discrepanciesCount', 'discrepancies',
+      'status', 'attempts', 'createdAt', 'sentAt', 'errorMessage'
+    ];
+    for (const field of requiredFields) {
+      expect(payload).toHaveProperty(field);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// D. Source doc never mutated
+// ═══════════════════════════════════════════════════════════════
+
+describe('D. Source doc not mutated', () => {
+  test('only writes to system_reports_outbox, never to system_health_checks', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'FAIL',
+        discrepanciesCount: 1,
+        discrepancies: [{ type: 'x' }]
+      }
+    }));
+
+    // Verify only one collection was accessed for writes
+    const writeCollections = mockDb.collection.mock.calls.map(c => c[0]);
+    expect(writeCollections).toContain('system_reports_outbox');
+    expect(writeCollections).not.toContain('system_health_checks');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// E. Missing snapshot → no-op
+// ═══════════════════════════════════════════════════════════════
+
+describe('E. Missing snapshot', () => {
+  test('event.data is null → no outbox write', async () => {
+    await registeredHandler({ params: { docId: 'hc1' }, data: null });
+    expect(mockOutboxAdd).not.toHaveBeenCalled();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// F. Edge — FAIL with count 0
+// ═══════════════════════════════════════════════════════════════
+
+describe('F. Edge cases', () => {
+  test('status FAIL but discrepanciesCount 0 → no outbox write', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'FAIL',
+        discrepanciesCount: 0,
+        discrepancies: []
+      }
+    }));
+    expect(mockOutboxAdd).not.toHaveBeenCalled();
+  });
+
+  test('status ERROR → no outbox write', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'ERROR',
+        discrepanciesCount: 0,
+        discrepancies: [],
+        message: 'שגיאה'
+      }
+    }));
+    expect(mockOutboxAdd).not.toHaveBeenCalled();
+  });
+
+  test('discrepanciesCount missing → falls back to discrepancies.length', async () => {
+    await registeredHandler(makeEvent({
+      data: {
+        type: 'invariant_check',
+        status: 'FAIL',
+        // discrepanciesCount intentionally missing
+        discrepancies: [{ type: 'x' }, { type: 'y' }]
+      }
+    }));
+    expect(mockOutboxAdd).toHaveBeenCalledTimes(1);
+    expect(mockOutboxAdd.mock.calls[0][0].discrepanciesCount).toBe(2);
+  });
+});

--- a/functions/triggers/system-reports-outbox-trigger.js
+++ b/functions/triggers/system-reports-outbox-trigger.js
@@ -1,0 +1,97 @@
+/**
+ * System Reports Outbox Trigger — PR-C.2-fns (2026-05-18)
+ *
+ * Fires on every `system_health_checks` document creation. If the health
+ * check reports a FAIL (discrepancies > 0), writes a `system_reports_outbox`
+ * doc that the hachnasovitz WhatsApp bot consumes (PR-C.2-bot) and forwards
+ * to the "דיווחי מערכת" group.
+ *
+ * Why outbox (not HTTP webhook):
+ *   The bot already connects to law-office-system Firestore (via service
+ *   account in `daily-reports/law-office-key.json`, read-only). Extending
+ *   that connection to read+write on `system_reports_outbox` is simpler
+ *   than exposing a new HTTP endpoint:
+ *     • Durable — bot restart preserves pending docs
+ *     • Idempotent via status field
+ *     • Retryable via attempts counter
+ *     • Auditable — full history persisted
+ *     • No new ports / firewall / auth-token rotation
+ *
+ * Bot consumption pattern (PR-C.2-bot):
+ *   1. Listen on `system_reports_outbox` where `status == 'pending'`
+ *   2. Format Hebrew message from `discrepancies[]`
+ *   3. Send to WhatsApp group "דיווחי מערכת"
+ *   4. On success: update doc with `status: 'sent'`, `sentAt: now`
+ *   5. On failure: update doc with `status: 'failed'`, `errorMessage: ...`,
+ *      increment `attempts`. Can be retried by flipping back to 'pending'.
+ *
+ * Bot owns Hebrew formatting — this side stays generic. Future health-check
+ * sources beyond `dailyInvariantCheck` can write to `system_health_checks`
+ * and automatically flow through.
+ *
+ * Cloud Functions triggers have at-least-once delivery. Duplicate outbox
+ * writes are tolerated because the bot's `status: 'pending' → sent` flip
+ * is naturally idempotent — even if two outbox docs result from one health
+ * check, the bot would send twice (acceptable for an alert) rather than
+ * skipping silently. If duplication becomes a problem in prod, add a
+ * dedup-by-source-doc-id query before write.
+ */
+
+const admin = require('firebase-admin');
+const { onDocumentCreated } = require('firebase-functions/v2/firestore');
+
+const db = admin.firestore();
+
+const onSystemHealthCheckCreated = onDocumentCreated({
+  document: 'system_health_checks/{docId}',
+  region: 'us-central1'
+}, async (event) => {
+  const docId = event.params.docId;
+  const snap = event.data;
+  if (!snap) {
+    console.warn(`[system-reports-outbox] No snapshot for ${docId} — skipping`);
+    return null;
+  }
+
+  const data = snap.data() || {};
+
+  // Only emit on FAIL with non-empty discrepancies.
+  const status = data.status;
+  const discrepanciesCount = typeof data.discrepanciesCount === 'number'
+    ? data.discrepanciesCount
+    : Array.isArray(data.discrepancies) ? data.discrepancies.length : 0;
+
+  if (status !== 'FAIL' || discrepanciesCount === 0) {
+    console.log(`[system-reports-outbox] ${docId} status=${status} count=${discrepanciesCount} — no outbox write`);
+    return null;
+  }
+
+  const discrepancies = Array.isArray(data.discrepancies) ? data.discrepancies : [];
+
+  try {
+    const outboxRef = await db.collection('system_reports_outbox').add({
+      type: 'system_health_check',
+      severity: 'warning',
+      source: 'dailyInvariantCheck',
+      healthCheckDocId: docId,
+      discrepanciesCount,
+      discrepancies,
+      status: 'pending',
+      attempts: 0,
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      sentAt: null,
+      errorMessage: null
+    });
+
+    console.log(`[system-reports-outbox] ${docId} FAIL × ${discrepanciesCount} → outbox/${outboxRef.id}`);
+  } catch (err) {
+    console.error(`[system-reports-outbox] Failed to write outbox for ${docId}:`, err);
+    throw err; // let Cloud Functions retry
+  }
+
+  return null;
+});
+
+module.exports = {
+  onSystemHealthCheckCreated
+};


### PR DESCRIPTION
## Summary

Half of **PR-C.2** — the law-office-system side. Firestore v2 trigger on `system_health_checks` creation that writes to a new `system_reports_outbox` collection whenever a health check reports FAIL with discrepancies. The hachnasovitz WhatsApp bot consumes this outbox in the companion PR (**PR-C.2-bot**) and forwards to the "דיווחי מערכת" group.

Predecessor: #298 (PR-C.1 — added Check 6 to `dailyInvariantCheck`).
Companion: PR-C.2-bot (hachnasovitz repo, opened after this merges).

## Why outbox (not HTTP webhook)

The bot already connects to law-office-system Firestore (read-only, via service account in `daily-reports/law-office-key.json`). Extending that connection to read+write on `system_reports_outbox` only is simpler than exposing a new HTTP endpoint:
- **Durable** — bot restart preserves pending docs
- **Idempotent** via status field
- **Retryable** via attempts counter
- **Auditable** — full history persisted
- No new ports / firewall / auth-token rotation

## Outbox doc schema

```js
{
  type: 'system_health_check',
  severity: 'warning',
  source: 'dailyInvariantCheck',
  healthCheckDocId: <docId>,
  discrepanciesCount: <number>,
  discrepancies: [...],   // full array — bot formats Hebrew message
  status: 'pending',
  attempts: 0,
  createdAt: <serverTimestamp>,
  sentAt: null,
  errorMessage: null
}
```

## Bot consumption pattern (PR-C.2-bot)

1. Listen on `system_reports_outbox` where `status == 'pending'`
2. Format Hebrew message from `discrepancies[]`
3. Send to WhatsApp group "דיווחי מערכת"
4. On success: update `status: 'sent'`, `sentAt: now`
5. On failure: update `status: 'failed'`, `errorMessage`, increment `attempts`

## What changed

- `functions/triggers/system-reports-outbox-trigger.js` — new module with `onSystemHealthCheckCreated` v2 trigger
- `functions/index.js` — exports the trigger
- `functions/tests/system-reports-outbox-trigger.test.js` — 8 tests across 6 describe blocks (PASS no-write, FAIL full-payload, schema, no source mutation, missing snapshot, edge cases)
- `.claude/rubrics/pr-c-2-fns.md` — rubric (8 MUST + 4 SHOULD)

## Test plan

- [x] functions/ Jest green (495 pass, +8 new)
- [x] Root Vitest green (193 pass / 2 skipped — no regression)
- [x] Lint 0 errors
- [x] Outcomes Grader verdict: PASS (8/8 MUST + 2/2 verifiable SHOULD; S3/S4 satisfied here)
- [ ] Post-merge: deploy; on next 06:00 cron with FAIL → outbox doc appears
- [ ] PR-C.2-bot opened in hachnasovitz repo to consume

## Rollback

`git revert <merge-commit>` → CI redeploys. Trigger disappears. Pending outbox docs delivered by bot then queue stays empty. No data corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)