### PR TITLE
feat(eslint): TZ-ban rule + final 5 fix sites (PR-G.3.11)

### DIFF
--- a/.claude/rubrics/pr-g-3-11.md
+++ b/.claude/rubrics/pr-g-3-11.md
@@ -1,0 +1,56 @@
+# Rubric — PR-G.3.11: ESLint TZ-ban rule + final 5 fix sites
+
+**Scope:** ESLint `no-restricted-syntax` rule banning `.toISOString().slice/substring/split(...)` repo-wide + fix 5 known sites + new helper `dateTimeToJerusalemLocalInput()` for datetime-local inputs + Vitest coverage.
+
+**Origin:** Final cleanup PR for the G.3.7→G.3.11 TZ-bug sequence. Investigation surfaced ~30 pre-existing violations across admin-panel + user-app that weren't in scope of prior PRs. Tommy approved (decision 2026-05-25): ship the rule as `'warn'` initially, fix planned sites + add allowlist, schedule a separate cleanup PR (`G.3.12` or `G.4.x`) to flip to `'error'` after the 30 existing violations are addressed.
+
+**Bug class (final, this is the rule that catches all of them):** any `.toISOString().slice/substring/split(...)` call returns UTC. Wrong day/time for Asia/Jerusalem at midnight boundary and for users abroad.
+
+**Behavioral change:** none for current frontend behavior (all 5 fixed sites either had visible bugs or were dead defensive code). The ESLint rule is non-blocking (`'warn'`) so existing CI/PRs are not affected.
+
+## MUST (10) — blocking
+
+1. **ESLint `no-restricted-syntax` rule added.** AST selector matches `CallExpression[callee.property.name=/^(slice|substring|split)$/][callee.object.type='CallExpression'][callee.object.callee.property.name='toISOString']`. Severity = `'warn'` per Tommy decision. *Evidence:* `eslint.config.js` `commonJsRules` block has the rule with explanatory comment.
+
+2. **`.claude/**` added to ESLint global ignores.** Required to silence pre-existing `.claude/firestore-scripts/*` UTC slices that aren't in scope of this PR. *Evidence:* `eslint.config.js` `ignores` blocks include `.claude/**`.
+
+3. **Allowlist override for `tz-helper.js` + test files.** Helper itself uses `Intl.DateTimeFormat` (no slice antipattern) but allowlist is symmetric protection. Test files exempt — may intentionally exercise the old pattern for regression coverage. *Evidence:* override block at end of `eslint.config.js`.
+
+4. **New helper `dateTimeToJerusalemLocalInput(date)` added to `tz-helper.js` + window mirror.** Returns `'YYYY-MM-DDTHH:mm'` in Asia/Jerusalem via `Intl.DateTimeFormat.formatToParts`. Defensive `''` return on invalid input. *Evidence:* function + export + window mirror present.
+
+5. **`TaskFormManager.js:61` fixed.** Uses `dateTimeToJerusalemLocalInput(tomorrow)` instead of `.toISOString().slice(0, 16)`. *Evidence:* import + diff.
+
+6. **`functions/admin/master-admin-wrappers.js:661` fixed.** Uses `normalizeDateToYMD(weekAgo)` instead of `.toISOString().split('T')[0]`. *Evidence:* require + diff.
+
+7. **`functions/src/deletion/audit.js:100` fixed.** Uses `todayInJerusalemYMD()` instead of `.toISOString().split('T')[0]`. *Evidence:* require + diff.
+
+8. **`apps/admin-panel/js/workload-analytics/WorkloadCalculator.js:1314` debug block removed.** Tommy chose "delete" over "eslint-disable". *Evidence:* diff shows debug `console.log` block gone, replaced with PR-G.3.11 comment.
+
+9. **`ai-context-builder.js:153` fallback guarded with inline eslint-disable.** Documents that fallback is intentional safety net for classic-script vs ES-module load-order race. *Evidence:* `// eslint-disable-next-line no-restricted-syntax -- PR-G.3.11: ...` present.
+
+10. **Vitest coverage for `dateTimeToJerusalemLocalInput` added.** 7 tests: format shape, DST summer, winter no-DST, critical local-IL-midnight round-trip, invalid Date, non-Date input, midnight-boundary case. *Evidence:* `tests/unit/user-app/tz-helper.test.ts` new describe block.
+
+## SHOULD (4) — non-blocking
+
+1. **Rule comment explains the helper choice + sibling helpers.** Cross-refers to `tz-helper.js` (frontend) + `calendar.js` (backend) so devs know where to import from. *Evidence:* comment block above the rule.
+
+2. **Rule severity choice documented in-config.** Comment explains why `'warn'` (avoid blocking unrelated PRs on 30 pre-existing violations) + plan to flip to `'error'` after follow-up PR. *Evidence:* comment in `eslint.config.js`.
+
+3. **All existing Jest + Vitest suites pass.** 293 Vitest (288 + 7 new) + 581 Jest unchanged. *Evidence:* test outputs.
+
+4. **PR body lists the ~30 pre-existing violations + tracks follow-up.** *Evidence:* PR body has "Follow-up cleanup" section enumerating files; task `#19` (NEW) added for the cleanup PR.
+
+## Out of scope (deferred to follow-up PR `G.3.12` / `G.4.x`)
+
+- 15 admin-panel sites: DataManager.js (2), ReportGenerator.js (1), ClientManagementModal.js (2), ClientsTable.js (1), UserDetailsModal.js (~10)
+- 8 user-app sites: main.js (3 — different sites than G.3.10 fixed), dialogs.js, forms.js (2), timesheet.js (2), quick-log.js (2)
+- 1 test file: `tests/test-concurrent-users.js:57` — may be intentional, review when cleaning up
+
+After ALL violations cleaned: flip rule from `'warn'` to `'error'`.
+
+## Test outputs required
+
+- Vitest: `npx vitest run` PASS. 293/295 (2 pre-existing skips).
+- Jest: 581/581.
+- Lint: 0 errors. ~30 new `no-restricted-syntax` warnings (expected, tracked).
+- Manual: no smoke. Backend fixes are 2 LOC each, deterministic. Frontend TaskFormManager: open user-app DEV → "Add Task" → confirm deadline default shows tomorrow 17:00 IL (not UTC 17:00 = 19:00/20:00 IL).

