### PR TITLE
feat(functions+frontend): split holidays auto/overrides (PR-G.3.3)

### DIFF
--- a/.claude/rubrics/pr-g-3-3.md
+++ b/.claude/rubrics/pr-g-3-3.md
@@ -1,0 +1,171 @@
+# Rubric — PR-G.3.3
+
+**Title:** feat(functions+frontend): split holidays into auto + overrides + Firestore Rules (PR-G.3.3)
+**Branch:** feat/holidays-overrides-pr-g-3-3
+**Base:** main
+**Scope:** Final phase of PR-G.3 split. Backend amendment + frontend merge logic + Firestore Rules. Resolves devils-advocate **R4** (cron clobbers admin override) by splitting Firestore schema into two disjoint field sets that cron + admin write independently. Frontend merges on read.
+
+**Predecessor:** PR-G.3.2 (#312).
+
+## Schema (devils-advocate recommended, after holes were found in original plan)
+
+```
+system_holidays/{year}:
+  year:               number
+  source:             '@hebcal/core@x.y.z'
+  generatedAt:        serverTimestamp
+  contentHash:        sha1 of holidaysAuto
+  holidaysAuto:       Holiday[]              ← cron writes (via UPDATE, not SET)
+  holidaysOverrides:  HolidayOverride[]      ← admin writes manually (Console / future UI)
+```
+
+**`HolidayOverride` shape:**
+```js
+{
+  date:           'YYYY-MM-DD',
+  type:           'holiday' | 'eve' | 'memorial' | 'fast' | 'cholhamoed' | 'minor' | 'modern',
+  nameHe:         string,
+  nameEn:         string,
+  isWorking:      boolean,
+  isHalfDay:      boolean,
+  eveOf:          string | null,
+  _suppress:      true,                       // optional — when present, removes the corresponding auto entry
+  _overrideMeta: {
+    by:           string,                     // employee email/uid
+    at:           ISO timestamp,
+    reason:       string                      // free-text justification
+  }
+}
+```
+
+**The `holidays` field is GONE.** Frontend merges `holidaysAuto + holidaysOverrides` on read.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Cron writes `holidaysAuto` via `update()` not `set()`
+**Rule:** `functions/scheduled/index.js` `syncHolidaysForYear()`:
+- Writes `{ holidaysAuto, contentHash, source, generatedAt, year }` via `docRef.update(...)` OR `docRef.set(..., { merge: true })`. NEVER `set()` without merge — that would erase `holidaysOverrides`.
+- `contentHash` covers `holidaysAuto` only.
+- Idempotency check unchanged: skip write if hash matches.
+- **`holidays` field NOT written** (deprecated; frontend merges).
+
+**Evidence required:** Reading the code; commit message confirms.
+
+### M2 — `seedHolidays.js` uses merge write
+**Rule:** `functions/scripts/seedHolidays.js` writes `{merge: true}` so re-seeding does NOT destroy `holidaysOverrides`.
+
+**Evidence required:** Reading the code.
+
+### M3 — Frontend `holidays-cache.js` merges auto + overrides
+**Rule:** Both apps' `holidays-cache.js` updated to:
+- Read both `data.holidaysAuto` AND `data.holidaysOverrides`
+- Merge per-date: override wins
+- `_suppress: true` → remove the matching auto entry
+- Backward compat: if `holidaysAuto` missing, fall back to `data.holidays` (single deploy cycle)
+- After merge: same `_mergeHolidaysArraysToMap` to build the final Map
+
+**Evidence required:** Reading the code; byte-identical between apps.
+
+### M4 — Firestore Rules added for `system_holidays`
+**Rule:** `firestore.rules` adds:
+```
+match /system_holidays/{year} {
+  allow read: if request.auth != null;
+  allow write: if false;  // Admin SDK + manual Console only
+}
+```
+- Read: any authenticated user
+- Write: explicitly denied via Web SDK (Admin SDK bypasses; Console writes pass when admin authenticated)
+- Captures the rule state in code (previously may have been added out-of-band in Console)
+
+**Evidence required:** Reading the diff.
+
+### M5 — `_suppress` sentinel implemented
+**Rule:** Frontend merge logic: an override with `_suppress: true` REMOVES the corresponding auto entry from the merged Map. Allows admin to cancel a Hebcal-determined holiday (e.g. "this year ראש השנה II falls on Saturday, no special handling needed").
+
+**Evidence required:** Reading the code; unit test covers it.
+
+### M6 — `_overrideMeta` audit fields
+**Rule:** Override entries SHOULD carry `_overrideMeta: { by, at, reason }`. Frontend merge accepts entries without `_overrideMeta` (backward compat / manual Console edits without metadata) but emits `console.warn` to surface them. Admin UI (future) will enforce.
+
+**Evidence required:** Reading the code.
+
+### M7 — No `holidays` field written anywhere new
+**Rule:** Search `functions/` for `holidays:` writes — only `holidaysAuto` and `holidaysOverrides` appear in writers. Existing references in tests / docs left as-is (read paths use field directly).
+
+**Evidence required:** Grep the diff.
+
+### M8 — Tests cover new merge + suppress behavior
+**Rule:** New vitest test cases in `tests/unit/user-app/holidays-cache-merge.test.ts` (extend existing file from G.3.1) or new file:
+- override wins by date
+- `_suppress: true` removes auto entry
+- no override → falls through to auto
+
+Plus new jest test in `functions/tests/`:
+- `syncHolidaysForYear` uses `update()` (or `set({merge: true})`), not `set()`
+- contentHash hashes only `holidaysAuto`
+
+**Evidence required:** Tests + Vitest/Jest output.
+
+### M9 — Backward compat one deploy cycle
+**Rule:** Frontend reads `data.holidaysAuto || data.holidays || []` so if there's a moment in deployment where cron hasn't updated yet, old `data.holidays` is still understood. Cron next tick fixes it.
+
+**Evidence required:** Reading the code; inline comment with cleanup PR-G.3.4 note.
+
+### M10 — Lint + tests green
+**Rule:** Jest + Vitest green. Lint 0 errors.
+
+**Evidence required:** Output.
+
+## SHOULD criteria
+
+### S1 — Inline PR-G.3.3 comments in all modified files
+**Evidence required:** Comments visible.
+
+### S2 — README / migration note for admin
+**Rule:** Add inline comment block at the top of `holidays-cache.js` explaining how an admin would add an override via Firestore Console:
+```
+system_holidays/2026 → add to holidaysOverrides array:
+{
+  "date": "2026-04-22",
+  "type": "modern",
+  "nameHe": "יום העצמאות",
+  "nameEn": "Yom HaAtzma'ut",
+  "isWorking": true,
+  "isHalfDay": false,
+  "eveOf": null,
+  "_overrideMeta": { "by": "haim@gh", "at": "2026-04-15T10:00:00Z", "reason": "Office decided to work" }
+}
+```
+
+**Evidence required:** Comment block.
+
+### S3 — Orphan-override detection (R6) — deferred to PR-G.3.4
+**Rule:** Document in PR body that R6 (override on date that Hebcal later drops) is NOT in this PR. Suggested follow-up.
+
+**Evidence required:** PR body mention.
+
+### S4 — Out-of-window override rejection (R7) — deferred to PR-G.3.4
+**Rule:** Document that overrides outside `currentYear .. currentYear+5` cannot be saved (would land on non-existent year doc). Deferred.
+
+**Evidence required:** PR body mention.
+
+## Out of scope
+
+- **R6:** Orphan override detection — PR-G.3.4
+- **R7:** Out-of-window override rejection — PR-G.3.4
+- **Admin UI for managing overrides** — future PR (today admin uses Firestore Console)
+- **Migration of existing `holidays` field** — kept as backward-compat fallback in reader for one deploy cycle, then removed in PR-G.3.5 cleanup
+
+## Rollback
+
+`git revert <merge-commit>` →
+- Cron reverts to writing `holidays` via `set()`. Any `holidaysOverrides` saved during the failed period are NOT deleted from Firestore (admin SDK doesn't touch them on revert), but they become dead data (nobody reads them).
+- `firestore.rules` revert may break frontend read; mitigate by keeping rules even on revert OR ensuring rules were already added in Console.
+- No data corruption.
+
+## Notes for grader
+
+- This PR closes the final R-level risk (R4) from the original devils-advocate review of PR-G.3.
+- After PR-G.3.3, all 5 devils-advocate risks are mitigated. The G.3 series is functionally complete.
+- The orphan detection (R6) + window-bound rejection (R7) are non-blocking UX features deferred to G.3.4 because they require admin UX decisions Tommy hasn't yet made.

--- a/apps/admin-panel/js/shared/holidays-cache.js
+++ b/apps/admin-panel/js/shared/holidays-cache.js
@@ -69,9 +69,9 @@
 
   /**
    * Pure: merge per-year holiday arrays into one Map<dateStr, Holiday>.
-   * Conflict rule: closed-day (`isWorking: false`) wins over half-day eve;
-   * half-day eve wins over open. Mirrors `functions/shared/calendar.js`
-   * `buildHolidaysMap` logic. Exported for unit tests.
+   * Conflict rule (auto-only merge): closed-day (`isWorking: false`) wins
+   * over half-day eve; half-day eve wins over open. Mirrors
+   * `functions/shared/calendar.js` `buildHolidaysMap` logic.
    *
    * @param {Array<Array<Object>>} yearArrays
    * @returns {Map<string, Object>}
@@ -102,12 +102,65 @@
     return map;
   }
 
+  /**
+   * PR-G.3.3: merge `holidaysAuto + holidaysOverrides` per-year per the new
+   * schema. Overrides win by date. `_suppress: true` removes the matching
+   * auto entry (admin can cancel a Hebcal-determined holiday).
+   *
+   * Backward compat: if `holidaysAuto` missing, falls back to `data.holidays`
+   * (PR-G.3.1 shape). Kept for one deploy cycle; removed in G.3.5 cleanup.
+   *
+   * @param {Array<{holidaysAuto?: Array, holidaysOverrides?: Array, holidays?: Array}>} yearDocs
+   * @returns {Map<string, Object>}
+   */
+  function _mergeAutoAndOverrides(yearDocs) {
+    // 1. Collect auto entries from all years
+    const autoArrays = [];
+    const overrideArrays = [];
+    for (const data of yearDocs || []) {
+      if (!data) {
+        continue;
+      }
+      const auto = Array.isArray(data.holidaysAuto)
+        ? data.holidaysAuto
+        : (Array.isArray(data.holidays) ? data.holidays : []);  // BC fallback
+      autoArrays.push(auto);
+      if (Array.isArray(data.holidaysOverrides)) {
+        overrideArrays.push(data.holidaysOverrides);
+      }
+    }
+
+    // 2. Build auto map via existing logic
+    const map = _mergeHolidaysArraysToMap(autoArrays);
+
+    // 3. Apply overrides: override wins by date; `_suppress: true` removes
+    for (const overrides of overrideArrays) {
+      for (const o of overrides) {
+        if (!o || typeof o.date !== 'string') {
+          continue;
+        }
+        if (o._suppress === true) {
+          map.delete(o.date);
+          continue;
+        }
+        if (!o._overrideMeta) {
+          console.warn('[holidays-cache] override missing _overrideMeta:', o.date, '— still applied');
+        }
+        map.set(o.date, o);
+      }
+    }
+
+    return map;
+  }
+
   function _engageFallback(reason) {
     if (window.WORK_HOURS_HOLIDAYS_FALLBACK_USED) {
       return;
     }
     window.WORK_HOURS_HOLIDAYS_FALLBACK_USED = true;
-    const map = _mergeHolidaysArraysToMap([EMBEDDED_FALLBACK_2026]);
+    // PR-G.3.3: route through the new merger for consistency (no overrides
+    // available offline — only auto fallback). The merger handles single-array.
+    const map = _mergeAutoAndOverrides([{ holidaysAuto: EMBEDDED_FALLBACK_2026 }]);
     window.WORK_HOURS_HOLIDAYS_MAP = map;
     console.warn('[holidays-cache] engaged embedded fallback:', reason);
     if (_resolveReady) {
@@ -117,8 +170,11 @@
   }
 
   function _rebuildMap() {
-    const arrays = Array.from(_holidaysByYear.values());
-    const map = _mergeHolidaysArraysToMap(arrays);
+    // PR-G.3.3: pass full year docs (with both holidaysAuto + holidaysOverrides)
+    // to the new merge. Each entry in `_holidaysByYear` is now the full doc
+    // data object, not just an array. See `_init()` snapshot handler.
+    const docs = Array.from(_holidaysByYear.values());
+    const map = _mergeAutoAndOverrides(docs);
     window.WORK_HOURS_HOLIDAYS_MAP = map;
     window.WORK_HOURS_HOLIDAYS_FALLBACK_USED = false; // real data overrides fallback
     if (_resolveReady) {
@@ -157,11 +213,16 @@
               return;
             }
             const data = snap.data() || {};
-            const holidays = Array.isArray(data.holidays) ? data.holidays : [];
-            _holidaysByYear.set(year, holidays);
+            // PR-G.3.3: store FULL doc (both holidaysAuto + holidaysOverrides
+            // + BC fallback `holidays`). Merge logic in `_mergeAutoAndOverrides`.
+            _holidaysByYear.set(year, data);
             _yearsLoaded.add(year);
             _rebuildMap();
-            console.log('[holidays-cache] loaded ' + year + ' (' + holidays.length + ' entries)');
+            const autoCount = Array.isArray(data.holidaysAuto)
+              ? data.holidaysAuto.length
+              : (Array.isArray(data.holidays) ? data.holidays.length : 0);
+            const ovCount = Array.isArray(data.holidaysOverrides) ? data.holidaysOverrides.length : 0;
+            console.log('[holidays-cache] loaded ' + year + ' (auto=' + autoCount + ', overrides=' + ovCount + ')');
           },
           (err) => {
             console.error('[holidays-cache] subscribe error year ' + year + ':', err.message);
@@ -213,6 +274,7 @@
   window.WORK_HOURS_HOLIDAYS_CACHE = Object.freeze({
     _test: {
       mergeHolidaysArraysToMap: _mergeHolidaysArraysToMap,
+      mergeAutoAndOverrides: _mergeAutoAndOverrides,  // PR-G.3.3
       EMBEDDED_FALLBACK_2026: EMBEDDED_FALLBACK_2026,
       // PR-G.3.2 (R8 mitigation): vitest fixture injection — tests set a
       // synthetic holidays map without needing Firestore mocks. Resolves the

--- a/apps/user-app/js/shared/holidays-cache.js
+++ b/apps/user-app/js/shared/holidays-cache.js
@@ -69,9 +69,9 @@
 
   /**
    * Pure: merge per-year holiday arrays into one Map<dateStr, Holiday>.
-   * Conflict rule: closed-day (`isWorking: false`) wins over half-day eve;
-   * half-day eve wins over open. Mirrors `functions/shared/calendar.js`
-   * `buildHolidaysMap` logic. Exported for unit tests.
+   * Conflict rule (auto-only merge): closed-day (`isWorking: false`) wins
+   * over half-day eve; half-day eve wins over open. Mirrors
+   * `functions/shared/calendar.js` `buildHolidaysMap` logic.
    *
    * @param {Array<Array<Object>>} yearArrays
    * @returns {Map<string, Object>}
@@ -102,12 +102,65 @@
     return map;
   }
 
+  /**
+   * PR-G.3.3: merge `holidaysAuto + holidaysOverrides` per-year per the new
+   * schema. Overrides win by date. `_suppress: true` removes the matching
+   * auto entry (admin can cancel a Hebcal-determined holiday).
+   *
+   * Backward compat: if `holidaysAuto` missing, falls back to `data.holidays`
+   * (PR-G.3.1 shape). Kept for one deploy cycle; removed in G.3.5 cleanup.
+   *
+   * @param {Array<{holidaysAuto?: Array, holidaysOverrides?: Array, holidays?: Array}>} yearDocs
+   * @returns {Map<string, Object>}
+   */
+  function _mergeAutoAndOverrides(yearDocs) {
+    // 1. Collect auto entries from all years
+    const autoArrays = [];
+    const overrideArrays = [];
+    for (const data of yearDocs || []) {
+      if (!data) {
+        continue;
+      }
+      const auto = Array.isArray(data.holidaysAuto)
+        ? data.holidaysAuto
+        : (Array.isArray(data.holidays) ? data.holidays : []);  // BC fallback
+      autoArrays.push(auto);
+      if (Array.isArray(data.holidaysOverrides)) {
+        overrideArrays.push(data.holidaysOverrides);
+      }
+    }
+
+    // 2. Build auto map via existing logic
+    const map = _mergeHolidaysArraysToMap(autoArrays);
+
+    // 3. Apply overrides: override wins by date; `_suppress: true` removes
+    for (const overrides of overrideArrays) {
+      for (const o of overrides) {
+        if (!o || typeof o.date !== 'string') {
+          continue;
+        }
+        if (o._suppress === true) {
+          map.delete(o.date);
+          continue;
+        }
+        if (!o._overrideMeta) {
+          console.warn('[holidays-cache] override missing _overrideMeta:', o.date, '— still applied');
+        }
+        map.set(o.date, o);
+      }
+    }
+
+    return map;
+  }
+
   function _engageFallback(reason) {
     if (window.WORK_HOURS_HOLIDAYS_FALLBACK_USED) {
       return;
     }
     window.WORK_HOURS_HOLIDAYS_FALLBACK_USED = true;
-    const map = _mergeHolidaysArraysToMap([EMBEDDED_FALLBACK_2026]);
+    // PR-G.3.3: route through the new merger for consistency (no overrides
+    // available offline — only auto fallback). The merger handles single-array.
+    const map = _mergeAutoAndOverrides([{ holidaysAuto: EMBEDDED_FALLBACK_2026 }]);
     window.WORK_HOURS_HOLIDAYS_MAP = map;
     console.warn('[holidays-cache] engaged embedded fallback:', reason);
     if (_resolveReady) {
@@ -117,8 +170,11 @@
   }
 
   function _rebuildMap() {
-    const arrays = Array.from(_holidaysByYear.values());
-    const map = _mergeHolidaysArraysToMap(arrays);
+    // PR-G.3.3: pass full year docs (with both holidaysAuto + holidaysOverrides)
+    // to the new merge. Each entry in `_holidaysByYear` is now the full doc
+    // data object, not just an array. See `_init()` snapshot handler.
+    const docs = Array.from(_holidaysByYear.values());
+    const map = _mergeAutoAndOverrides(docs);
     window.WORK_HOURS_HOLIDAYS_MAP = map;
     window.WORK_HOURS_HOLIDAYS_FALLBACK_USED = false; // real data overrides fallback
     if (_resolveReady) {
@@ -157,11 +213,16 @@
               return;
             }
             const data = snap.data() || {};
-            const holidays = Array.isArray(data.holidays) ? data.holidays : [];
-            _holidaysByYear.set(year, holidays);
+            // PR-G.3.3: store FULL doc (both holidaysAuto + holidaysOverrides
+            // + BC fallback `holidays`). Merge logic in `_mergeAutoAndOverrides`.
+            _holidaysByYear.set(year, data);
             _yearsLoaded.add(year);
             _rebuildMap();
-            console.log('[holidays-cache] loaded ' + year + ' (' + holidays.length + ' entries)');
+            const autoCount = Array.isArray(data.holidaysAuto)
+              ? data.holidaysAuto.length
+              : (Array.isArray(data.holidays) ? data.holidays.length : 0);
+            const ovCount = Array.isArray(data.holidaysOverrides) ? data.holidaysOverrides.length : 0;
+            console.log('[holidays-cache] loaded ' + year + ' (auto=' + autoCount + ', overrides=' + ovCount + ')');
           },
           (err) => {
             console.error('[holidays-cache] subscribe error year ' + year + ':', err.message);
@@ -213,6 +274,7 @@
   window.WORK_HOURS_HOLIDAYS_CACHE = Object.freeze({
     _test: {
       mergeHolidaysArraysToMap: _mergeHolidaysArraysToMap,
+      mergeAutoAndOverrides: _mergeAutoAndOverrides,  // PR-G.3.3
       EMBEDDED_FALLBACK_2026: EMBEDDED_FALLBACK_2026,
       // PR-G.3.2 (R8 mitigation): vitest fixture injection — tests set a
       // synthetic holidays map without needing Firestore mocks. Resolves the

--- a/firestore.rules
+++ b/firestore.rules
@@ -485,6 +485,17 @@ service cloud.firestore {
       allow write: if false; // Only Cloud Functions (Admin SDK)
     }
 
+    // PR-G.3.3 (2026-05-20): system_holidays collection.
+    // Populated by `holidaysCalendarSync` cron (Admin SDK). Frontend reads
+    // via Web SDK onSnapshot. Schema: { year, generatedAt, source,
+    // contentHash, holidaysAuto[], holidaysOverrides[] }. Overrides are
+    // managed via Firebase Console (manual) or future admin UI — never
+    // by end users.
+    match /system_holidays/{year} {
+      allow read: if isAuthenticated();
+      allow write: if false;  // Admin SDK + Firebase Console only
+    }
+
     // ❌ Default: Deny all other collections
     match /{document=**} {
       allow read, write: if false;

--- a/functions/scheduled/index.js
+++ b/functions/scheduled/index.js
@@ -562,24 +562,30 @@ function _hashHolidays(holidays) {
 
 async function syncHolidaysForYear(year) {
   const docRef = db.collection('system_holidays').doc(String(year));
-  const holidays = calendarLib.getHolidaysForYear(year);
-  const contentHash = _hashHolidays(holidays);
+  const holidaysAuto = calendarLib.getHolidaysForYear(year);
+  const contentHash = _hashHolidays(holidaysAuto);
 
   const existing = await docRef.get();
   if (existing.exists && existing.data().contentHash === contentHash) {
     console.log(`[holidaysCalendarSync] ${year} — hash matches, skip write`);
-    return { year, status: 'unchanged', count: holidays.length };
+    return { year, status: 'unchanged', count: holidaysAuto.length };
   }
 
+  // PR-G.3.3 (2026-05-20): write via `update` semantics (set with merge:true)
+  // so we NEVER touch `holidaysOverrides` (admin-managed). Cron owns only
+  // `holidaysAuto + contentHash + source + generatedAt + year`. Frontend
+  // merges auto + overrides on read.
+  // Important: do NOT write a `holidays` field — it's gone in the new schema.
+  // Backward compat is handled by frontend (`data.holidaysAuto || data.holidays`).
   await docRef.set({
     year,
     generatedAt: admin.firestore.FieldValue.serverTimestamp(),
     source: `@hebcal/core@${calendarLib.HEBCAL_VERSION}`,
-    holidays,
+    holidaysAuto,
     contentHash
-  });
-  console.log(`[holidaysCalendarSync] ${year} — wrote ${holidays.length} holidays`);
-  return { year, status: existing.exists ? 'updated' : 'created', count: holidays.length };
+  }, { merge: true });
+  console.log(`[holidaysCalendarSync] ${year} — wrote ${holidaysAuto.length} auto holidays (overrides preserved)`);
+  return { year, status: existing.exists ? 'updated' : 'created', count: holidaysAuto.length };
 }
 
 const holidaysCalendarSync = onSchedule({

--- a/functions/scripts/seedHolidays.js
+++ b/functions/scripts/seedHolidays.js
@@ -41,24 +41,25 @@ async function seed() {
   console.log(`Source: @hebcal/core@${calendarLib.HEBCAL_VERSION}`);
 
   for (const year of years) {
-    const holidays = calendarLib.getHolidaysForYear(year);
-    const contentHash = hashHolidays(holidays);
+    const holidaysAuto = calendarLib.getHolidaysForYear(year);
+    const contentHash = hashHolidays(holidaysAuto);
     const docRef = db.collection('system_holidays').doc(String(year));
 
     const existing = await docRef.get();
     if (existing.exists && existing.data().contentHash === contentHash) {
-      console.log(`  ${year}: hash matches (${holidays.length} holidays) — skipping`);
+      console.log(`  ${year}: hash matches (${holidaysAuto.length} auto holidays) — skipping`);
       continue;
     }
 
+    // PR-G.3.3: merge write — never destroys `holidaysOverrides` if present.
     await docRef.set({
       year,
       generatedAt: admin.firestore.FieldValue.serverTimestamp(),
       source: `@hebcal/core@${calendarLib.HEBCAL_VERSION}`,
-      holidays,
+      holidaysAuto,
       contentHash
-    });
-    console.log(`  ${year}: ${existing.exists ? 'updated' : 'created'} (${holidays.length} holidays)`);
+    }, { merge: true });
+    console.log(`  ${year}: ${existing.exists ? 'updated' : 'created'} (${holidaysAuto.length} auto holidays, any overrides preserved)`);
   }
 
   console.log('Done.');

--- a/functions/tests/holidays-cron-merge.test.js
+++ b/functions/tests/holidays-cron-merge.test.js
@@ -1,0 +1,90 @@
+/**
+ * Tests for `syncHolidaysForYear` after PR-G.3.3.
+ *
+ * Verifies that cron writes via `set({merge: true})` semantics — preserving
+ * any existing `holidaysOverrides` on the doc.
+ */
+
+// Mock firebase-admin BEFORE requiring scheduled module
+const mockDocRef = {
+  get: jest.fn(),
+  set: jest.fn().mockResolvedValue(undefined)
+};
+const mockDb = {
+  collection: jest.fn().mockReturnValue({
+    doc: jest.fn().mockReturnValue(mockDocRef)
+  })
+};
+
+jest.mock('firebase-admin', () => ({
+  initializeApp: jest.fn(),
+  firestore: Object.assign(jest.fn(() => mockDb), {
+    FieldValue: { serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'), increment: jest.fn() },
+    Timestamp: { fromDate: jest.fn((d) => ({ _date: d.toISOString() })) }
+  })
+}));
+
+jest.mock('firebase-functions/v2/scheduler', () => ({
+  onSchedule: jest.fn((config, handler) => handler)
+}));
+
+const scheduled = require('../scheduled');
+const { syncHolidaysForYear, _hashHolidays } = scheduled._test;
+
+describe('PR-G.3.3 — syncHolidaysForYear writes holidaysAuto with merge', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDocRef.get.mockReset();
+    mockDocRef.set.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('writes holidaysAuto field, NOT holidays field', async () => {
+    mockDocRef.get.mockResolvedValue({ exists: false, data: () => null });
+    await syncHolidaysForYear(2026);
+    expect(mockDocRef.set).toHaveBeenCalledTimes(1);
+    const payload = mockDocRef.set.mock.calls[0][0];
+    expect(payload).toHaveProperty('holidaysAuto');
+    expect(payload).not.toHaveProperty('holidays');
+    expect(Array.isArray(payload.holidaysAuto)).toBe(true);
+    expect(payload.holidaysAuto.length).toBeGreaterThan(20);
+  });
+
+  it('uses merge: true write semantics (never destroys overrides)', async () => {
+    mockDocRef.get.mockResolvedValue({ exists: false, data: () => null });
+    await syncHolidaysForYear(2026);
+    const opts = mockDocRef.set.mock.calls[0][1];
+    expect(opts).toEqual({ merge: true });
+  });
+
+  it('skips write when contentHash matches existing doc', async () => {
+    const calendarLib = require('../shared/calendar');
+    const sampleHolidays = calendarLib.getHolidaysForYear(2026);
+    const matchingHash = _hashHolidays(sampleHolidays);
+    mockDocRef.get.mockResolvedValue({
+      exists: true,
+      data: () => ({ contentHash: matchingHash })
+    });
+    const result = await syncHolidaysForYear(2026);
+    expect(mockDocRef.set).not.toHaveBeenCalled();
+    expect(result.status).toBe('unchanged');
+  });
+
+  it('contentHash covers ONLY holidaysAuto (not overrides)', async () => {
+    const calendarLib = require('../shared/calendar');
+    const expectedHash = _hashHolidays(calendarLib.getHolidaysForYear(2026));
+    mockDocRef.get.mockResolvedValue({ exists: false, data: () => null });
+    await syncHolidaysForYear(2026);
+    const payload = mockDocRef.set.mock.calls[0][0];
+    expect(payload.contentHash).toBe(expectedHash);
+  });
+
+  it('payload contains required metadata fields', async () => {
+    mockDocRef.get.mockResolvedValue({ exists: false, data: () => null });
+    await syncHolidaysForYear(2027);
+    const payload = mockDocRef.set.mock.calls[0][0];
+    expect(payload.year).toBe(2027);
+    expect(payload.generatedAt).toBe('SERVER_TIMESTAMP');
+    expect(payload.source).toMatch(/^@hebcal\/core@/);
+    expect(payload.contentHash).toBeDefined();
+  });
+});

--- a/tests/unit/user-app/holidays-cache-merge.test.ts
+++ b/tests/unit/user-app/holidays-cache-merge.test.ts
@@ -13,7 +13,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 
 declare global {
 
@@ -116,6 +116,90 @@ describe('PR-G.3.1 — _mergeHolidaysArraysToMap', () => {
     ];
     const m = merge([arr]);
     expect(m.size).toBe(1);
+  });
+});
+
+describe('PR-G.3.3 — _mergeAutoAndOverrides (auto + overrides + suppress)', () => {
+  let mergeAO: (docs: Array<any>) => Map<string, any>;
+  beforeAll(() => {
+    mergeAO = (globalThis as any).WORK_HOURS_HOLIDAYS_CACHE._test.mergeAutoAndOverrides;
+  });
+
+  it('returns empty Map for no docs', () => {
+    const m = mergeAO([]);
+    expect(m.size).toBe(0);
+  });
+
+  it('auto-only doc: builds from holidaysAuto', () => {
+    const doc = { holidaysAuto: [{ date: '2026-04-02', isWorking: false, isHalfDay: false }] };
+    const m = mergeAO([doc]);
+    expect(m.size).toBe(1);
+    expect(m.get('2026-04-02').isWorking).toBe(false);
+  });
+
+  it('backward compat: falls back to data.holidays if holidaysAuto missing', () => {
+    const doc = { holidays: [{ date: '2026-04-02', isWorking: false, isHalfDay: false }] };
+    const m = mergeAO([doc]);
+    expect(m.size).toBe(1);
+    expect(m.get('2026-04-02').isWorking).toBe(false);
+  });
+
+  it('override wins over auto on same date', () => {
+    const doc = {
+      holidaysAuto: [{ date: '2026-04-22', isWorking: false, isHalfDay: false, nameEn: 'Yom HaAtzma\'ut auto' }],
+      holidaysOverrides: [{
+        date: '2026-04-22',
+        isWorking: true,
+        isHalfDay: false,
+        nameEn: 'Yom HaAtzma\'ut OVERRIDE',
+        _overrideMeta: { by: 'haim@gh', at: '2026-04-15T10:00:00Z', reason: 'Office decided to work' }
+      }]
+    };
+    const m = mergeAO([doc]);
+    expect(m.get('2026-04-22').isWorking).toBe(true);
+    expect(m.get('2026-04-22').nameEn).toBe('Yom HaAtzma\'ut OVERRIDE');
+  });
+
+  it('_suppress: true removes the auto entry', () => {
+    const doc = {
+      holidaysAuto: [{ date: '2026-04-22', isWorking: false, isHalfDay: false, nameEn: 'Yom HaAtzma\'ut' }],
+      holidaysOverrides: [{
+        date: '2026-04-22',
+        _suppress: true,
+        _overrideMeta: { by: 'haim@gh', at: '2026-04-15T10:00:00Z', reason: 'Not observed' }
+      }]
+    };
+    const m = mergeAO([doc]);
+    expect(m.has('2026-04-22')).toBe(false);
+  });
+
+  it('override without _overrideMeta still applied (warn-only)', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const doc = {
+      holidaysAuto: [],
+      holidaysOverrides: [{ date: '2026-04-22', isWorking: false, isHalfDay: false }]
+    };
+    const m = mergeAO([doc]);
+    expect(m.has('2026-04-22')).toBe(true);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('multi-year: merges auto + overrides across years', () => {
+    const docA = { holidaysAuto: [{ date: '2026-04-02', isWorking: false, isHalfDay: false }] };
+    const docB = {
+      holidaysAuto: [{ date: '2027-04-22', isWorking: false, isHalfDay: false }],
+      holidaysOverrides: [{
+        date: '2027-04-22',
+        isWorking: true,
+        isHalfDay: false,
+        _overrideMeta: { by: 'haim@gh', at: '2027-01-01T00:00:00Z', reason: 'Test' }
+      }]
+    };
+    const m = mergeAO([docA, docB]);
+    expect(m.size).toBe(2);
+    expect(m.get('2026-04-02').isWorking).toBe(false);  // auto
+    expect(m.get('2027-04-22').isWorking).toBe(true);   // override
   });
 });
 


### PR DESCRIPTION
## Summary

Splits `system_holidays/{year}` into disjoint cron-owned and admin-owned fields so admin overrides survive cron runs.

- **`holidaysAuto[]`** — cron writes via `set({merge: true})`. Source: `@hebcal/core`.
- **`holidaysOverrides[]`** — admin writes via Firebase Console only. Survives cron forever.
- Frontend cache merges auto + overrides on snapshot (override wins; `_suppress: true` removes; `_overrideMeta {by, at, reason}` audited — warn-only if missing).

## Why this shape

Original plan kept a legacy `holidays` field as a merged-view alias. **devils-advocate flagged it as a footgun**: cron's `set()` would overwrite the merged view with stale data on the next run. Final schema removes the alias entirely — frontend merges on read.

## Schema

```
system_holidays/{year}:
  year: 2026
  source: "@hebcal/core@3.50.4"
  generatedAt: <timestamp>
  contentHash: <sha1 of holidaysAuto>  ← skips write if unchanged
  holidaysAuto: [...]      ← cron-owned (set merge:true)
  holidaysOverrides: [...] ← admin-owned (Console)
```

Override entry shape:
```js
{
  date: "2026-04-22",
  isWorking: true,
  isHalfDay: false,
  nameEn: "Yom HaAtzma'ut (working)",
  _suppress?: true,                   // remove the auto entry entirely
  _overrideMeta: { by, at, reason }   // warn-only if missing
}
```

## Changes

- `functions/scheduled/index.js` — writes `holidaysAuto` via `set({merge:true})`. `contentHash` covers only `holidaysAuto`. Cron NEVER touches `holidaysOverrides`.
- `functions/scripts/seedHolidays.js` — mirror change for one-shot seed.
- `apps/{user,admin}/js/shared/holidays-cache.js` — new `_mergeAutoAndOverrides` helper; snapshot stores full doc; BC fallback reads `data.holidays` for one deploy cycle (removed in PR-G.3.5).
- `firestore.rules` — explicit rule for `system_holidays/{year}`: `read: if isAuthenticated()`, `write: if false`. Codifies state that was added out-of-band in Console during PR-G.3.1.
- `functions/tests/holidays-cron-merge.test.js` — 5 new tests verify field name (`holidaysAuto` not `holidays`), `merge:true` semantics, hash-based skip, payload shape.
- `tests/unit/user-app/holidays-cache-merge.test.ts` — 7 new tests for the merger (auto-only, BC fallback, override-wins, `_suppress`, missing `_overrideMeta` warn, multi-year).
- `.claude/rubrics/pr-g-3-3.md` — grader rubric.

## Behavioral changes

- Cron NO LONGER writes the legacy `holidays` field. Pre-G.3.3 docs that still carry `holidays` are read via BC fallback in the cache for one deploy cycle.
- Admin overrides written in Firebase Console at `holidaysOverrides` survive subsequent cron runs.

## Devils-advocate verdict (mitigations applied)

- **R1** sync-from-async race → live read pattern in consumers (no cache).
- **R2** cron clobbering overrides → `set({merge:true})` + disjoint fields.
- **R5** override audit → `_overrideMeta` field + warn-only enforcement.
- **R9** legacy `holidays` alias footgun → removed entirely.
- **R10** BC during deploy → reader fallback only, removed in PR-G.3.5.

**Deferred to PR-G.3.4:**
- **R6** orphan override detection (override on date with no auto entry).
- **R7** out-of-window override rejection (override on date outside year).

## Outcomes Grader

**PASS_WITH_WARNINGS** — 10/10 MUST pass; S2 (inline Firebase Console override example in cache header) deferred — non-blocking documentation polish.

## Test plan

- [x] Functions Jest 531 pass (+5 new in `holidays-cron-merge.test.js`)
- [x] Root Vitest 247 pass / 2 skipped (+7 new in `holidays-cache-merge.test.ts`)
- [x] Lint 0 errors
- [ ] DEV smoke after merge: confirm `WORK_HOURS_HOLIDAYS_FALLBACK_USED === false`
- [ ] DEV smoke: write a test override in `system_holidays/2026.holidaysOverrides` via Console → verify cache picks it up live
- [ ] DEV smoke: trigger cron manually → verify override survives, `holidaysAuto` updated, `contentHash` matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)