### PR TITLE
fix(whatsapp-bot): TZ-safe today-lookup using Asia/Jerusalem helpers (PR-G.3.8)

### DIFF
--- a/.claude/rubrics/pr-g-3-8.md
+++ b/.claude/rubrics/pr-g-3-8.md
@@ -1,0 +1,58 @@
+# Rubric — PR-G.3.8: fix TZ bug in WhatsApp Bot today-lookup
+
+**Scope:** `functions/src/whatsapp-bot/WhatsAppBot.js` (3 sites) + new helpers in `functions/shared/calendar.js` + tests. Backend-only (Cloud Function `whatsappWebhook`). No firestore.rules, no frontend, no migrations.
+
+**Origin:** Surfaced by `completeness-checker` during PR-G.3.7 investigation 2026-05-24. Same antipattern class as PR-G.3.7 (calendar.js TZ bug), different module + different shape.
+
+**Bug:**
+- `WhatsAppBot.js:996` (`showAllEmployeesTimesheets`) + `:1069` (`showEmployeeTimesheets`): `new Date().toISOString().substring(0, 10)` returns UTC date. Cloud Functions runs in UTC; between 00:00–03:00 IL (winter) / 00:00–04:00 IL (DST), query returns yesterday's date → "אין רישומי שעות להיום" wrongly.
+- `WhatsAppBot.js:652` (`showStats`): `new Date().setHours(0,0,0,0)` produces UTC midnight; Firestore Timestamp `where('approvedAt','>=',today)` skews `approvedToday`/`rejectedToday` counts by 3–4h.
+
+**Risk:** Zero data risk (read-only Firestore queries). Worst-case wrong fix = wrong response text. No writes, no aggregates, no audit.
+
+## MUST (10) — blocking
+
+1. **`todayInJerusalemYMD()` helper added + exported.** New function in `functions/shared/calendar.js` using `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jerusalem' })`. *Evidence:* function defined; exported in `module.exports` and `_test`.
+
+2. **`startOfTodayInJerusalem()` helper added + exported.** New function returning `Date` for IL midnight, suitable for Timestamp `>=` queries. Honors DST via probe-derived offset (not hardcoded). *Evidence:* function defined + exported.
+
+3. **`WhatsAppBot.js:996` fixed.** `showAllEmployeesTimesheets` uses `todayInJerusalemYMD()`. *Evidence:* grep file shows zero `.toISOString().substring` / `.toISOString().slice` after fix.
+
+4. **`WhatsAppBot.js:1069` fixed.** `showEmployeeTimesheets` uses `todayInJerusalemYMD()`. *Evidence:* same grep.
+
+5. **`WhatsAppBot.js:652` (showStats) fixed.** Uses `startOfTodayInJerusalem()`. *Evidence:* grep file shows zero `setHours(0,0,0,0)` after fix.
+
+6. **WhatsAppBot.js imports helpers.** `const { todayInJerusalemYMD, startOfTodayInJerusalem } = require('../../shared/calendar');` at top of file. *Evidence:* require line present near other requires.
+
+7. **TZ-matrix tests prove invariance.** New `functions/tests/whatsapp-bot-tz.test.js` runs helpers under simulated UTC, Asia/Jerusalem, America/Los_Angeles, Pacific/Kiritimati. Critical case: 00:30 IL after UTC midnight returns IL today, not UTC yesterday. *Evidence:* file exists; tests pass.
+
+8. **Existing tests in `quicklog-date-type.test.js` no longer encode the bug.** 4 assertions (`new Date().toISOString().substring(0,10)` as expected-value) rewritten to use the new helper as source of truth. *Evidence:* `git diff functions/tests/quicklog-date-type.test.js` shows replacements with `PR-G.3.8` comment.
+
+9. **All existing tests pass.** Jest + Vitest unchanged. No regression in functions suite. *Evidence:* `npx jest` green.
+
+10. **No data migration, no schema change.** Read-only fix on production query path. *Evidence:* `git diff` shows zero changes to Firestore schemas, rules, or migration scripts.
+
+## SHOULD (4) — non-blocking
+
+1. **Inline comment at import warns against UTC antipattern.** Helps future maintainers see why helper exists. *Evidence:* comment block above `require('../../shared/calendar')` in WhatsAppBot.js.
+
+2. **JSDoc on `todayInJerusalemYMD` + `startOfTodayInJerusalem`.** Explain the bug class and the fix pattern. *Evidence:* JSDoc blocks above each function.
+
+3. **Header at `WhatsAppBot.js:1035` stays consistent with query.** Header uses `toLocaleDateString('he-IL')` (already TZ-correct via locale default); after fix, header day == query day. *Evidence:* no change to line 1035 (already correct).
+
+4. **PR body documents 3 sibling PRs deferred.** G.3.9 (functions/timesheet/index.js WRITE path — HIGH severity), G.3.10 (apps/user-app readers), G.3.11 (ESLint ban + remaining admin sites). *Evidence:* PR body has "Sibling PRs" section.
+
+## Out of scope (deferred)
+
+- **G.3.9** — `functions/timesheet/index.js:160,166` (WRITE path, HIGH severity) — different module + different review weight
+- **G.3.10** — `apps/user-app/js/main.js`, `daily-meter.js`, `ai-context-builder.js` — frontend, different deploy path (Netlify, not Cloud Functions)
+- **G.3.11** — ESLint `no-restricted-syntax` rule banning `.toISOString().slice(0,N)` + remaining sites in `functions/src/deletion/audit.js`, `functions/admin/master-admin-wrappers.js`, `apps/admin-panel/`
+- WhatsApp dist artifacts (rebuilt by deploy)
+- Cron / changefeed redeploys (none affected)
+
+## Test outputs required
+
+- Jest: `npx jest` PASS for all suites. New `whatsapp-bot-tz.test.js` adds ~6 tests.
+- Vitest: unchanged (no frontend touched).
+- Lint: 0 errors.
+- Manual smoke (post-deploy): from admin WhatsApp number after 00:00 IL, send "תפריט" → choose timesheets menu → verify response shows TODAY's entries (not yesterday's).

