### PR TITLE
fix(user-app): move popup outside ring DOM + tighten gap (PR-F.3)

### DIFF
--- a/apps/user-app/js/modules/components/sidebar/daily-meter.css
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.css
@@ -152,7 +152,7 @@
      max-height capped popup HEIGHT but not its absolute Y position.
      Sidebar width = 72px (sidebar-config.js); 14px gap from sidebar edge. */
   position: fixed;
-  right: calc(72px + 14px);
+  right: calc(72px + 8px);  /* PR-F.3: tightened from 14px gap → 8px */
   bottom: 20px;
   transform: translateX(10px);
   width: 230px;

--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -129,6 +129,11 @@ return;
   _render(container) {
     this._el = document.createElement('div');
     this._el.className = 'gh-daily-meter';
+    // PR-F.3: popup is a SIBLING of the ring (not a child). The ring uses
+    // `transform: scale(1.06)` on hover, which would otherwise turn the
+    // ring into the containing block for the popup's `position: fixed`
+    // (CSS spec — a transformed ancestor anchors fixed-positioned
+    // descendants), causing the popup to drift on hover.
     this._el.innerHTML = `
       <div class="gh-daily-meter-ring" title="מד דיווח יומי — לחץ לפירוט">
         ${this._isNewFeature() ? '<span class="gh-daily-meter-badge-new"></span>' : ''}
@@ -142,9 +147,9 @@ return;
           <div class="gh-daily-meter-pct">0%</div>
           <div class="gh-daily-meter-hours">0:00</div>
         </div>
-        <div class="gh-daily-meter-popup"></div>
       </div>
       <span class="gh-daily-meter-label">דיווח יומי</span>
+      <div class="gh-daily-meter-popup"></div>
     `;
 
     // Insert as first child of footer (above break button)


### PR DESCRIPTION
## Summary

Real root-cause fix for "popup moves on hover" reported after #304.

## Root cause

```css
.gh-daily-meter-ring:hover { transform: scale(1.06); }
```

Per the CSS spec, a transformed ancestor establishes a new containing block for any `position: fixed` descendants. The popup was a **child of the ring**. On hover, the ring's `transform: scale(...)` turned the ring into the popup's containing block — the popup lost its viewport anchor and tracked the (slightly scaled) ring instead of staying fixed at the viewport edge. User experience: popup drifts up/down/sideways on hover.

This explains why my prior fix (#304) only addressed the "popup top clipped above viewport" symptom but not the hover-drift symptom — both stem from the popup being inside a transformed ancestor.

## Fix

Move the popup OUT of the ring element. Popup is now a sibling of `.gh-daily-meter-ring`, both inside `.gh-daily-meter` (which itself has no transform). `position: fixed` now correctly anchors to the viewport regardless of ring hover state.

Also: tighten the gap from the sidebar — `right: calc(72px + 8px)` (was `72px + 14px`) — so the popup sits closer to the ring, matching the original (pre-PR-F.2) visual proximity.

## What's unchanged

- Ring hover animation (still `transform: scale(1.06)`)
- Ring badge, label, color states, pulse animations
- Status row, tab toggle, week-view rendering, internal scroll
- Mobile media query (display: none ≤ 768px)
- Slide-in animation (translateX 10px → 0)
- Outside-click handler (`this._el.contains(e.target)` still covers popup since popup remains inside the same outer `.gh-daily-meter`)
- Bridge `::after` element

## Test plan

- [x] Root Vitest green (216 pass)
- [x] Lint 0 errors
- [ ] Post-merge DEV smoke:
  - Click ring → popup opens, stays in place when hovering ring
  - Switch to "השבוע" → expand a day → popup stays put, content scrolls inside
  - Verify popup is closer to sidebar than #304

## Rollback

`git revert <merge-commit>` → popup goes back inside the ring → hover-drift returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)