### PR TITLE
fix(user-app): daily-meter popup viewport overflow + cream FA icons (PR-F.1)

### DIFF
--- a/apps/user-app/js/modules/components/sidebar/daily-meter.css
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.css
@@ -151,6 +151,13 @@
   bottom: 0;
   transform: translateX(10px);
   width: 230px;
+
+  /* PR-F.1: cap to viewport so tall week-view never clips above screen top.
+     Reserve 24px buffer from viewport edge. Internal scrolling via the
+     list block below. */
+  max-height: calc(100vh - 24px);
+  display: flex;
+  flex-direction: column;
   background: #1e293b;
   border-radius: 12px;
   padding: 16px 18px;
@@ -226,7 +233,10 @@
   display: flex;
   flex-direction: column;
   gap: 3px;
-  max-height: 320px;
+
+  /* PR-F.1: flex-grow inside capped popup. min-height: 0 allows shrinking. */
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -293,16 +303,19 @@
 }
 
 .gh-daily-meter-popup-day-badge {
+  /* PR-F.1: unified cream icon color. Semantic color comes from the
+     row's tinted background (.missing/.met/.partial). Keeps badges
+     elegant + consistent with sidebar palette. */
   font-size: 10px;
   width: 16px;
   text-align: center;
+  color: #f1f5f9;
+  opacity: 0.9;
 }
 
-.gh-daily-meter-popup-day-badge.missing { color: #ef4444; }
-
-.gh-daily-meter-popup-day-badge.met { color: #22c55e; }
-
-.gh-daily-meter-popup-day-badge.partial { color: #f59e0b; }
+.gh-daily-meter-popup-day-badge i {
+  font-size: 11px;
+}
 
 .gh-daily-meter-popup-day-hours {
   font-weight: 600;
@@ -383,6 +396,10 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+
+  /* PR-F.1: flex-grow inside capped popup; cap kept for today view sanity */
+  flex: 1 1 auto;
+  min-height: 0;
   max-height: 260px;
   overflow-y: auto;
 }

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -417,16 +417,16 @@ return;
       } else if (dayInfo.totalHours === 0) {
         // Workday with no reports — flag it
         dayClass = ' missing';
-        badgeHtml = '<span class="gh-daily-meter-popup-day-badge missing" title="יום עבודה ללא דיווחים">⚠️</span>';
+        badgeHtml = '<span class="gh-daily-meter-popup-day-badge missing" title="יום עבודה ללא דיווחים"><i class="fas fa-circle-exclamation"></i></span>';
       } else if (dayInfo.totalHours >= this._dailyTarget) {
         dayClass = ' met';
-        badgeHtml = '<span class="gh-daily-meter-popup-day-badge met" title="עמדת בתקן">✓</span>';
+        badgeHtml = '<span class="gh-daily-meter-popup-day-badge met" title="עמדת בתקן"><i class="fas fa-check"></i></span>';
       } else if (isToday) {
         dayClass = ' today partial';
-        badgeHtml = '<span class="gh-daily-meter-popup-day-badge partial" title="חלקי (היום)">~</span>';
+        badgeHtml = '<span class="gh-daily-meter-popup-day-badge partial" title="חלקי (היום)"><i class="fas fa-hourglass-half"></i></span>';
       } else {
         dayClass = ' partial';
-        badgeHtml = '<span class="gh-daily-meter-popup-day-badge partial" title="חלקי">~</span>';
+        badgeHtml = '<span class="gh-daily-meter-popup-day-badge partial" title="חלקי"><i class="fas fa-hourglass-half"></i></span>';
       }
 
       const expanded = !!this._expandedDays[dayInfo.dateStr];


### PR DESCRIPTION
## Summary

Two visual fixes on top of PR-F (#302):

1. **Viewport overflow** — popup is bottom-anchored to the sidebar ring and grows upward. With week view content, total height can exceed available viewport space, clipping the popup header above the screen edge. Fix: cap `.gh-daily-meter-popup` to `max-height: calc(100vh - 24px)` and turn it into a flex column. Both `.popup-list` (today) and `.popup-week-list` (week) get `flex: 1 1 auto; min-height: 0` so they shrink and scroll **inside** the capped container instead of pushing the popup top off-screen.

2. **Cream Font Awesome icons** — replaces emoji badges (`✓` / `~` / `⚠️`) with proper Font Awesome icons in a unified cream tone:
   - Met workday: `fa-check`
   - Partial: `fa-hourglass-half`
   - Missing workday: `fa-circle-exclamation`
   - All icons: `#f1f5f9` @ `0.9` opacity
   - Semantic color preserved via existing row tint backgrounds (`.missing` red tint, `.met` green tint, `.partial` orange tint).

Predecessor: #302 (PR-F — week view).

## What changed

- `apps/user-app/js/modules/components/sidebar/daily-meter.js` — 4 emoji → FA icon HTML in `_renderWeekBody`
- `apps/user-app/js/modules/components/sidebar/daily-meter.css` — popup `max-height` cap + flex layout, badge color unified to cream

## Test plan

- [x] Root Vitest green (216 pass — `_groupByDay` unit tests unaffected)
- [x] Lint 0 errors
- [ ] Post-merge DEV smoke: open user-app, click ring, switch to "השבוע" — verify
  - Popup never clips above viewport top, even with all 7 days expanded
  - Week list scrolls inside popup if too tall
  - Icons render in cream, with row tint indicating status

## Rollback

`git revert <merge-commit>` → reverts to PR-F state (emoji + uncapped popup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)