--- a/apps/admin-panel/js/workload-analytics/WorkloadCalculator.js
+++ b/apps/admin-panel/js/workload-analytics/WorkloadCalculator.js
@@ -1307,12 +1307,9 @@ tasksByDay[dateKey] = [];
                     console.log('  workHoursCalculator.isWorkDay(peakDay):', isWorkDay);
                 }
 
-                // 🐛 DEBUG: Date key generation format
-                const sampleDate = new Date(2026, 0, 17); // Jan 17, 2026
-                console.log('  Date key format test (2026-01-17):');
-                console.log('    dateToString:', this.dateToString(sampleDate));
-                console.log('    toISOString().slice(0,10):', sampleDate.toISOString().slice(0, 10));
-
+                // PR-G.3.11: removed debug log comparing dateToString vs
+                // .toISOString().slice(0,10). The bug it documented is now
+                // covered by the repo-wide ESLint rule; debug no longer needed.
                 window._peakDebugLogged = true;
             }
 

--- a/apps/user-app/components/add-task/TaskFormManager.js
+++ b/apps/user-app/components/add-task/TaskFormManager.js
@@ -14,6 +14,10 @@
  * - קבלת נתוני הטופס
  */
 
+// PR-G.3.11: canonical IL-TZ helper. DO NOT use .toISOString().slice(0,16)
+// for datetime-local input — yields UTC, jumps back 2-3h for IL users.
+import { dateTimeToJerusalemLocalInput } from '../../js/modules/tz-helper.js';
+
 const DRAFT_STORAGE_KEY = 'addTaskDraft';
 
 /**
@@ -57,9 +61,10 @@ export class TaskFormManager {
 
       const deadlineInput = this.form.querySelector('#taskDeadline');
       if (deadlineInput) {
-        // Format for datetime-local input: YYYY-MM-DDTHH:MM
-        const formattedDate = tomorrow.toISOString().slice(0, 16);
-        deadlineInput.value = formattedDate;
+        // Format for datetime-local input: YYYY-MM-DDTHH:MM in Asia/Jerusalem
+        // PR-G.3.11: was `.toISOString().slice(0, 16)` (UTC) — jumped back
+        // 2-3h for IL users, more for users abroad.
+        deadlineInput.value = dateTimeToJerusalemLocalInput(tomorrow);
       }
     }
 

--- a/apps/user-app/js/modules/ai-system/ai-context-builder.js
+++ b/apps/user-app/js/modules/ai-system/ai-context-builder.js
@@ -150,7 +150,8 @@ class AIContextBuilder {
       oneMonthAgo.setMonth(oneMonthAgo.getMonth() - 1);
       const oneMonthAgoStr = (window.TZHelper && window.TZHelper.dateToJerusalemYMD)
         ? window.TZHelper.dateToJerusalemYMD(oneMonthAgo)
-        : oneMonthAgo.toISOString().substring(0, 10); // safety fallback if tz-helper not loaded
+        // eslint-disable-next-line no-restricted-syntax -- PR-G.3.11: safety fallback for load-order race (classic-script vs ES-module); never fires in production. See lines 145-148 above.
+        : oneMonthAgo.toISOString().substring(0, 10);
 
       const snapshot = await this.db
         .collection('timesheet_entries')

--- a/apps/user-app/js/modules/tz-helper.js
+++ b/apps/user-app/js/modules/tz-helper.js
@@ -120,6 +120,47 @@ export function startOfMonthYMD(ymd) {
   return `${ymd.slice(0, 7)}-01`;
 }
 
+/**
+ * PR-G.3.11: format a Date as `YYYY-MM-DDTHH:mm` in Asia/Jerusalem.
+ * Suitable for `<input type="datetime-local">` `.value` assignments.
+ *
+ * Bug fixed: was `date.toISOString().slice(0, 16)` which yields UTC
+ * (e.g. for IL 17:00 winter, UTC is 15:00, so the picker default jumps
+ * back 2-3h for IL users; worse for users abroad).
+ *
+ * @param {Date} date - JS Date instance
+ * @returns {string} `YYYY-MM-DDTHH:mm` or `''` on invalid input
+ */
+const _JERUSALEM_DATETIME_FMT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Jerusalem',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false
+});
+
+export function dateTimeToJerusalemLocalInput(date) {
+  if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+    return '';
+  }
+  // en-CA + above options yields parts in form 'YYYY-MM-DD, HH:mm' on Chrome
+  // and 'YYYY-MM-DD, HH:mm' on Firefox. Use formatToParts for stable output.
+  const parts = _JERUSALEM_DATETIME_FMT.formatToParts(date);
+  const get = (type) => parts.find((p) => p.type === type)?.value || '';
+  const y = get('year');
+  const m = get('month');
+  const d = get('day');
+  let h = get('hour');
+  const min = get('minute');
+  // Some engines emit '24' for midnight under hour12:false — normalize to '00'.
+  if (h === '24') {
+    h = '00';
+  }
+  return `${y}-${m}-${d}T${h}:${min}`;
+}
+
 // ─────────────────────────────────────────────────────────────────
 // Window mirror — for non-module consumers (matches dates.js pattern)
 // ─────────────────────────────────────────────────────────────────