--- a/functions/shared/calendar.js
+++ b/functions/shared/calendar.js
@@ -90,6 +90,78 @@ function _hdateToISO(hdate) {
 }
 
 /**
+ * PR-G.3.8 (2026-05-24): canonical "today in Asia/Jerusalem" helpers for
+ * any Cloud Function or Node code that needs to query Firestore for IL
+ * "today" data.
+ *
+ * Bug class: `new Date().toISOString().slice(0,10)` and
+ * `new Date().setHours(0,0,0,0)` use the host's idea of "today" — which on
+ * Cloud Functions (UTC) is wrong for Asia/Jerusalem between 00:00-03:00
+ * local time (winter) or 00:00-04:00 (DST). Result: queries return
+ * yesterday's data, or Timestamp ranges miss 3-4 hours of IL "today".
+ *
+ * Fix pattern:
+ *   - For string `where('date','==',X)` queries → use `todayInJerusalemYMD()`
+ *   - For Timestamp `where('approvedAt','>=',X)` queries → use `startOfTodayInJerusalem()`
+ *
+ * Implementation uses `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jerusalem' })`
+ * which yields `YYYY-MM-DD` regardless of host TZ. `en-CA` chosen over
+ * `sv-SE` for broader Intl coverage.
+ *
+ * NEVER use `.toISOString().slice(0,10)` or `setHours(0,0,0,0)` on a
+ * fresh `new Date()` for IL-tied logic — that's the bug this helper fixes.
+ */
+
+const _JERUSALEM_DATE_FMT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Jerusalem',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit'
+});
+
+/**
+ * Return today's date in Asia/Jerusalem as `YYYY-MM-DD`.
+ *
+ * @returns {string} e.g. `'2026-05-24'`
+ */
+function todayInJerusalemYMD() {
+  // en-CA formatter yields `YYYY-MM-DD` directly.
+  return _JERUSALEM_DATE_FMT.format(new Date());
+}
+
+/**
+ * Return a `Date` object representing 00:00:00 of today in Asia/Jerusalem,
+ * suitable for Firestore Timestamp `where('field','>=',X)` queries.
+ *
+ * @returns {Date}
+ */
+function startOfTodayInJerusalem() {
+  const ymd = todayInJerusalemYMD(); // 'YYYY-MM-DD'
+  // Construct from local IL fields → produce instant for 00:00 IL.
+  // We cannot trust `new Date('YYYY-MM-DDT00:00:00')` (parses as host-local),
+  // so build the UTC instant manually: IL midnight = UTC midnight − offset.
+  // Offset: derive from a probe date so we honor DST automatically.
+  const [y, m, d] = ymd.split('-').map(Number);
+  // Probe: noon IL is unambiguous (never crosses DST boundary within the
+  // hour). Compute its UTC ms and derive the IL UTC offset for that day.
+  const probeUTC = Date.UTC(y, m - 1, d, 12, 0, 0);
+  const probeAsIL = _JERUSALEM_DATE_FMT.formatToParts(new Date(probeUTC));
+  // We just need the offset. Re-format the probe as IL time-of-day.
+  const ilHourFmt = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Jerusalem',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  });
+  const parts = ilHourFmt.format(new Date(probeUTC)).split(':');
+  const ilHour = Number(parts[0]);
+  // probeUTC is 12:00 UTC. If IL shows e.g. "15:00", offset = +3h.
+  const offsetHours = ilHour - 12;
+  // IL midnight = UTC midnight − offsetHours
+  return new Date(Date.UTC(y, m - 1, d, -offsetHours, 0, 0));
+}
+
+/**
  * Modern (Israel-state) days where the office is CLOSED.
  * Other modern days like Family Day, Hebrew Language Day, Yom HaAliyah,
  * Herzl Day, Yom Yerushalayim → not in this set → open by default.
@@ -338,11 +410,16 @@ module.exports = {
   buildHolidaysMap,
   isWorkday,
   getDayInfo,
+  // PR-G.3.8: TZ-safe "today" helpers for Cloud Functions
+  todayInJerusalemYMD,
+  startOfTodayInJerusalem,
   // Exported for unit tests
   _test: {
     classifyEvent,
     _dayOfWeekUTC,
     _hdateToISO,  // PR-G.3.7
+    todayInJerusalemYMD,        // PR-G.3.8
+    startOfTodayInJerusalem,    // PR-G.3.8
     CLOSED_MODERN_BASENAMES,
     CLOSED_MINOR_BASENAMES
   }

--- a/functions/src/whatsapp-bot/WhatsAppBot.js
+++ b/functions/src/whatsapp-bot/WhatsAppBot.js
@@ -8,6 +8,11 @@
 
 const admin = require('firebase-admin');
 const SessionManager = require('./SessionManager');
+// PR-G.3.8: TZ-safe "today" helpers — DO NOT replace with
+// `new Date().toISOString().slice(0,10)` or `new Date().setHours(0,0,0,0)`.
+// Cloud Functions runs in UTC; those patterns return yesterday's date
+// for IL clock 00:00-03:00 (winter) / 00:00-04:00 (DST).
+const { todayInJerusalemYMD, startOfTodayInJerusalem } = require('../../shared/calendar');
 
 class WhatsAppBot {
     constructor() {
@@ -649,8 +654,9 @@ class WhatsAppBot {
      */
     async showStats(userInfo, session) {
         try {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
+            // PR-G.3.8: IL midnight (not host UTC midnight) — skews
+            // approvedToday/rejectedToday by 3-4h on Cloud Functions otherwise.
+            const today = startOfTodayInJerusalem();
 
             const [approvedToday, rejectedToday, pendingTotal] = await Promise.all([
                 // אושרו היום
@@ -992,8 +998,9 @@ class WhatsAppBot {
      */
     async showAllEmployeesTimesheets() {
         try {
-            // date field is stored as "YYYY-MM-DD" string — query with string match
-            const todayStr = new Date().toISOString().substring(0, 10);
+            // date field is stored as "YYYY-MM-DD" string — query with string match.
+            // PR-G.3.8: use Asia/Jerusalem (not host UTC) for "today".
+            const todayStr = todayInJerusalemYMD();
 
             // קבל את כל רישומי השעות של היום
             const timesheetsSnapshot = await this.db.collection('timesheet_entries')
@@ -1065,8 +1072,9 @@ class WhatsAppBot {
      */
     async showEmployeeTimesheets(employee) {
         try {
-            // date field is stored as "YYYY-MM-DD" string — query with string match
-            const todayStr = new Date().toISOString().substring(0, 10);
+            // date field is stored as "YYYY-MM-DD" string — query with string match.
+            // PR-G.3.8: use Asia/Jerusalem (not host UTC) for "today".
+            const todayStr = todayInJerusalemYMD();
 
             // קבל רישומי שעות של העובד להיום
             const timesheetsSnapshot = await this.db.collection('timesheet_entries')

--- a/functions/tests/quicklog-date-type.test.js
+++ b/functions/tests/quicklog-date-type.test.js
@@ -383,7 +383,12 @@ describe('WhatsApp Bot — date query and display', () => {
   // ───────────────────────────────────────────────────────────
 
   test('showAllEmployeesTimesheets queries date with "YYYY-MM-DD" string', async () => {
-    const todayStr = new Date().toISOString().substring(0, 10);
+    // PR-G.3.8: source-of-truth is the same helper the bot uses, NOT
+    // `new Date().toISOString().substring(0,10)` — the bug we just fixed.
+    // Comparing against the helper means the test passes on CI (UTC) AND
+    // local dev machines (Asia/Jerusalem) without encoding the bug.
+    const { todayInJerusalemYMD } = require('../shared/calendar');
+    const todayStr = todayInJerusalemYMD();
 
     const mockGet = jest.fn().mockResolvedValue({ empty: true, forEach: jest.fn() });
     const mockWhere = jest.fn().mockReturnValue({ get: mockGet });
@@ -408,7 +413,9 @@ describe('WhatsApp Bot — date query and display', () => {
   // ───────────────────────────────────────────────────────────
 
   test('showEmployeeTimesheets queries date with "YYYY-MM-DD" string', async () => {
-    const todayStr = new Date().toISOString().substring(0, 10);
+    // PR-G.3.8: source-of-truth via helper (see comment in test above).
+    const { todayInJerusalemYMD } = require('../shared/calendar');
+    const todayStr = todayInJerusalemYMD();
 
     const mockGet = jest.fn().mockResolvedValue({ empty: true, forEach: jest.fn() });
     const mockWhere2 = jest.fn().mockReturnValue({ get: mockGet });
@@ -434,7 +441,10 @@ describe('WhatsApp Bot — date query and display', () => {
   // ───────────────────────────────────────────────────────────
 
   test('showEmployeeTimesheets handles entry.date as "YYYY-MM-DD" string', async () => {
-    const todayStr = new Date().toISOString().substring(0, 10);
+    // PR-G.3.8: todayStr unused in this test (display path); kept for clarity.
+    const { todayInJerusalemYMD } = require('../shared/calendar');
+    const todayStr = todayInJerusalemYMD();
+    void todayStr;
     const entries = [{
       data: () => ({
         minutes: 60,
@@ -464,7 +474,10 @@ describe('WhatsApp Bot — date query and display', () => {
   });
 
   test('showEmployeeTimesheets handles entry.date as legacy Timestamp', async () => {
-    const todayStr = new Date().toISOString().substring(0, 10);
+    // PR-G.3.8: todayStr unused in this test (display path); kept for clarity.
+    const { todayInJerusalemYMD } = require('../shared/calendar');
+    const todayStr = todayInJerusalemYMD();
+    void todayStr;
     const entries = [{
       data: () => ({
         minutes: 45,

--- a/functions/tests/whatsapp-bot-tz.test.js
+++ b/functions/tests/whatsapp-bot-tz.test.js
@@ -1,0 +1,178 @@
+/**
+ * PR-G.3.8: TZ-invariance tests for WhatsApp Bot "today" helpers.
+ *
+ * The helpers `todayInJerusalemYMD()` and `startOfTodayInJerusalem()` live
+ * in `functions/shared/calendar.js`. They must produce the SAME logical
+ * Asia/Jerusalem day regardless of the host process timezone (process.env.TZ).
+ *
+ * Tests run the helpers under simulated TZs:
+ *   - UTC                  (Cloud Functions default)
+ *   - Asia/Jerusalem       (developer machine)
+ *   - America/Los_Angeles  (UTC-7/-8, behind IL)
+ *   - Pacific/Kiritimati   (UTC+14, ahead of IL)
+ *
+ * Edge case validated: when host clock is on day N but IL clock is on day
+ * N+1 (or N-1), the helper returns the IL day — not the host day. This is
+ * the exact bug fixed in WhatsAppBot.js:996, :1069, :652.
+ */
+
+describe('todayInJerusalemYMD() — TZ invariance', () => {
+  const TZS = ['UTC', 'Asia/Jerusalem', 'America/Los_Angeles', 'Pacific/Kiritimati'];
+
+  function runUnderTZ(tz, fn) {
+    const original = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+      jest.resetModules();
+      return fn();
+    } finally {
+      process.env.TZ = original;
+      jest.resetModules();
+    }
+  }
+
+  test.each(TZS)('returns YYYY-MM-DD string under TZ=%s', (tz) => {
+    runUnderTZ(tz, () => {
+      const { todayInJerusalemYMD } = require('../shared/calendar');
+      const out = todayInJerusalemYMD();
+      expect(typeof out).toBe('string');
+      expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  test('all TZs produce the SAME IL day for the same UTC instant', () => {
+    // Pin "now" to a specific UTC instant — we'll mock Date for each TZ.
+    // 2026-05-24T22:30:00Z = 2026-05-25 01:30 in Asia/Jerusalem (DST, UTC+3).
+    // Under UTC the host thinks it's still 2026-05-24, but IL is already 2026-05-25.
+    const PINNED_UTC = new Date('2026-05-24T22:30:00.000Z');
+
+    const results = TZS.map((tz) => {
+      return runUnderTZ(tz, () => {
+        // Override Date constructor to return the pinned instant.
+        const RealDate = Date;
+        global.Date = class extends RealDate {
+          constructor(...args) {
+            if (args.length === 0) {
+              super(PINNED_UTC.getTime());
+            } else {
+              super(...args);
+            }
+          }
+          static now() { return PINNED_UTC.getTime(); }
+        };
+        try {
+          const { todayInJerusalemYMD } = require('../shared/calendar');
+          return { tz, out: todayInJerusalemYMD() };
+        } finally {
+          global.Date = RealDate;
+        }
+      });
+    });
+
+    // All four must agree, and all must say 2026-05-25 (the IL day for that UTC instant).
+    const unique = new Set(results.map((r) => r.out));
+    expect(unique.size).toBe(1);
+    expect(results[0].out).toBe('2026-05-25');
+  });
+
+  test('CRITICAL: 00:30 IL after UTC midnight returns IL today, not UTC yesterday', () => {
+    // Exact bug scenario: between 00:00-03:00 IL (winter) / 04:00 (DST),
+    // host UTC clock is still on previous day. Old code returned UTC date.
+    // New code must return IL date.
+    //
+    // 2026-01-15T22:30:00Z (winter) = 2026-01-16 00:30 IL (UTC+2, no DST).
+    const PINNED_UTC = new Date('2026-01-15T22:30:00.000Z');
+
+    runUnderTZ('UTC', () => {
+      const RealDate = Date;
+      global.Date = class extends RealDate {
+        constructor(...args) {
+          if (args.length === 0) super(PINNED_UTC.getTime());
+          else super(...args);
+        }
+        static now() { return PINNED_UTC.getTime(); }
+      };
+      try {
+        const { todayInJerusalemYMD } = require('../shared/calendar');
+        const out = todayInJerusalemYMD();
+        // Buggy old impl would return '2026-01-15' (UTC day).
+        // Fixed impl returns '2026-01-16' (IL day).
+        expect(out).toBe('2026-01-16');
+      } finally {
+        global.Date = RealDate;
+      }
+    });
+  });
+});
+
+describe('startOfTodayInJerusalem() — produces correct IL midnight Date', () => {
+  test('returns a Date object', () => {
+    const { startOfTodayInJerusalem } = require('../shared/calendar');
+    const d = startOfTodayInJerusalem();
+    expect(d).toBeInstanceOf(Date);
+    expect(Number.isFinite(d.getTime())).toBe(true);
+  });
+
+  test('IL midnight is exactly the start of the IL day (DST winter 2026-01)', () => {
+    // 2026-01-15 IL midnight = 2026-01-14T22:00:00Z (UTC+2 winter).
+    // We pin a UTC instant during 2026-01-15 IL, expect that exact UTC ms.
+    const PINNED_UTC = new Date('2026-01-15T12:00:00.000Z'); // 14:00 IL
+    const RealDate = Date;
+    global.Date = class extends RealDate {
+      constructor(...args) {
+        if (args.length === 0) super(PINNED_UTC.getTime());
+        else super(...args);
+      }
+      static now() { return PINNED_UTC.getTime(); }
+      static UTC = RealDate.UTC;
+    };
+    try {
+      jest.resetModules();
+      const { startOfTodayInJerusalem } = require('../shared/calendar');
+      const d = startOfTodayInJerusalem();
+      // Expected: 2026-01-14T22:00:00Z (IL midnight in winter UTC+2).
+      expect(d.toISOString()).toBe('2026-01-14T22:00:00.000Z');
+    } finally {
+      global.Date = RealDate;
+      jest.resetModules();
+    }
+  });
+
+  test('IL midnight in DST summer 2026-07 is UTC-3 offset', () => {
+    // 2026-07-15 IL midnight = 2026-07-14T21:00:00Z (UTC+3 DST).
+    const PINNED_UTC = new Date('2026-07-15T12:00:00.000Z'); // 15:00 IL DST
+    const RealDate = Date;
+    global.Date = class extends RealDate {
+      constructor(...args) {
+        if (args.length === 0) super(PINNED_UTC.getTime());
+        else super(...args);
+      }
+      static now() { return PINNED_UTC.getTime(); }
+      static UTC = RealDate.UTC;
+    };
+    try {
+      jest.resetModules();
+      const { startOfTodayInJerusalem } = require('../shared/calendar');
+      const d = startOfTodayInJerusalem();
+      expect(d.toISOString()).toBe('2026-07-14T21:00:00.000Z');
+    } finally {
+      global.Date = RealDate;
+      jest.resetModules();
+    }
+  });
+
+  test('IL midnight matches the YMD from todayInJerusalemYMD', () => {
+    // Sanity: both helpers must agree on the IL day.
+    const { todayInJerusalemYMD, startOfTodayInJerusalem } = require('../shared/calendar');
+    const ymd = todayInJerusalemYMD();
+    const midnight = startOfTodayInJerusalem();
+    // Read back the YMD of midnight via the IL formatter — must equal `ymd`.
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'Asia/Jerusalem',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    });
+    expect(fmt.format(midnight)).toBe(ymd);
+  });
+});


### PR DESCRIPTION
## Summary

Fix TZ bug in WhatsApp bot "today" lookups. Cloud Functions runs in UTC; between 00:00-03:00 IL (winter) / 00:00-04:00 (DST), bot returned **yesterday's** data:
- `showAllEmployeesTimesheets()` / `showEmployeeTimesheets()` → empty "אין רישומי שעות להיום"
- `showStats()` → 3-4h skew on `approvedToday` / `rejectedToday` Timestamp range

Fix = 2 new helpers in `functions/shared/calendar.js` (`todayInJerusalemYMD`, `startOfTodayInJerusalem`) using `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jerusalem' })` + probe-derived DST offset. All 3 antipattern sites in WhatsAppBot.js replaced with helper calls.

## Changes

- **`functions/shared/calendar.js`** — 2 new helpers + JSDoc + exports
- **`functions/src/whatsapp-bot/WhatsAppBot.js`** — 3 sites fixed (lines ~652, ~996, ~1069) + import + warning comment
- **`functions/tests/quicklog-date-type.test.js`** — 4 assertions rewritten to use helper as source-of-truth (were encoding the bug)
- **`functions/tests/whatsapp-bot-tz.test.js`** — NEW. 10 tests covering TZ invariance + DST + critical 00:30 IL edge case
- **`.claude/rubrics/pr-g-3-8.md`** — NEW. 10 MUST + 4 SHOULD criteria

## Grader

**VERDICT: PASS (10/10 MUST + 4/4 SHOULD)** — see `.claude/rubrics/pr-g-3-8.md` + commit message.

## Risk

**Zero data risk.** Read-only Firestore queries. No schema/migration. No firestore.rules change. No frontend change.

## Tests

- Jest: **561/561 pass** (was 551 + new 10)
- Lint: 0 new errors (2197 pre-existing warnings unchanged)

## Sibling PRs (deferred — same bug class, different surface)

| PR | Site | Severity |
|----|------|----------|
| G.3.9 | `functions/timesheet/index.js:160,166` | **HIGH** (WRITE path) |
| G.3.10 | `apps/user-app/js/main.js`, `daily-meter.js`, `ai-context-builder.js` | MED (frontend, separate deploy) |
| G.3.11 | ESLint `no-restricted-syntax` + admin sites + `audit.js` | LOW (preventative) |

## Test plan

- [x] Local Jest: all green
- [x] Lint: 0 errors
- [ ] Deploy Preview CI green
- [ ] Manual post-deploy smoke: from admin WhatsApp after 00:00 IL → "תפריט" → timesheets menu → verify TODAY's entries (not yesterday)

🤖 Generated with [Claude Code](https://claude.com/claude-code)