### PR TITLE
chore(claude): add DECISION POINT RULE — agent consultation before user questions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,40 @@ Before opening any PR — `outcomes-grader` MUST evaluate work against rubric `.
 Returns VERDICT: PASS / FAIL / PASS_WITH_WARNINGS. FAIL blocks PR open.
 Read-only. Separate context. No exceptions. (Details: `.claude/docs/OUTCOMES-GRADER-USAGE.md`)
 
+## DECISION POINT RULE (חובה)
+**Before any AskUserQuestion that asks Tommy to choose between approaches/scopes/architecture/priorities — Claude MUST consult the relevant specialized sub-agent first** (from `.claude/agents/`). The question presented to Tommy must include:
+
+1. The investigating agent's name
+2. The agent's verdict / finding (1-2 lines)
+3. The agent's recommendation
+4. Alternatives with trade-offs
+
+**Trigger:** approach choice (A/B/C), scope sizing (1 PR or N?), prioritization (X first or Y?), architectural trade-offs, behavioral changes, resource decisions (new dep, infra).
+
+**Skip:** trivial yes/no ("להמשיך?"), clarification of wording, tiny changes (<50 lines, no architectural impact), status checks ("איפה אנחנו?"), after-deploy smoke results.
+
+**Relevant agents** (`.claude/agents/`): `intent-refiner`, `devils-advocate`, `navigator`, `data-investigator`, `outcomes-grader`, `reviewer`, `security`, `performance`, `firebase-rules`, `refactoring`, `tester`, `backend`, `frontend`, `ci-cd`, `devops`, `explainer`.
+
+**Anti-pattern (forbidden):**
+```
+AskUserQuestion("איזה approach? A או B?")  # ← no agent consulted = blocked
+```
+
+**Correct pattern:**
+```
+[Invoke devils-advocate / navigator / etc.]
+[Receive verdict + recommendation + reasoning]
+AskUserQuestion(
+  question: "🤖 [agent-name]: [verdict]. ממליץ [option].
+            
+            [options with trade-offs]"
+)
+```
+
+**Why:** Tommy's explicit demand 2026-05-20 — "אני מחפש צוות שנעבוד תמיד יחד אבל שתמיד יהיה בפעולה ועבודה". Decisions made by Claude alone are weaker than decisions backed by specialized agent analysis. Each agent is a perspective. Together = engineered work.
+
+**Exemption:** if Tommy says "מהר" / "תחליט אתה" / "פשוט תעשה" — skip agent consultation. Note the skip in response (auditable).
+
 ## MANDATORY RULES
 
 - Every task starts with:


### PR DESCRIPTION
## Summary

Adds a new mandatory section to `CLAUDE.md` — **DECISION POINT RULE** — requiring Claude to consult a specialized sub-agent before asking Tommy any decision-point question (approach choice, scope sizing, architecture trade-off, etc.).

## Why

Tommy's explicit demand 2026-05-20: **"אני מחפש צוות שנעבוד תמיד יחד אבל שתמיד יהיה בפעולה ועבודה"**.

Decisions made by Claude alone are weaker than decisions backed by specialized agent analysis. The 15 agents in `.claude/agents/` (`intent-refiner`, `devils-advocate`, `navigator`, `data-investigator`, `outcomes-grader`, etc.) each provide a perspective. Bringing them in before each decision is the difference between solo work and engineered work.

## What changed

`CLAUDE.md` — one new section `DECISION POINT RULE (חובה)` added after `OUTCOMES GRADER RULE`. No other file touched.

## Effect

From the next decision-point question onward:

**Anti-pattern (forbidden):**
```
AskUserQuestion("איזה approach? A או B?")  ← no agent consulted = blocked
```

**Correct pattern:**
```
[Invoke devils-advocate / navigator / etc.]
[Receive verdict + recommendation + reasoning]
AskUserQuestion(
  question: "🤖 [agent-name]: [verdict]. ממליץ [option].
            
            [options with trade-offs]"
)
```

## Trigger / Skip rules

**Trigger** (must consult agent):
- Approach choice (A vs B vs C)
- Scope sizing (1 PR or N?)
- Prioritization
- Architectural trade-offs
- Behavioral changes
- Resource decisions (new dep, infra change)

**Skip** (agent not needed):
- Trivial yes/no confirmations ("להמשיך?")
- Wording clarification
- Tiny changes (<50 lines, no architectural impact)
- Status checks ("איפה אנחנו?")
- After-deploy smoke results

## Exemption

If Tommy explicitly says "מהר" / "תחליט אתה" / "פשוט תעשה" → skip agent consultation, note the skip in response (auditable).

## Test plan

Documentation-only PR. No code, no tests, no lint impact. Verify rendering of new section + correct anchor/structure.

## Rollback

`git revert <merge-commit>` → rule disappears. No data impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)