### PR TITLE
fix(user-app): accordion behavior in week view — only one day open at a time (PR-F.4)

### DIFF
--- a/apps/user-app/js/modules/components/sidebar/daily-meter.js
+++ b/apps/user-app/js/modules/components/sidebar/daily-meter.js
@@ -35,8 +35,9 @@ export class DailyMeter {
     // PR-F: active tab — 'today' | 'week'. Default to 'today' (current behavior).
     this._activeTab = 'today';
 
-    // PR-F: per-day expand state in week view — { 'YYYY-MM-DD': true|false }
-    this._expandedDays = {};
+    // PR-F.4: single expanded day at a time (accordion). 'YYYY-MM-DD' or null.
+    // Replaces the per-key map from PR-F so only one day is open simultaneously.
+    this._expandedDay = null;
 
     // Store date string for "today" — recalculated on update
     this._todayStr = this._getTodayStr();
@@ -309,15 +310,17 @@ return;
       });
     });
 
-    // Day-row toggle handlers (week view only)
+    // Day-row toggle handlers (week view only) — accordion (PR-F.4)
     this._popupEl.querySelectorAll('.gh-daily-meter-popup-day-header').forEach(hdr => {
       hdr.addEventListener('click', (e) => {
         e.stopPropagation();
         const dayKey = hdr.getAttribute('data-day');
-        if (dayKey) {
-          this._expandedDays[dayKey] = !this._expandedDays[dayKey];
-          this._renderPopupContent();
+        if (!dayKey) {
+          return;
         }
+        // Same row → toggle close. Different row → switch (auto-close prior).
+        this._expandedDay = this._expandedDay === dayKey ? null : dayKey;
+        this._renderPopupContent();
       });
     });
   }
@@ -434,7 +437,7 @@ return;
         badgeHtml = '<span class="gh-daily-meter-popup-day-badge partial" title="חלקי"><i class="fas fa-hourglass-half"></i></span>';
       }
 
-      const expanded = !!this._expandedDays[dayInfo.dateStr];
+      const expanded = this._expandedDay === dayInfo.dateStr;
       const chevron = dayInfo.totalHours > 0
         ? `<i class="fas fa-chevron-${expanded ? 'up' : 'down'} gh-daily-meter-popup-day-chevron"></i>`
         : '';


### PR DESCRIPTION
## Summary

Replace multi-open day expansion with proper accordion: opening one day automatically closes any previously-open day.

## Before

Each day's chevron toggled independently. User could have all 7 days expanded simultaneously → cluttered, hard to scan.

## After

Single-day expansion. Click day A → row opens. Click day B → row A auto-closes, row B opens. Click day B again → row B closes.

## Implementation

3-line conceptual change:

```js
// constructor
this._expandedDay = null;  // was: this._expandedDays = {}

// click handler
this._expandedDay = this._expandedDay === dayKey ? null : dayKey;
// was: this._expandedDays[dayKey] = !this._expandedDays[dayKey];

// render
const expanded = this._expandedDay === dayInfo.dateStr;
// was: const expanded = !!this._expandedDays[dayInfo.dateStr];
```

## Test plan

- [x] Vitest 216 pass — pure helpers unaffected
- [x] Lint 0 errors
- [ ] DEV smoke: open week tab → expand day A → expand day B (A should auto-close) → click B again (B closes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)