### PR TITLE
fix(timesheet): TZ-safe date normalization in all write paths (PR-G.3.9)

### DIFF
--- a/.claude/rubrics/pr-g-3-9.md
+++ b/.claude/rubrics/pr-g-3-9.md
@@ -1,0 +1,55 @@
+# Rubric — PR-G.3.9: TZ-safe date normalization in timesheet write paths
+
+**Scope:** `functions/timesheet/index.js` (3 write paths: createQuickLogEntry, createTimesheetEntry_v2, updateTimesheetEntry) + new shared helper `normalizeDateToYMD()` in `functions/shared/calendar.js` + tests. Backend-only.
+
+**Origin:** Surfaced as G.3.8 sibling. Refined by navigator 2026-05-25: bug is THEORETICAL for current frontend (`apps/user-app/js/quick-log.js` always sends ISO string → string path is TZ-safe) but a latent trap for any future caller sending Timestamp / `{seconds, nanoseconds}` constructed from local-IL-midnight.
+
+**Bug class (G.3.7/G.3.8/G.3.9 family):** `d.toISOString().substring(0, 10)` on a Date built from local-midnight → returns UTC date, off by -1.
+
+**Behavioral change (per `functions/CLAUDE.md`):** `createTimesheetEntry_v2` + `updateTimesheetEntry` previously wrote `data.date` raw (stored as whatever caller sent — string OR object). Now: always normalized to `YYYY-MM-DD` string. **Consistency improvement**, not a fallback loosening. Current production frontend already sends strings, so no observable difference; future callers cannot accidentally persist a Timestamp object.
+
+## MUST (10) — blocking
+
+1. **`normalizeDateToYMD(input)` helper added + exported.** New function in `functions/shared/calendar.js`. Accepts string / `{seconds, nanoseconds}` / `{toDate()}` / throws on invalid. *Evidence:* function defined; exported in `module.exports` and `_test`.
+
+2. **`createQuickLogEntry` date-parsing block replaced.** Previous ~30-line block (lines 140-174) replaced with call to `normalizeDateToYMD()`. *Evidence:* `git diff functions/timesheet/index.js` shows block deleted, single normalize call inserted.
+
+3. **`createQuickLogEntry` audit log uses normalized value.** Line 510 (`details.date`) changed from `data.date` (raw) → `dateString` (normalized). *Evidence:* diff shows the change.
+
+4. **`createTimesheetEntry_v2` normalizes `data.date` at top.** After validation, before transaction. *Evidence:* `data.date = normalizeDateToYMD(data.date)` in createTimesheetEntry_v2 function body; error path raises `invalid-argument` HttpsError.
+
+5. **`updateTimesheetEntry` normalizes `data.date` at top.** Same pattern. *Evidence:* same code in updateTimesheetEntry.
+
+6. **timesheet/index.js imports helper.** `const { normalizeDateToYMD } = require('../shared/calendar');` at top with explanatory comment. *Evidence:* require line + comment present.
+
+7. **New `normalize-date-ymd.test.js` covers all input shapes.** Tests: string (YYYY-MM-DD, full ISO, ISO with offset, invalid) + {seconds} (UTC midnight, **local-IL-midnight critical case**, winter no-DST, DST summer, nanoseconds tolerated) + Timestamp.toDate() (valid, local-IL-midnight, invalid Date) + invalid inputs (null, undefined, number, unrecognized object) + 4-TZ matrix proving the local-IL-midnight critical case yields `'2026-04-02'` under UTC / Asia/Jerusalem / America/Los_Angeles / Pacific/Kiritimati. *Evidence:* test file exists; all tests pass.
+
+8. **All existing tests pass.** Jest suite. Existing `quicklog-date-type.test.js` (which mocks createQuickLogEntry inputs) still green — output format unchanged. *Evidence:* `npx jest` PASS for full suite.
+
+9. **No `firestore.rules`, no schema, no migration.** Output to Firestore unchanged (still `YYYY-MM-DD` string). No back-fill needed; existing entries keep their format. *Evidence:* `git diff` confined to `functions/`.
+
+10. **No frontend changes.** `apps/user-app/js/quick-log.js` already sends ISO string; no change needed. *Evidence:* `git diff apps/` empty.
+
+## SHOULD (4) — non-blocking
+
+1. **Explanatory comments at import + helper.** JSDoc on `normalizeDateToYMD` explains the bug class + accepted shapes. Inline comment in timesheet/index.js warns against UTC antipattern. *Evidence:* JSDoc + comments present.
+
+2. **Behavioral change documented in PR body.** Explicit statement that createTimesheetEntry_v2 / updateTimesheetEntry now normalize (previously raw). Confirms no observable difference for current frontend. *Evidence:* "Behavioral change" section in PR body.
+
+3. **Error path uses HttpsError with invalid-argument code.** Mirrors existing pattern in same file. *Evidence:* try/catch wraps the normalize call in each function.
+
+4. **Helper-level tests use TZ matrix.** Proves the critical case independently of host TZ (not just CI-default UTC). *Evidence:* `test.each(TZS)` block in test file.
+
+## Out of scope (deferred)
+
+- **G.3.10** — `apps/user-app/js/main.js`, `daily-meter.js`, `ai-context-builder.js` (frontend readers)
+- **G.3.11** — ESLint `no-restricted-syntax` ban on `.toISOString().slice/substring(0,N)` + remaining admin sites + audit
+- `apps/user-app/js/modules/firebase-server-adapter.js` etc. — frontend callers of createTimesheetEntry_v2/updateTimesheetEntry are out of scope (this PR only normalizes backend receive-side)
+- `functions/admin/master-admin-wrappers.js`, `functions/src/deletion/audit.js` — G.3.11 candidates
+
+## Test outputs required
+
+- Jest: `npx jest` PASS. New `normalize-date-ymd.test.js` adds ~20 tests.
+- Vitest: unchanged.
+- Lint: 0 errors.
+- Manual: no smoke required — refactor + helper addition with full test coverage. Existing frontend behavior unchanged.