@@ -129,6 +170,7 @@ if (typeof window !== 'undefined') {
     dateToJerusalemYMD,
     addDaysYMD,
     dayOfWeekYMD,
-    startOfMonthYMD
+    startOfMonthYMD,
+    dateTimeToJerusalemLocalInput
   };
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ const commonIgnores = [
   'devtools/**',
   'docs/**',
   '.github/**',
+  '.claude/**', // ✅ PR-G.3.11: agent prompts, hooks, one-off Firestore investigation scripts
   'functions/**', // ✅ Server-side code (Node.js) - different linting rules
   'scripts/**',   // ✅ Ad-hoc maintenance/migration scripts (Node.js, console output expected)
   '**/lib/**',    // ✅ Vendored third-party libraries (e.g. lucide.min.js)
@@ -60,6 +61,24 @@ const commonJsRules = {
     ignoreComments: true,
     ignoreStrings: true,
     ignoreTemplateLiterals: true
+  }],
+
+  // PR-G.3.11: Ban `.toISOString().slice/substring/split(...)` — UTC date,
+  // drifts at IL midnight + breaks for users abroad. Use TZ-safe helpers:
+  //   frontend: `apps/user-app/js/modules/tz-helper.js` →
+  //     todayInJerusalemYMD / dateToJerusalemYMD / dateTimeToJerusalemLocalInput
+  //   backend: `functions/shared/calendar.js` →
+  //     todayInJerusalemYMD / normalizeDateToYMD / startOfTodayInJerusalem
+  // Severity = 'warn' INITIALLY — flips to 'error' in a follow-up PR after
+  // the ~30 pre-existing violations across admin-panel + user-app are
+  // cleaned up incrementally. Setting 'error' now would block CI on
+  // unrelated PRs. The warning still surfaces the rule, prevents NEW
+  // violations from going unnoticed in review, and lets `npx eslint
+  // --max-warnings=0` enforce it locally for any developer who opts in.
+  // Allowlist: tz-helper.js (the helper itself) — see overrides below.
+  'no-restricted-syntax': ['warn', {
+    selector: "CallExpression[callee.property.name=/^(slice|substring|split)$/][callee.object.type='CallExpression'][callee.object.callee.property.name='toISOString']",
+    message: 'Use tz-helper (todayInJerusalemYMD / dateToJerusalemYMD / dateTimeToJerusalemLocalInput) instead of .toISOString().slice/substring/split — returns UTC, drifts at IL midnight. PR-G.3.7→G.3.11.'
   }]
 };
 
