### PR TITLE
fix(user-app): daily-meter popup position:fixed prevents top-clip (PR-F.2)

### DIFF
--- a/apps/user-app/js/modules/components/sidebar/daily-meter.css
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.css
@@ -146,16 +146,17 @@
    ═══════════════════════════════════════ */
 
 .gh-daily-meter-popup {
-  position: absolute;
-  left: calc(-230px - 14px);
-  bottom: 0;
+  /* PR-F.2: position: fixed anchored to viewport bottom-right so popup never
+     extends above the viewport top when content is tall (week view + expanded
+     day rows). Previous absolute+bottom:0 anchor caused top-clipping because
+     max-height capped popup HEIGHT but not its absolute Y position.
+     Sidebar width = 72px (sidebar-config.js); 14px gap from sidebar edge. */
+  position: fixed;
+  right: calc(72px + 14px);
+  bottom: 20px;
   transform: translateX(10px);
   width: 230px;
-
-  /* PR-F.1: cap to viewport so tall week-view never clips above screen top.
-     Reserve 24px buffer from viewport edge. Internal scrolling via the
-     list block below. */
-  max-height: calc(100vh - 24px);
+  max-height: calc(100vh - 40px);
   display: flex;
   flex-direction: column;
   background: #1e293b;


### PR DESCRIPTION
## Summary

Real fix for the popup-clipping issue that PR-F.1 (#303) didn't fully solve.

**Why PR-F.1 wasn't enough:** `max-height: calc(100vh - 24px)` caps height, but the popup uses `position: absolute` anchored to `bottom: 0` of the ring parent (52×52 element near the bottom of the sidebar). With week view + an expanded day row, content can grow tall enough that even within `max-height`, the popup's TOP edge ends up above the viewport top:

```
bottom edge   = parent.bottom (~ y=620 in 700px viewport)
height        = max-height = ~676px
top edge      = 620 − 676 = -56  ← above viewport, clipped
```

**Fix:** switch popup to `position: fixed` anchored to the viewport directly.

```css
position: fixed;
right: calc(72px + 14px);  /* sidebar width 72px + 14px gap */
bottom: 20px;
max-height: calc(100vh - 40px);
```

Bottom edge anchored 20px from viewport bottom; max-height caps remaining upward growth → top edge never crosses y=20. The flex column layout from PR-F.1 + inner scroll on the week list still apply, so very tall content scrolls **inside** the popup.

The bridge `::after` and slide-in `translateX(10px)` animation stay attached to the popup box. Mobile media query (`display: none` ≤ 768px) untouched.

## Test plan

- [x] Root Vitest green (216 pass — no functional changes to JS)
- [x] Lint 0 errors
- [ ] Post-merge DEV smoke: click ring → switch to "השבוע" → expand every day → verify popup top stays inside viewport with internal scroll

## Rollback

`git revert <merge-commit>` → reverts to PR-F.1 state (top-clip on tall content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)