--- a/functions/shared/calendar.js
+++ b/functions/shared/calendar.js
@@ -135,6 +135,63 @@ function todayInJerusalemYMD() {
  *
  * @returns {Date}
  */
+/**
+ * PR-G.3.9 (2026-05-25): convert any caller-supplied date input to
+ * `YYYY-MM-DD` in Asia/Jerusalem TZ.
+ *
+ * Accepts:
+ *   - String (ISO 8601 or `YYYY-MM-DD`) — preserves the input prefix to
+ *     avoid TZ shift (matches existing createQuickLogEntry contract).
+ *   - `{seconds, nanoseconds}` map (legacy Callable Timestamp serialization)
+ *   - Object with `.toDate()` (Firestore Timestamp)
+ *
+ * Throws on null / number / unsupported type / unparseable string.
+ *
+ * Bug class (G.3.7/G.3.8 family): previous code used
+ * `d.toISOString().substring(0, 10)` which converts to UTC. If the caller
+ * sent a Timestamp built from local-midnight (e.g. `new Date(2026, 3, 2)`
+ * in Asia/Jerusalem = `2026-04-01T21:00:00Z`), the slice yielded
+ * `"2026-04-01"` — wrong day by -1. Theoretical for the current
+ * `apps/user-app/js/quick-log.js` frontend (which sends ISO strings), but
+ * a latent trap if any caller ever sends a Timestamp.
+ *
+ * @param {*} input - the raw value from `data.date`
+ * @returns {string} `YYYY-MM-DD`
+ * @throws {Error} on invalid input
+ */
+function normalizeDateToYMD(input) {
+  if (input == null) {
+    throw new Error('normalizeDateToYMD: input is null/undefined');
+  }
+  const t = typeof input;
+  if (t === 'string') {
+    // Preserve input prefix — TZ-safe for both 'YYYY-MM-DD' and
+    // 'YYYY-MM-DDTHH:mm:ss.sssZ'. Validates parseability first.
+    const parsed = new Date(input);
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error(`normalizeDateToYMD: invalid date string '${input}'`);
+    }
+    return input.substring(0, 10);
+  }
+  if (t !== 'object') {
+    throw new Error(`normalizeDateToYMD: unsupported type '${t}'`);
+  }
+  // Firestore Timestamp-like map (legacy Callable serialization)
+  if (typeof input.seconds === 'number') {
+    const d = new Date(input.seconds * 1000);
+    return _JERUSALEM_DATE_FMT.format(d);
+  }
+  // Firestore Timestamp object
+  if (typeof input.toDate === 'function') {
+    const d = input.toDate();
+    if (!(d instanceof Date) || Number.isNaN(d.getTime())) {
+      throw new Error('normalizeDateToYMD: .toDate() did not return a valid Date');
+    }
+    return _JERUSALEM_DATE_FMT.format(d);
+  }
+  throw new Error('normalizeDateToYMD: object has no recognized shape (need .seconds or .toDate)');
+}
+
 function startOfTodayInJerusalem() {
   const ymd = todayInJerusalemYMD(); // 'YYYY-MM-DD'
   // Construct from local IL fields → produce instant for 00:00 IL.
@@ -413,6 +470,8 @@ module.exports = {
   // PR-G.3.8: TZ-safe "today" helpers for Cloud Functions
   todayInJerusalemYMD,
   startOfTodayInJerusalem,
+  // PR-G.3.9: normalize caller-supplied date input → YYYY-MM-DD (Asia/Jerusalem)
+  normalizeDateToYMD,
   // Exported for unit tests
   _test: {
     classifyEvent,
@@ -420,6 +479,7 @@ module.exports = {
     _hdateToISO,  // PR-G.3.7
     todayInJerusalemYMD,        // PR-G.3.8
     startOfTodayInJerusalem,    // PR-G.3.8
+    normalizeDateToYMD,         // PR-G.3.9
     CLOSED_MODERN_BASENAMES,
     CLOSED_MINOR_BASENAMES
   }

--- a/functions/tests/normalize-date-ymd.test.js
+++ b/functions/tests/normalize-date-ymd.test.js
@@ -1,0 +1,132 @@
+/**
+ * PR-G.3.9: tests for `normalizeDateToYMD(input)` — accepts string /
+ * {seconds, nanoseconds} / Timestamp object; returns YYYY-MM-DD in
+ * Asia/Jerusalem TZ regardless of host TZ.
+ *
+ * Critical case: local-midnight {seconds} input from a caller in
+ * Asia/Jerusalem yields the IL date, NOT the UTC date. This is the latent
+ * trap that PR-G.3.9 closes in functions/timesheet/index.js:160, 166.
+ */
+
+const { normalizeDateToYMD } = require('../shared/calendar');
+
+describe('normalizeDateToYMD — string inputs', () => {
+  test('YYYY-MM-DD short string → same string', () => {
+    expect(normalizeDateToYMD('2026-04-02')).toBe('2026-04-02');
+  });
+
+  test('ISO 8601 string → date prefix', () => {
+    expect(normalizeDateToYMD('2026-04-02T00:00:00.000Z')).toBe('2026-04-02');
+  });
+
+  test('ISO string with TZ offset → prefix (no TZ shift)', () => {
+    // The existing contract: extract the input prefix verbatim. Caller
+    // already chose the YMD when they constructed the string.
+    expect(normalizeDateToYMD('2026-04-02T23:59:59.999Z')).toBe('2026-04-02');
+  });
+
+  test('invalid string → throws', () => {
+    expect(() => normalizeDateToYMD('not-a-date')).toThrow(/invalid date string/);
+  });
+});
+
+describe('normalizeDateToYMD — {seconds, nanoseconds} inputs (Asia/Jerusalem)', () => {
+  test('UTC midnight seconds → same UTC day (offset = +2/+3, still same day)', () => {
+    // 2026-04-02T00:00:00.000Z = 2026-04-02 03:00 IL DST → same day either way
+    const seconds = Math.floor(new Date('2026-04-02T00:00:00.000Z').getTime() / 1000);
+    expect(normalizeDateToYMD({ seconds, nanoseconds: 0 })).toBe('2026-04-02');
+  });
+
+  test('CRITICAL: local-IL-midnight seconds yields IL date, not UTC yesterday', () => {
+    // Caller in Asia/Jerusalem does `new Date(2026, 3, 2).getTime() / 1000`
+    // = epoch for 2026-04-02 00:00 IL = 2026-04-01T21:00:00.000Z (DST UTC+3).
+    // Old buggy code: `d.toISOString().substring(0,10)` = "2026-04-01" ❌
+    // New helper: returns IL date "2026-04-02" ✅
+    const seconds = Math.floor(new Date('2026-04-01T21:00:00.000Z').getTime() / 1000);
+    expect(normalizeDateToYMD({ seconds, nanoseconds: 0 })).toBe('2026-04-02');
+  });
+
+  test('22:30 UTC = 01:30 IL DST next day → returns IL day', () => {
+    // 2026-05-24T22:30:00.000Z = 2026-05-25 01:30 IL (UTC+3 DST)
+    const seconds = Math.floor(new Date('2026-05-24T22:30:00.000Z').getTime() / 1000);
+    expect(normalizeDateToYMD({ seconds, nanoseconds: 0 })).toBe('2026-05-25');
+  });
+
+  test('winter (no DST) — 22:30 UTC = 00:30 IL next day → returns IL day', () => {
+    // 2026-01-15T22:30:00.000Z = 2026-01-16 00:30 IL (UTC+2 winter)
+    const seconds = Math.floor(new Date('2026-01-15T22:30:00.000Z').getTime() / 1000);
+    expect(normalizeDateToYMD({ seconds, nanoseconds: 0 })).toBe('2026-01-16');
+  });
+
+  test('nanoseconds field is tolerated (ignored)', () => {
+    const seconds = Math.floor(new Date('2026-04-02T12:00:00.000Z').getTime() / 1000);
+    expect(normalizeDateToYMD({ seconds, nanoseconds: 500000000 })).toBe('2026-04-02');
+  });
+});
+
+describe('normalizeDateToYMD — Timestamp object (.toDate)', () => {
+  test('Timestamp.toDate() returning a Date → IL YMD', () => {
+    const fakeTimestamp = {
+      toDate: () => new Date('2026-04-02T12:00:00.000Z')
+    };
+    expect(normalizeDateToYMD(fakeTimestamp)).toBe('2026-04-02');
+  });
+
+  test('Timestamp built from local-IL-midnight → IL date', () => {
+    // Same bug pattern as the {seconds} case
+    const fakeTimestamp = {
+      toDate: () => new Date('2026-04-01T21:00:00.000Z') // 2026-04-02 00:00 IL DST
+    };
+    expect(normalizeDateToYMD(fakeTimestamp)).toBe('2026-04-02');
+  });
+
+  test('.toDate() returning an invalid Date → throws', () => {
+    const bad = { toDate: () => new Date('invalid') };
+    expect(() => normalizeDateToYMD(bad)).toThrow(/valid Date/);
+  });
+});
+
+describe('normalizeDateToYMD — invalid inputs', () => {
+  test('null → throws', () => {
+    expect(() => normalizeDateToYMD(null)).toThrow(/null\/undefined/);
+  });
+
+  test('undefined → throws', () => {
+    expect(() => normalizeDateToYMD(undefined)).toThrow(/null\/undefined/);
+  });
+
+  test('number → throws (unsupported type)', () => {
+    expect(() => normalizeDateToYMD(12345)).toThrow(/unsupported type/);
+  });
+
+  test('plain object with neither .seconds nor .toDate → throws', () => {
+    expect(() => normalizeDateToYMD({ foo: 'bar' })).toThrow(/no recognized shape/);
+  });
+});
+
+describe('normalizeDateToYMD — TZ invariance under different host TZ', () => {
+  // Confirms the {seconds} / Timestamp branches use Intl with timeZone:
+  // Asia/Jerusalem, so the answer is the same on UTC hosts (Cloud Functions)
+  // and on Asia/Jerusalem hosts (developer machines).
+  const TZS = ['UTC', 'Asia/Jerusalem', 'America/Los_Angeles', 'Pacific/Kiritimati'];
+
+  function runUnderTZ(tz, fn) {
+    const original = process.env.TZ;
+    process.env.TZ = tz;
+    try {
+      jest.resetModules();
+      return fn();
+    } finally {
+      process.env.TZ = original;
+      jest.resetModules();
+    }
+  }
+
+  test.each(TZS)('local-IL-midnight {seconds} → "2026-04-02" under TZ=%s', (tz) => {
+    runUnderTZ(tz, () => {
+      const { normalizeDateToYMD: helper } = require('../shared/calendar');
+      const seconds = Math.floor(new Date('2026-04-01T21:00:00.000Z').getTime() / 1000);
+      expect(helper({ seconds, nanoseconds: 0 })).toBe('2026-04-02');
+    });
+  });
+});

--- a/functions/timesheet/index.js
+++ b/functions/timesheet/index.js
@@ -38,6 +38,11 @@ const {
 
 const { getOrCreateInternalCase } = require('./internal-case');
 
+// PR-G.3.9: TZ-safe `data.date` normalization for all write paths.
+// DO NOT use `.toISOString().substring(0,10)` on a caller-supplied Date —
+// it converts to UTC and shifts the day by -1 for Asia/Jerusalem local-midnight.
+const { normalizeDateToYMD } = require('../shared/calendar');
+
 /**
  * ════════════════════════════════════════════════════════════════════════════
  * 🎯 Quick Log Entry - Manager/Admin Only
@@ -134,44 +139,17 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
     // 3️⃣ DATE PARSING (Before transaction)
     // ═══════════════════════════════════════════════════════════════════
 
-    // Parse date - normalize ALL formats to "YYYY-MM-DD" string
-    // (matches createTimesheetEntry_v2 and all existing queries)
+    // PR-G.3.9: normalize ALL formats to `YYYY-MM-DD` string via shared
+    // TZ-safe helper. Replaces ad-hoc parsing that used
+    // `.toISOString().substring(0,10)` on the {seconds} / Timestamp paths —
+    // which converted local-midnight to UTC and shifted by -1 day.
     let dateString;
-    const dateType = typeof data.date;
-
-    if (dateType === 'string') {
-      // ISO string format (current format from frontend)
-      // e.g. "2026-04-02T00:00:00.000Z" or "2026-04-02"
-      const d = new Date(data.date);
-      if (isNaN(d.getTime())) {
-        throw new functions.https.HttpsError(
-          'invalid-argument',
-          'Invalid date string format'
-        );
-      }
-      // Extract YYYY-MM-DD directly from input to avoid timezone shift
-      dateString = data.date.substring(0, 10);
-      console.log('[Quick Log] Date parsed from string:', data.date, '→', dateString);
-
-    } else if (data.date && dateType === 'object' && typeof data.date.seconds === 'number') {
-      // Firestore Timestamp-like map: {seconds, nanoseconds}
-      // (legacy format from Callable Function serialization)
-      const d = new Date(data.date.seconds * 1000);
-      dateString = d.toISOString().substring(0, 10);
-      console.log('[Quick Log] Date parsed from {seconds, nanoseconds} map →', dateString);
-
-    } else if (data.date && typeof data.date.toDate === 'function') {
-      // Real Firestore Timestamp object (unlikely but supported)
-      const d = data.date.toDate();
-      dateString = d.toISOString().substring(0, 10);
-      console.log('[Quick Log] Date parsed from Timestamp object →', dateString);
-
-    } else {
-      throw new functions.https.HttpsError(
-        'invalid-argument',
-        'Invalid date format. Expected ISO string, {seconds, nanoseconds}, or Timestamp object'
-      );
+    try {
+      dateString = normalizeDateToYMD(data.date);
+    } catch (e) {
+      throw new functions.https.HttpsError('invalid-argument', e.message);
     }
+    console.log('[Quick Log] Date normalized:', data.date, '→', dateString);
 
     // ═══════════════════════════════════════════════════════════════════
     // 4️⃣ TRANSACTION - All operations atomic
@@ -507,7 +485,8 @@ exports.createQuickLogEntry = functions.https.onCall(async (data, context) => {
           clientId: data.clientId,
           clientName: finalClientName,
           minutes: data.minutes,
-          date: data.date
+          // PR-G.3.9: use normalized YYYY-MM-DD (not raw input) for audit consistency
+          date: dateString
         },
         timestamp: admin.firestore.FieldValue.serverTimestamp(),
         userAgent: null,
@@ -612,6 +591,15 @@ exports.createTimesheetEntry_v2 = functions.https.onCall(async (data, context) =
 
     if (!data.date) {
       throw new functions.https.HttpsError('invalid-argument', 'חסר תאריך');
+    }
+
+    // PR-G.3.9: normalize date input (string / {seconds} / Timestamp) to
+    // 'YYYY-MM-DD' in Asia/Jerusalem. Previously this function wrote
+    // `data.date` raw — inconsistent schema if any caller sent a Timestamp.
+    try {
+      data.date = normalizeDateToYMD(data.date);
+    } catch (e) {
+      throw new functions.https.HttpsError('invalid-argument', e.message);
     }
 
     if (typeof data.minutes !== 'number' || data.minutes <= 0) {
@@ -1123,6 +1111,15 @@ exports.updateTimesheetEntry = functions.https.onCall(async (data, context) => {
         'invalid-argument',
         'חסר תאריך'
       );
+    }
+
+    // PR-G.3.9: normalize date input to 'YYYY-MM-DD' in Asia/Jerusalem.
+    // Mirrors createQuickLogEntry + addTimeEntry; ensures consistent schema
+    // on UPDATE path regardless of caller-supplied format.
+    try {
+      data.date = normalizeDateToYMD(data.date);
+    } catch (e) {
+      throw new functions.https.HttpsError('invalid-argument', e.message);
     }
 
     if (typeof data.minutes !== 'number' || data.minutes <= 0) {


### PR DESCRIPTION
## Summary

Eliminate TZ-shift latent trap in `functions/timesheet/index.js`. Add canonical `normalizeDateToYMD()` helper and apply across all 3 write paths (`createQuickLogEntry`, `createTimesheetEntry_v2`, `updateTimesheetEntry`).

**Bug status:** THEORETICAL for current frontend (`apps/user-app/js/quick-log.js` sends ISO strings → string path is TZ-safe). But the `{seconds}` / Timestamp branches at lines 160, 166 used `.toISOString().substring(0, 10)` — would have returned the wrong day if any future caller sent a Timestamp built from local-IL-midnight.

## Changes

- **`functions/shared/calendar.js`** — new `normalizeDateToYMD(input)` helper. Accepts string / `{seconds, nanoseconds}` / `{toDate()}`; returns `YYYY-MM-DD` in Asia/Jerusalem via `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Jerusalem' })`.
- **`functions/timesheet/index.js`**:
  - `createQuickLogEntry`: 30-line inline parser replaced with helper call. Audit log (line 489) now writes normalized `dateString` instead of raw `data.date`.
  - `createTimesheetEntry_v2`: added normalize at top (after validation, before transaction). Was: writing `data.date` raw.
  - `updateTimesheetEntry`: same.
- **`functions/tests/normalize-date-ymd.test.js`** — NEW. 20 tests: string inputs, {seconds}, Timestamp, invalid inputs, plus 4-TZ matrix (UTC / Asia/Jerusalem / America/Los_Angeles / Pacific/Kiritimati) and CRITICAL local-IL-midnight case.
- **`.claude/rubrics/pr-g-3-9.md`** — NEW. 10 MUST + 4 SHOULD.

## Behavioral change (per functions/CLAUDE.md BEHAVIORAL CHANGE RULE)

`createTimesheetEntry_v2` + `updateTimesheetEntry` previously wrote `data.date` **raw** — could persist any caller-supplied shape (string, Timestamp, {seconds} map). Now: always normalized to `YYYY-MM-DD` string.

**Consistency improvement, not a fallback loosening.** Current frontend only sends strings, so production behavior is unchanged. Future callers cannot accidentally persist a non-string `date` into `timesheet_entries`.

## Mental model (per functions/CLAUDE.md)

| Question | Answer |
|----------|--------|
| What writes data? | `createQuickLogEntry`, `createTimesheetEntry_v2`, `updateTimesheetEntry` |
| What reads it? | WhatsApp bot (G.3.8), apps/user-app readers (G.3.10), admin panel, reports |
| Aggregate recalc? | None — `date` not used in aggregation |
| Backward compat? | Output schema unchanged (still `YYYY-MM-DD` string). Existing entries keep their format. |
| Source of truth? | `timesheet_entries.date` (string, normalized at write-time) |

## Risk

**Read-only output (still `YYYY-MM-DD` string).** No schema, no migration, no back-fill. Reader contracts unchanged.

## Rollback

Revert the 4-file commit. Helpers are net-new; reverting drops them along with their callers in a single op. No data state to roll back.

## Grader

**VERDICT: PASS_WITH_WARNINGS (10/10 MUST + 4/4 SHOULD)** — warnings were process-only (uncommitted at grading time; rubric naming fixed pre-commit).

## Tests

- Jest: **581/581 pass** (was 561 + new 20)
- Lint: 0 new errors
- Manual: no smoke required — refactor + helper addition with full coverage. Frontend behavior unchanged.

## Sibling PRs (deferred)

| PR | Site | Severity |
|----|------|----------|
| G.3.10 | `apps/user-app/js/main.js`, `daily-meter.js`, `ai-context-builder.js` | MED (frontend readers) |
| G.3.11 | ESLint `no-restricted-syntax` ban + `functions/admin/master-admin-wrappers.js` + `functions/src/deletion/audit.js` + admin panel | LOW (preventative) |

## Test plan

- [x] Local Jest all green
- [x] Lint 0 errors
- [ ] Deploy Preview CI green
- [ ] (No manual smoke needed — refactor, frontend behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)