@@ -74,6 +93,7 @@ export default [
       'devtools/**',
       'docs/**',
       '.github/**',
+      '.claude/**',
       'functions/**',
       'scripts/**'
     ]
@@ -144,6 +164,20 @@ export default [
       'import/no-duplicates': 'error',
 
       ...commonJsRules
+    }
+  },
+  // PR-G.3.11: allowlist for tz-helper itself (defines the canonical
+  // `Intl.DateTimeFormat` usage and may legitimately format Date objects).
+  // Test files also exempt — they may intentionally exercise the old pattern
+  // for regression coverage.
+  {
+    files: [
+      'apps/user-app/js/modules/tz-helper.js',
+      'tests/**/*.test.{js,ts}',
+      'tests/**/*.spec.{js,ts}'
+    ],
+    rules: {
+      'no-restricted-syntax': 'off'
     }
   }
 ];

--- a/functions/admin/master-admin-wrappers.js
+++ b/functions/admin/master-admin-wrappers.js
@@ -15,6 +15,10 @@
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 
+// PR-G.3.11: TZ-safe date helpers. DO NOT use `.toISOString().split('T')[0]`
+// or `.slice(0,10)` — UTC, drifts at IL midnight.
+const { normalizeDateToYMD } = require('../shared/calendar');
+
 // שימוש ב-Admin SDK הקיים (מאותחל ב-index.js)
 const db = admin.firestore();
 const auth = admin.auth();
@@ -656,9 +660,10 @@ exports.getUserFullDetails = functions.https.onCall(async (data, context) => {
     }));
 
     // חישוב סטטיסטיקות שעות
+    // PR-G.3.11: weekAgoStr anchored to Asia/Jerusalem; was UTC slice → off-by-1 at IL midnight.
     const now = new Date();
     const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const weekAgoStr = weekAgo.toISOString().split('T')[0];
+    const weekAgoStr = normalizeDateToYMD(weekAgo);
 
     let hoursThisWeek = 0;
     let hoursThisMonth = 0;

--- a/functions/src/deletion/audit.js
+++ b/functions/src/deletion/audit.js
@@ -7,6 +7,9 @@
  */
 
 const admin = require('firebase-admin');
+// PR-G.3.11: TZ-safe "today" helper. DO NOT use `.toISOString().split('T')[0]`
+// — UTC, audit log silently writes to wrong day's bucket near IL midnight.
+const { todayInJerusalemYMD } = require('../../shared/calendar');
 
 /**
  * Log deletion attempt
@@ -97,7 +100,9 @@ async function logDeletionAttempt(db, {
  */
 async function updateDeletionMetrics(db, adminEmail, deletedCounts) {
   try {
-    const today = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+    // PR-G.3.11: IL-anchored "today" so daily_${today} bucket key matches
+    // the IL day at midnight (was UTC slice → 3-4h skew).
+    const today = todayInJerusalemYMD();
 
     const metricsRef = db.collection('deletion_metrics').doc(`daily_${today}`);
 

--- a/tests/unit/user-app/tz-helper.test.ts
+++ b/tests/unit/user-app/tz-helper.test.ts
@@ -15,7 +15,8 @@ import {
   dateToJerusalemYMD,
   addDaysYMD,
   dayOfWeekYMD,
-  startOfMonthYMD
+  startOfMonthYMD,
+  dateTimeToJerusalemLocalInput
 } from '../../../apps/user-app/js/modules/tz-helper.js';
 
 describe('todayInJerusalemYMD', () => {
@@ -200,5 +201,53 @@ describe('integration: week-range computation (mirror of daily-meter logic)', ()
     expect(dow).toBe(3);
     const startStr = addDaysYMD(todayStr, -dow);
     expect(startStr).toBe('2026-05-24');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────
+// PR-G.3.11: dateTimeToJerusalemLocalInput
+// ─────────────────────────────────────────────────────────────────
+describe('dateTimeToJerusalemLocalInput (PR-G.3.11)', () => {
+  it('returns YYYY-MM-DDTHH:mm format', () => {
+    const out = dateTimeToJerusalemLocalInput(new Date('2026-04-02T15:30:00.000Z'));
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  });
+
+  it('15:30 UTC summer DST = 18:30 IL (UTC+3)', () => {
+    const out = dateTimeToJerusalemLocalInput(new Date('2026-07-02T15:30:00.000Z'));
+    expect(out).toBe('2026-07-02T18:30');
+  });
+
+  it('15:30 UTC winter = 17:30 IL (UTC+2)', () => {
+    const out = dateTimeToJerusalemLocalInput(new Date('2026-01-15T15:30:00.000Z'));
+    expect(out).toBe('2026-01-15T17:30');
+  });
+
+  it('CRITICAL: tomorrow 17:00 local-IL (DST) round-trips correctly', () => {
+    // Build "tomorrow 17:00 IL" the way TaskFormManager does:
+    //   const tomorrow = new Date(); tomorrow.setDate(+1); tomorrow.setHours(17,0,0,0);
+    // On a JS host in any TZ, .setHours(17,0,0,0) sets HOST-local 17:00.
+    // We simulate a host in Asia/Jerusalem by using a pinned host-local moment.
+    // For deterministic test: pass a Date whose UTC value equals 2026-07-02T14:00:00Z
+    // (= 2026-07-02 17:00 IL DST). Expected: '2026-07-02T17:00'.
+    const out = dateTimeToJerusalemLocalInput(new Date('2026-07-02T14:00:00.000Z'));
+    expect(out).toBe('2026-07-02T17:00');
+  });
+
+  it('invalid Date → empty string', () => {
+    expect(dateTimeToJerusalemLocalInput(new Date('invalid'))).toBe('');
+  });
+
+  it('non-Date input → empty string', () => {
+    // @ts-expect-error - intentionally wrong type for defensive coverage
+    expect(dateTimeToJerusalemLocalInput('2026-07-02T14:00:00Z')).toBe('');
+    // @ts-expect-error - same
+    expect(dateTimeToJerusalemLocalInput(null)).toBe('');
+  });
+
+  it('midnight 00:00 IL — preserves the date without rolling back', () => {
+    // 2026-07-01T21:00:00Z = 2026-07-02 00:00 IL DST.
+    const out = dateTimeToJerusalemLocalInput(new Date('2026-07-01T21:00:00.000Z'));
+    expect(out).toBe('2026-07-02T00:00');
   });
 });


### PR DESCRIPTION
## Summary

Final cleanup PR for the G.3.7→G.3.11 TZ-bug sequence. Adds preventative ESLint rule + closes 5 remaining known sites + introduces `dateTimeToJerusalemLocalInput()` helper for datetime-local inputs.

## Changes

**ESLint rule (`eslint.config.js`):**
- New `no-restricted-syntax` matching `.toISOString().slice/substring/split(...)` repo-wide
- Severity = **`'warn'`** initially (~30 pre-existing violations exist outside this PR's scope; `'error'` would block CI on unrelated PRs)
- Allowlist: `tz-helper.js` + test files
- Added `.claude/**` to global ignores (one-off Firestore investigation scripts)

**5 fixed sites:**
| File | Was | Now |
|------|-----|-----|
| `TaskFormManager.js:61` | `.toISOString().slice(0,16)` | `dateTimeToJerusalemLocalInput(tomorrow)` |
| `master-admin-wrappers.js:661` | `.toISOString().split('T')[0]` | `normalizeDateToYMD(weekAgo)` |
| `audit.js:100` | `.toISOString().split('T')[0]` | `todayInJerusalemYMD()` |
| `WorkloadCalculator.js:1314` | debug `console.log` | removed |
| `ai-context-builder.js:153` | UTC fallback | `eslint-disable-next-line` + rationale |

**New helper:** `dateTimeToJerusalemLocalInput(date) → 'YYYY-MM-DDTHH:mm'` in Asia/Jerusalem via `Intl.DateTimeFormat.formatToParts`. 7 new Vitest tests.

## Mental models (per per-app CLAUDE.md files)

**functions/CLAUDE.md:**
- Writes: `deletion_metrics/daily_${today}` bucket key now IL-anchored (was UTC = 3-4h skew → wrong bucket near IL midnight)
- Reads: `entry.date >= weekAgoStr` string comparison unchanged; only boundary value is now IL-correct
- No CREATE/UPDATE/DELETE paths altered; no aggregate drift
- Backward compat: existing audit entries keep their bucket keys; new entries land in correct IL-anchored buckets

**apps/admin-panel/CLAUDE.md:**
- WorkloadCalculator change is dead-debug removal. No displayed data, no filtering, no counts, no permissions affected.

**apps/user-app/CLAUDE.md:**
- TaskFormManager: visible default datetime picker value now correctly shows IL time. IL users in winter saw "19:00" default, now see "17:00" as intended. Behavioral consistency improvement; no flow / submission change.

## Risk

**Read-only fixes + non-blocking lint rule.** No schema, no migration. Rollback = `git revert <commit>` (additive only).

## Tests

- Vitest: **293/295 pass** (288 + 7 new for dateTimeToJerusalemLocalInput, 2 pre-existing skips)
- Jest: **581/581** (no functions/ logic changes — only `require()` additions + helper calls)
- Lint: **0 errors**, ~30 new `no-restricted-syntax` warnings (intentional, tracked)

## Grader

**VERDICT: PASS_WITH_WARNINGS (10/10 MUST + 4/4 SHOULD)** — warnings were process-only (PR-body sections, rubric staging) — addressed in this PR.

## Follow-up (task #19)

After this PR merges, ~30 pre-existing violations remain across:
- **Admin Panel (15):** DataManager (2), ReportGenerator (1), ClientManagementModal (2), ClientsTable (1), UserDetailsModal (~10)
- **User App (8):** main.js (3 — different sites than G.3.10 fixed), dialogs, forms (2), timesheet (2), quick-log (2)
- **Tests (1):** test-concurrent-users.js (review intent)

Plan: incremental cleanup PR (**G.3.12 / G.4.x** — task #19) → flip rule severity from `'warn'` to `'error'`.

## Closes TZ-bug sequence

| PR | Scope | Status |
|----|-------|--------|
| G.3.7 | `functions/shared/calendar.js` (hebcal HDate conversion) | ✅ merged |
| G.3.8 | WhatsApp bot today-lookup | ✅ merged |
| G.3.9 | timesheet write paths (createQuickLogEntry / addTimeEntry / updateTimesheetEntry) | ✅ merged |
| G.3.10 | user-app frontend readers (main.js / daily-meter / ai-context) | ✅ merged |
| **G.3.11** | **ESLint rule + final 5 sites + datetime-local helper** | **this PR** |

## Test plan

- [x] Vitest + Jest green
- [x] Lint 0 errors
- [ ] Deploy Preview CI green
- [ ] Manual: open user-app DEV → "Add Task" → confirm deadline default = tomorrow **17:00** IL (not 19:00 or 20:00)
- [ ] Manual (post-merge to production-stable): admin panel master view → confirm `hoursThisWeek` correct at IL midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)