### PR TITLE
fix(deduction): prefer fresh packages over depleted (PR-DED-1)

### DIFF
--- a/.claude/rubrics/pr-ded-1.md
+++ b/.claude/rubrics/pr-ded-1.md
@@ -1,0 +1,96 @@
+# Rubric — PR-DED-1
+
+**Title:** fix(deduction): prefer fresh packages over depleted in getActivePackage
+**Branch:** fix/deduction-active-package-selection
+**Base:** main
+**Scope:** Fix selection-priority bug in `getActivePackage` that caused depleted packages to be selected for deduction even when fresh packages were available, blocking customers from logging hours (CLIENT_OVERDRAFT_SOFT "פנה לגיא") despite paid-for fresh hours. Bug confirmed via client 2026065 (Miri Daniel) stage_a: pkg_initial (depleted, hoursRemaining=-7.6) was selected instead of pkg_additional (active, hoursRemaining=35.5). Fix introduces two-pass selection (fresh first, then depleted fallback) with FIFO tie-break by purchaseDate.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Two-pass selection in canonical helper
+**Rule:** `getActivePackage` in `functions/src/modules/deduction/deduction-logic.js` MUST return a package with `hoursRemaining > 0` whenever one exists in the eligible status set, before falling back to depleted/overdraft packages.
+**Evidence required:** `functions/tests/get-active-package.test.js` — test "Bug repro: depleted initial + fresh additional → returns fresh additional" passes.
+
+### M2 — FIFO tie-break by purchase date
+**Rule:** When multiple fresh packages exist (`hoursRemaining > 0`), the OLDEST package by `purchaseDate` (or `createdAt` if missing) MUST be returned. Drains old additionals before new ones — matches per-package billing model.
+**Evidence required:** test "two fresh packages → returns oldest by purchaseDate ASC" passes.
+
+### M3 — Backward compatibility preserved (single depleted package)
+**Rule:** When a stage/service has only depleted/overdraft packages and `allowOverdraft=true`, the function MUST return the eligible fallback package (within `-10h` floor or unrestricted if `overrideActive=true`).
+**Evidence required:** tests "BC: single package, status=active, hoursRemaining=-5 → returns it" + "overrideActive=true + only depleted past -10h → returns depleted" pass.
+
+### M4 — overrideActive preserves fresh-first priority
+**Rule:** With `overrideActive=true`, fresh packages MUST still take priority over depleted. Override only bypasses the `-10h` floor in fallback pass.
+**Evidence required:** test "overrideActive=true + depleted+fresh → returns FRESH (priority preserved)" passes.
+
+### M5 — Trigger inline duplicates aligned
+**Rule:** Both inline package-selection fallbacks in `functions/triggers/timesheet-trigger.js` (HOURS path + LEGAL_PROCEDURE path) MUST apply the same two-pass priority: fresh first, then depleted fallback.
+**Evidence required:** grep diff for the two inline filter sites — both show fresh-first selection then fallback.
+
+### M6 — No regressions in existing test suites
+**Rule:** All existing tests in `functions/tests/` and `tests/unit/` MUST pass.
+**Evidence required:** `jest` output `599+ passed, 0 failed` for `functions/tests/`; `vitest` passes for `tests/unit/deduction.test.ts`.
+
+### M7 — G3 monitoring (PRODUCT-GRADE)
+**Rule:** When fallback path is taken (depleted/overdraft selected because no fresh exists), the function MUST emit a structured `console.warn` with package id, status, hoursRemaining, overrideActive. Allows post-deploy detection of clients stuck on depleted.
+**Evidence required:** test output shows the warn line during fallback tests.
+
+## SHOULD criteria (warning on FAIL, doesn't block)
+
+### S1 — README updated
+**Rule:** `functions/src/modules/deduction/README.md` should reflect the new selection priority + the API signature with `allowOverdraft` and `overrideActive` parameters.
+**Evidence required:** README contains "Selection priority" section + version-history entry for v3.1.0 (PR-DED-1).
+
+### S2 — Stale comment refresh
+**Rule:** The block comment header at `getActivePackage` should describe the new two-pass selection, not the legacy "first package" behavior.
+**Evidence required:** diff shows updated docblock with "Two-pass selection" explanation.
+
+### S3 — Integration test imports the real exported function
+**Rule:** New test file should `require` the actual `getActivePackage` from `functions/src/modules/deduction/deduction-logic.js` (no inline mock).
+**Evidence required:** `functions/tests/get-active-package.test.js` line 21 has `const { getActivePackage } = require('../src/modules/deduction/deduction-logic');`.
+
+## Out of scope
+
+This PR explicitly does NOT:
+
+- Bring `apps/user-app/src/modules/deduction/deduction-logic.js` (drifted v1) to parity with `functions/`. Tommy decision: leave for separate work.
+- Fix `overrideActive` propagation in legal_procedure deduction paths (feature gap since 2026-03-15; tracked as PR-DED-2). Grader confirmed via 3 sub-agents: NOT a regression, NEVER worked end-to-end. Out of PR-DED-1 scope.
+- Backfill / migrate existing PROD clients stuck on depleted packages. Post-deploy data audit (Firestore query) is operational, not code change.
+- Touch the `setServiceOverride` API at `clients/index.js:1208` (rejects non-HOURS — feature gap, PR-DED-2).
+- Cleanup historical investigation scripts (`scripts/investigate-overdraft-2025306.js` etc.) that reference legacy contract.
+
+## Rollback
+
+Trivial code-only revert:
+
+```bash
+git revert <merge-commit-sha>
+git push origin production-stable
+```
+
+No data migration. No schema change. New entries written between deploy and revert will be attributed to fresh packages instead of depleted — this is data-correct (the fix routes deduction to the right place), so revert preserves data integrity.
+
+If selective rollback needed without reverting: hot-patch `getActivePackage` to call `.find()` on the eligible-status set without the two-pass filter (returns old behavior).
+
+## PRODUCT-GRADE GATES status
+
+- **G1** — customer-visible errors are professional → **PASS** (existing Hebrew CLIENT_OVERDRAFT_SOFT message preserved; fix REDUCES misfires)
+- **G2** — rollback path documented → **PASS** (this section)
+- **G3** — monitoring touched (data-mutating? selection logic is read-only mid-deduction) → **PASS** (`console.warn` on fallback selection)
+- **G4** — test proves customer scenario → **PASS** (`functions/tests/get-active-package.test.js` "Bug repro" mirrors Miri 2026065 PROD data)
+- **G5** — Hebrew customer-facing text → **N/A** (no UI strings changed; backend logic only)
+- **G6** — no breaking change without migration plan → **PASS_WITH_NOTE** (behavioral change: new entries attribute to fresh package instead of depleted. NEW entries only. Existing entries unchanged. Per-package report breakdown will show different attribution after deploy — documented in PR body.)
+- **G7** — security review if auth/PII/permissions touched → **N/A** (no auth/PII/permission changes; selection logic only. Verified by security sub-agent in investigation phase.)
+
+## Notes for grader
+
+- Bug found via PROD data investigation on client 2026065 (Miri Daniel). Console output verified: `pkg_initial=depleted, -7.6h; pkg_additional=active, 35.5h`. Fix routes deduction to additional → customer can resume work.
+- Three sub-agents (backend, security, devils-advocate + completeness-checker, navigator, data-investigator) consulted during investigation phase. Findings:
+  - Backend: confirmed safe; identified inline duplicates in trigger.
+  - Security: PASS_WITH_WARNINGS — per-package floor evasion vector exists today via package stacking, not introduced by this PR.
+  - Devils-advocate: SHIP with guard; per-package floor is intentional system-wide.
+  - Completeness-checker: flagged stale README + comment + user-app drift; 3 included in PR (README/comment/missed-trigger-site), 1 deferred (user-app drift) per Tommy decision.
+  - Navigator (post-deploy): confirmed 7 sites in 3 files broken for override+legal_procedure — feature gap, tracked separately as PR-DED-2.
+  - Data-investigator: confirmed override for legal_procedure NEVER worked — gap since 8b5f922 (March 15, 2026). PR-DED-1 deliberately scoped to selection only.
+- Tests verified: 18 new + 599 existing + 19 vitest = 636 total passed, 0 failed.
+- This PR runs alongside PR-B.12's `log_only` soak mode (task #5 pending) — net safety: any invariant drift will be logged before becoming enforcement.

--- a/functions/src/modules/deduction/README.md
+++ b/functions/src/modules/deduction/README.md
@@ -88,8 +88,44 @@ const hours = DeductionSystem.calculateRemainingHours(service);
 
 ### Deduction Logic
 
-#### `getActivePackage(stage)`
-מוצא חבילה פעילה בשלב.
+#### `getActivePackage(stage, allowOverdraft = true, overrideActive = false)`
+מוצא חבילה לקיזוז בשלב/בשירות, לפי סדר עדיפויות.
+
+**Parameters:**
+- `stage` (Object) — Stage or service object with `packages` array
+- `allowOverdraft` (boolean) — אם `false`, מחזיר רק חבילות עם שעות חיוביות (strict mode)
+- `overrideActive` (boolean) — אם `true`, רצפת ה-10h- נעקפת בpass הfallback
+
+**Selection priority (PR-DED-1, 2026-05-25):**
+
+1. **Fresh pass** — מעדיף חבילה **הוותיקה ביותר** (לפי `purchaseDate` / `createdAt` עולה) שעומדת בכל אלה:
+   - `hoursRemaining > 0`
+   - `status ∈ {'active', 'pending', no-status}`
+
+2. **Fallback pass** (רק אם `allowOverdraft=true`) — אם אין fresh, מחזיר חבילה ראשונה שעומדת ב:
+   - `status ∈ {'active', 'pending', 'overdraft', 'depleted'}` (Branch A — modern stage)
+   - או `status ∈ {'active', 'overdraft', 'depleted', no-status}` (Branch B — BC, stage ללא `.status`)
+   - `hoursRemaining > -10` (או כל ערך אם `overrideActive=true`)
+
+3. אם אין מועמדים → `null`.
+
+**Why two passes:** מערכת ה-billing מציגה ללקוח breakdown פר-חבילה (`ReportGenerator.renderPackagesBreakdown`). drain של חבילה ישנה לפני חדשה הוא FIFO billing נכון. בנוסף — חבילה depleted אסור שתבלוק רישום שעות אם יש חבילה טריה זמינה.
+
+**Example (Miri Daniel, client 2026065 stage_a):**
+```javascript
+const stage = {
+  status: 'active',
+  packages: [
+    { id: 'pkg_initial',    status: 'depleted', hoursRemaining: -7.6, purchaseDate: '2025-06-01' },
+    { id: 'pkg_additional', status: 'active',   hoursRemaining: 35.5, purchaseDate: '2026-05-25' }
+  ]
+};
+const pkg = DeductionSystem.getActivePackage(stage);
+// Pre-PR-DED-1: returned pkg_initial (depleted, blocked customer at -10h floor)
+// Post-PR-DED-1: returns pkg_additional (fresh, customer can log hours)
+```
+
+**G3 monitoring:** הפונקציה כותבת `console.warn` כש-fallback נבחר (חבילה לא-fresh). מאפשר זיהוי שלבים שצריכים חבילה חדשה.
 
 #### `deductHoursFromPackage(pkg, hours)`
 קיזוז שעות מחבילה (כולל סגירה אוטומטית).
@@ -156,6 +192,16 @@ npm run test calculators.test.ts
 - [DATA_STRUCTURE_STANDARD.md](../../docs/DATA_STRUCTURE_STANDARD.md) - מבנה הנתונים
 
 ## 📝 Version History
+
+### v3.1.0 (2026-05-25) — PR-DED-1
+- 🐛 fix: `getActivePackage` בחר חבילה ראשונה במערך גם אם depleted, מתעלם מחבילה טרייה שזמינה
+- ✨ selection priority חדש: fresh-first ב-pass ראשון, fallback ל-depleted/overdraft רק אם אין fresh
+- ✨ FIFO tie-break לפי `purchaseDate` / `createdAt` ASC (drain ישן לפני חדש)
+- ✨ G3 monitoring: `console.warn` בfallback path
+- 🧪 18 בדיקות חדשות ב-`functions/tests/get-active-package.test.js`
+
+### v3.0.0 (2025-11-23)
+- 🏗️ Architectural upgrade — immutable patterns ב-`deductHoursFromPackage` / `deductHoursFromStage`
 
 ### v1.0.0 (2025-11-11)
 - ✨ מודול מודולרי חדש

--- a/functions/src/modules/deduction/deduction-logic.js
+++ b/functions/src/modules/deduction/deduction-logic.js
@@ -46,57 +46,144 @@
  */
 
 /**
- * Finds the active package in a stage
+ * Finds the active package in a stage/service for deduction.
  *
- * @param {Object} stage - Stage object with packages array
- * @param {boolean} allowOverdraft - Allow packages with negative hours (up to -10)
- * @returns {Object|null} Active package or null if not found
+ * @param {Object} stage - Stage or service object with packages array
+ * @param {boolean} allowOverdraft - Allow falling back to packages with negative hours (up to -10)
+ * @param {boolean} overrideActive - When true, the -10h floor is bypassed in the fallback pass
+ * @returns {Object|null} Selected package or null if none eligible
  *
- * 🔥 FIX (2025-12-01): במבנה החדש של Legal Procedure v2.0,
- * כאשר stage.status === 'active', החבילה הראשונה צריכה להיות active
- * גם אם package.status === 'pending' (זה מצב תקין!)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * 📝 SELECTION PRIORITY (PR-DED-1, 2026-05-25)
+ * ═══════════════════════════════════════════════════════════════════════════
  *
- * ✅ UPGRADE (2025-12-21): תמיכה ב-overdraft עד -10 שעות
- * כדי למנוע הפרעה למהלך העבודה התקין
+ * Two-pass selection:
+ *   1. **Fresh pass:** prefer the OLDEST package (by purchaseDate / createdAt
+ *      ascending) with `hoursRemaining > 0` AND status in
+ *      ['active', 'pending', no-status]. This drains old "additional"
+ *      packages FIFO before newer ones — matches per-package billing model
+ *      surfaced by `ReportGenerator.renderPackagesBreakdown`.
+ *
+ *   2. **Fallback pass (only if allowOverdraft):** if no fresh package
+ *      exists, return the first eligible package within the -10h floor
+ *      (or any package if overrideActive=true). Status set includes
+ *      'overdraft' and 'depleted' to keep BC for legacy single-package
+ *      overdraft flows.
+ *
+ * Why this exists:
+ *   Before this fix, `.find()` returned the FIRST eligible package, which
+ *   meant a depleted initial package (hoursRemaining=-7.6, status=depleted)
+ *   was selected even when a fresh additional package (hoursRemaining=35.5,
+ *   status=active) existed alongside it. Result: customer-blocking
+ *   CLIENT_OVERDRAFT_SOFT errors despite having paid for fresh hours.
+ *
+ * Historical context (preserved):
+ *   - 2025-12-01: pending packages eligible when stage.status === 'active'
+ *   - 2025-12-21: overdraft window (-10h) for uninterrupted workflow
+ *   - 2026-05-25 (this fix): fresh-first priority over depleted
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
  */
 
 const { SYSTEM_CONSTANTS } = require('../../../shared/constants');
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+
+// Helper: ascending sort key for FIFO tie-break of fresh packages
+function _packageOrderKey(pkg) {
+  const raw = pkg.purchaseDate || pkg.createdAt;
+  if (!raw) return Number.POSITIVE_INFINITY; // no timestamp → sort to end
+  const t = new Date(raw).getTime();
+  return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+}
 
 function getActivePackage(stage, allowOverdraft = true, overrideActive = false) {
   if (!stage || !stage.packages || stage.packages.length === 0) {
     return null;
   }
 
-  // 🔥 FIX: אם השלב הוא active, קח את החבילה הראשונה עם שעות
-  // זה פותר את הבאג שבו stage_b.status='active' אבל package.status='pending'
+  // Branch A: modern data — packages live under an active/completed stage.
+  // Eligible statuses include 'pending' (legal_procedure v2.0 — stage active,
+  // first package may carry status='pending' initially).
   if (stage.status === 'active' || stage.status === 'completed') {
-    return stage.packages.find(pkg => {
-      const isActiveOrPending = !pkg.status || pkg.status === 'active' || pkg.status === 'pending' || pkg.status === 'overdraft' || pkg.status === 'depleted';
-      const hoursRemaining = pkg.hoursRemaining || 0;
+    const eligibleStatus = (s) =>
+      !s || s === 'active' || s === 'pending' || s === 'overdraft' || s === 'depleted';
 
-      if (allowOverdraft) {
-        // ✅ אפשר חריגה עד -10 שעות (כולל חבילות depleted)
-        return isActiveOrPending && (overrideActive || hoursRemaining > -10);
-      } else {
-        // התנהגות מקורית - רק חבילות עם שעות חיוביות
-        return isActiveOrPending && hoursRemaining > 0;
-      }
+    // Pass 1 (fresh): hoursRemaining > 0 AND status fresh-or-pending.
+    // FIFO tie-break by purchaseDate/createdAt ascending — old "additional"
+    // packages drain before newly purchased ones.
+    const freshCandidates = stage.packages.filter(pkg => {
+      const status = pkg.status;
+      const isFresh = !status || status === 'active' || status === 'pending';
+      return isFresh && (pkg.hoursRemaining || 0) > 0;
+    });
+    if (freshCandidates.length > 0) {
+      freshCandidates.sort((a, b) => _packageOrderKey(a) - _packageOrderKey(b));
+      return freshCandidates[0];
+    }
+
+    // No allowOverdraft → strict mode, no depleted fallback.
+    if (!allowOverdraft) {
+      return null;
+    }
+
+    // Pass 2 (fallback): depleted/overdraft within -10h floor (or any if override).
+    const fallbackA = stage.packages.find(pkg => {
+      if (!eligibleStatus(pkg.status)) return false;
+      const hoursRemaining = pkg.hoursRemaining || 0;
+      return overrideActive || hoursRemaining > -10;
     }) || null;
+    if (fallbackA) {
+      try {
+        console.warn(
+          `[deduction] getActivePackage fallback to non-fresh package id=${fallbackA.id} ` +
+          `status=${fallbackA.status || 'none'} hoursRemaining=${fallbackA.hoursRemaining || 0} ` +
+          `overrideActive=${overrideActive}`
+        );
+      } catch (_) { /* logging is best-effort */ }
+    }
+    return fallbackA;
   }
 
-  // Backward compatibility: packages ישנים ללא stage.status
-  // Find first package with status 'active' (or no status) and hoursRemaining > 0
-  return stage.packages.find(pkg => {
-    const isActive = !pkg.status || pkg.status === 'active' || pkg.status === 'overdraft' || pkg.status === 'depleted';
-    const hoursRemaining = pkg.hoursRemaining || 0;
+  // Branch B: BC — legacy packages without an explicit stage.status.
+  // Eligible statuses tighter ('pending' NOT included here, matching legacy).
+  const eligibleStatusBC = (s) =>
+    !s || s === 'active' || s === 'overdraft' || s === 'depleted';
 
-    if (allowOverdraft) {
-      return isActive && (overrideActive || hoursRemaining > -10);
-    } else {
-      return isActive && hoursRemaining > 0;
-    }
+  // Pass 1 (fresh): hoursRemaining > 0 AND status active-or-none.
+  const freshCandidatesBC = stage.packages.filter(pkg => {
+    const status = pkg.status;
+    const isFresh = !status || status === 'active';
+    return isFresh && (pkg.hoursRemaining || 0) > 0;
+  });
+  if (freshCandidatesBC.length > 0) {
+    freshCandidatesBC.sort((a, b) => _packageOrderKey(a) - _packageOrderKey(b));
+    return freshCandidatesBC[0];
+  }
+
+  if (!allowOverdraft) {
+    return null;
+  }
+
+  // Pass 2 (fallback): same -10h floor + override semantics as Branch A.
+  const fallback = stage.packages.find(pkg => {
+    if (!eligibleStatusBC(pkg.status)) return false;
+    const hoursRemaining = pkg.hoursRemaining || 0;
+    return overrideActive || hoursRemaining > -10;
   }) || null;
+
+  // PR-DED-1 G3 monitoring: log when fallback path is taken (depleted/overdraft
+  // selected because no fresh package exists). Helps spot misconfigured stages
+  // post-deploy.
+  if (fallback) {
+    try {
+      console.warn(
+        `[deduction] getActivePackage fallback to non-fresh package id=${fallback.id} ` +
+        `status=${fallback.status || 'none'} hoursRemaining=${fallback.hoursRemaining || 0} ` +
+        `overrideActive=${overrideActive}`
+      );
+    } catch (_) { /* logging is best-effort */ }
+  }
+  return fallback;
 }
 
 /**

--- a/functions/tests/get-active-package.test.js
+++ b/functions/tests/get-active-package.test.js
@@ -1,0 +1,279 @@
+/**
+ * PR-DED-1 (2026-05-25) — getActivePackage selection priority.
+ *
+ * Tests the canonical exported function (not an inline mock). Covers:
+ *   - Bug repro: depleted initial + fresh additional → returns fresh
+ *   - BC: single package, depleted within -10h → returns it (allowOverdraft)
+ *   - BC: single package, active hours>0 → returns it
+ *   - All depleted past -10h → null
+ *   - allowOverdraft=false → strict mode, only fresh packages
+ *   - overrideActive + depleted past -10h → returns it
+ *   - overrideActive + depleted+fresh → returns FRESH (priority preserved)
+ *   - FIFO tie-break by purchaseDate ascending
+ *   - Stage status BC branch (no stage.status field)
+ *   - Branch A: pending status eligible when stage.status='active'
+ *
+ * Imports the real module to prevent fossil tests.
+ */
+
+const { getActivePackage } = require('../src/modules/deduction/deduction-logic');
+
+describe('getActivePackage — PR-DED-1 selection priority', () => {
+
+  // ─── Bug repro: Miri Daniel (2026065) Stage A ───
+  test('Bug repro: depleted initial + fresh additional → returns fresh additional', () => {
+    const stage = {
+      id: 'stage_a',
+      status: 'active',
+      packages: [
+        {
+          id: 'pkg_initial_a_1777470303951',
+          type: 'initial',
+          status: 'depleted',
+          hours: 24.5,
+          hoursUsed: 32.1,
+          hoursRemaining: -7.6,
+          purchaseDate: '2025-06-01T00:00:00.000Z'
+        },
+        {
+          id: 'pkg_additional_stage_a_1779705754049',
+          type: 'additional',
+          status: 'active',
+          hours: 35.5,
+          hoursUsed: 0,
+          hoursRemaining: 35.5,
+          purchaseDate: '2026-05-25T00:00:00.000Z'
+        }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pkg_additional_stage_a_1779705754049');
+    expect(result.type).toBe('additional');
+  });
+
+  // ─── BC: single depleted package within -10h ───
+  test('BC: single package, status=active, hoursRemaining=-5 → returns it (allowOverdraft fallback)', () => {
+    const stage = {
+      // no stage.status — BC branch
+      packages: [
+        { id: 'pkg_only', status: 'active', hoursRemaining: -5 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pkg_only');
+  });
+
+  // ─── BC: single active with positive hours ───
+  test('BC: single package, status=active, hoursRemaining=10 → returns it (fresh pass)', () => {
+    const stage = {
+      packages: [
+        { id: 'pkg_only', status: 'active', hoursRemaining: 10 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pkg_only');
+  });
+
+  // ─── All depleted past -10h ───
+  test('all packages past -10h → returns null without override', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'pkg_1', status: 'depleted', hoursRemaining: -12 },
+        { id: 'pkg_2', status: 'depleted', hoursRemaining: -15 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).toBeNull();
+  });
+
+  // ─── overrideActive: bypass -10h floor ───
+  test('overrideActive=true + only depleted past -10h → returns depleted', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'pkg_only', status: 'depleted', hoursRemaining: -20 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, /* overrideActive */ true);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pkg_only');
+  });
+
+  // ─── overrideActive does NOT bypass fresh-first priority ───
+  test('overrideActive=true + depleted+fresh → returns FRESH (priority preserved)', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'depleted_pkg', status: 'depleted', hoursRemaining: -20 },
+        { id: 'fresh_pkg', status: 'active', hoursRemaining: 10 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, /* overrideActive */ true);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('fresh_pkg');
+  });
+
+  // ─── allowOverdraft=false: strict mode ───
+  test('allowOverdraft=false + only depleted → returns null', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'pkg_only', status: 'depleted', hoursRemaining: -5 }
+      ]
+    };
+
+    const result = getActivePackage(stage, /* allowOverdraft */ false, false);
+    expect(result).toBeNull();
+  });
+
+  test('allowOverdraft=false + active hours>0 → returns it', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'pkg_only', status: 'active', hoursRemaining: 5 }
+      ]
+    };
+
+    const result = getActivePackage(stage, /* allowOverdraft */ false, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pkg_only');
+  });
+
+  // ─── FIFO tie-break: two fresh packages, oldest wins ───
+  test('two fresh packages → returns oldest by purchaseDate ASC', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        {
+          id: 'newer',
+          status: 'active',
+          hoursRemaining: 10,
+          purchaseDate: '2026-05-25T00:00:00.000Z'
+        },
+        {
+          id: 'older',
+          status: 'active',
+          hoursRemaining: 10,
+          purchaseDate: '2026-01-01T00:00:00.000Z'
+        }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('older');
+  });
+
+  // ─── FIFO with createdAt fallback ───
+  test('two fresh packages — uses createdAt when purchaseDate missing', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'newer', status: 'active', hoursRemaining: 10, createdAt: '2026-05-25T00:00:00.000Z' },
+        { id: 'older', status: 'active', hoursRemaining: 10, createdAt: '2026-01-01T00:00:00.000Z' }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result.id).toBe('older');
+  });
+
+  // ─── Pending packages eligible in modern branch ───
+  test('Branch A (stage.status=active): pending package with hours>0 is eligible', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'pending_pkg', status: 'pending', hoursRemaining: 15 }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result).not.toBeNull();
+    expect(result.id).toBe('pending_pkg');
+  });
+
+  // ─── Empty / null edge cases ───
+  test('null stage → null', () => {
+    expect(getActivePackage(null)).toBeNull();
+  });
+
+  test('stage without packages → null', () => {
+    expect(getActivePackage({ packages: [] })).toBeNull();
+  });
+
+  test('stage with undefined packages → null', () => {
+    expect(getActivePackage({})).toBeNull();
+  });
+
+  // ─── Boundary: exactly -10h (inclusive of -10 ineligible per > -10) ───
+  test('package with hoursRemaining=-10 exactly is INELIGIBLE without override', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'edge', status: 'depleted', hoursRemaining: -10 }
+      ]
+    };
+    expect(getActivePackage(stage, true, false)).toBeNull();
+  });
+
+  test('package with hoursRemaining=-9.99 IS eligible (fallback)', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'edge', status: 'depleted', hoursRemaining: -9.99 }
+      ]
+    };
+    const r = getActivePackage(stage, true, false);
+    expect(r).not.toBeNull();
+    expect(r.id).toBe('edge');
+  });
+
+  // ─── Mixed: fresh > 0 wins over older active with 0 ───
+  test('older active with 0 hours + newer active with hours → returns newer (fresh-first)', () => {
+    const stage = {
+      status: 'active',
+      packages: [
+        {
+          id: 'empty_old',
+          status: 'active',
+          hoursRemaining: 0,
+          purchaseDate: '2026-01-01T00:00:00.000Z'
+        },
+        {
+          id: 'fresh_new',
+          status: 'active',
+          hoursRemaining: 5,
+          purchaseDate: '2026-05-25T00:00:00.000Z'
+        }
+      ]
+    };
+
+    const result = getActivePackage(stage, true, false);
+    expect(result.id).toBe('fresh_new');
+  });
+
+  // ─── Status 'overdraft' is fallback-only, not fresh ───
+  test('overdraft status with positive hoursRemaining → still treated as overdraft (fallback)', () => {
+    // Edge case: rare. Confirms we don't accidentally promote 'overdraft' to fresh tier.
+    const stage = {
+      status: 'active',
+      packages: [
+        { id: 'overdraft_pkg', status: 'overdraft', hoursRemaining: 5 },
+        { id: 'active_pkg', status: 'active', hoursRemaining: 3 }
+      ]
+    };
+    // Both are eligible; active_pkg wins fresh pass.
+    const result = getActivePackage(stage, true, false);
+    expect(result.id).toBe('active_pkg');
+  });
+});

--- a/functions/triggers/timesheet-trigger.js
+++ b/functions/triggers/timesheet-trigger.js
@@ -354,12 +354,40 @@ const onTimesheetEntryChanged = onDocumentWritten({
           let resolvedPackageId = packageId;
 
           if (!resolvedPackageId) {
-            // Fallback: find first eligible package (same priority as getActivePackage)
-            const fallbackPkg = (targetService.packages || []).find((pkg) => {
-              const status = pkg.status || 'active';
-              return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
-                && (hasOverride || (pkg.hoursRemaining || 0) > -10);
-            });
+            // PR-DED-1 (2026-05-25): two-pass selection — prefer FRESH packages
+            // (hoursRemaining > 0, active/pending) over depleted ones. FIFO
+            // tie-break by purchaseDate/createdAt ASC. Matches updated
+            // getActivePackage in deduction-logic.js.
+            //
+            // ⚠️ DO NOT EDIT IN ISOLATION — the canonical implementation lives
+            // at `functions/src/modules/deduction/deduction-logic.js`
+            // `getActivePackage`. This inline duplicate exists because the
+            // trigger runs as a separate process and reimports the module
+            // would add cold-start cost. ANY change to the canonical selection
+            // priority MUST be mirrored here, and vice versa.
+            const _orderKey = (p) => {
+              const raw = p.purchaseDate || p.createdAt;
+              if (!raw) return Number.POSITIVE_INFINITY;
+              const t = new Date(raw).getTime();
+              return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+            };
+            const _packages = targetService.packages || [];
+            const _fresh = _packages
+              .filter((pkg) => {
+                const status = pkg.status || 'active';
+                const isFresh = ['active', 'pending'].includes(status);
+                return isFresh && (pkg.hoursRemaining || 0) > 0;
+              })
+              .sort((a, b) => _orderKey(a) - _orderKey(b));
+            let fallbackPkg = _fresh[0] || null;
+            if (!fallbackPkg) {
+              // Fallback: depleted/overdraft within -10h floor (override bypasses).
+              fallbackPkg = _packages.find((pkg) => {
+                const status = pkg.status || 'active';
+                return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
+                  && (hasOverride || (pkg.hoursRemaining || 0) > -10);
+              });
+            }
             if (fallbackPkg) {
               resolvedPackageId = fallbackPkg.id;
               console.log(`🔧 [timesheet-trigger] Resolved missing packageId → ${resolvedPackageId} for entry ${entryId}`);
@@ -393,12 +421,38 @@ const onTimesheetEntryChanged = onDocumentWritten({
           }
 
           if (targetStage.pricingType !== PT.FIXED && !packageId) {
-            // Fallback: find first eligible package from stage
-            const fallbackStagePkg = (targetStage.packages || []).find((pkg) => {
-              const status = pkg.status || 'active';
-              return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
-                && (pkg.hoursRemaining || 0) > -10;
-            });
+            // PR-DED-1 (2026-05-25): two-pass selection — prefer FRESH packages
+            // (hoursRemaining > 0) over depleted ones. FIFO tie-break.
+            // NOTE: overrideActive propagation for legal_procedure is a
+            // separate feature gap (PR-DED-2); this PR only fixes selection
+            // priority, preserving the current behavior of ignoring override
+            // on this code path.
+            //
+            // ⚠️ DO NOT EDIT IN ISOLATION — see note above the HOURS-path
+            // inline duplicate. Mirror with deduction-logic.js getActivePackage.
+            const _orderKey = (p) => {
+              const raw = p.purchaseDate || p.createdAt;
+              if (!raw) return Number.POSITIVE_INFINITY;
+              const t = new Date(raw).getTime();
+              return Number.isFinite(t) ? t : Number.POSITIVE_INFINITY;
+            };
+            const _packages = targetStage.packages || [];
+            const _fresh = _packages
+              .filter((pkg) => {
+                const status = pkg.status || 'active';
+                const isFresh = ['active', 'pending'].includes(status);
+                return isFresh && (pkg.hoursRemaining || 0) > 0;
+              })
+              .sort((a, b) => _orderKey(a) - _orderKey(b));
+            let fallbackStagePkg = _fresh[0] || null;
+            if (!fallbackStagePkg) {
+              // Fallback: depleted/overdraft within -10h floor.
+              fallbackStagePkg = _packages.find((pkg) => {
+                const status = pkg.status || 'active';
+                return ['active', 'pending', 'overdraft', 'depleted'].includes(status)
+                  && (pkg.hoursRemaining || 0) > -10;
+              });
+            }
 
             if (fallbackStagePkg) {
               console.log(`🔧 [timesheet-trigger] Resolved missing packageId → ${fallbackStagePkg.id} for hourly stage ${resolvedStageId}`);


### PR DESCRIPTION
## Summary

Fixes a customer-blocking PROD bug in `getActivePackage` where depleted packages were selected for deduction even when fresh packages with positive hours were available, raising `CLIENT_OVERDRAFT_SOFT` ("פנה לגיא") despite paid-for fresh hours.

**Confirmed via client 2026065 (Miri Daniel) stage_a:** `pkg_initial` (depleted, -7.6h) was selected over `pkg_additional` (active, 35.5h). User logging 3h hit `-7.6 - 3 = -10.6 < -10` → block.

**Root cause:** `.find()` returned first eligible package without preferring those with positive hours remaining. Selection logic treated `depleted` status as equivalent to `active` for selection purposes when within the -10h floor.

**Fix:** Two-pass selection. Pass 1 — oldest package (by `purchaseDate` / `createdAt` ASC) with `hoursRemaining > 0` AND status in `{active, pending, no-status}`. Pass 2 (fallback) — first eligible within `-10h` floor or any if `overrideActive=true`.

## VERDICT: PASS

Outcomes-grader (separate context) verified 7/7 MUST + 3/3 SHOULD + 7/7 product-grade gates. Rubric: `.claude/rubrics/pr-ded-1.md`.

## PRODUCT-GRADE GATES

| Gate | Status | Notes |
|------|--------|-------|
| G1 — customer-visible errors professional | PASS | No new error strings; existing Hebrew `CLIENT_OVERDRAFT_SOFT` flow preserved; fix REDUCES false misfires. |
| G2 — rollback path documented | PASS | See "Rollback" below. |
| G3 — monitoring touched (data-mutating) | PASS | `console.warn` emitted when fallback path (non-fresh package) is selected — enables post-deploy detection of clients stuck on depleted. |
| G4 — test proves customer scenario | PASS | `functions/tests/get-active-package.test.js` "Bug repro: Miri Daniel" mirrors real PROD data exactly. |
| G5 — Hebrew customer-facing text | N/A | No UI strings changed; backend selection logic only. |
| G6 — no breaking change without migration plan | PASS_WITH_NOTE | Behavioral change: NEW timesheet entries route to fresh package instead of depleted. Existing entries unchanged. Per-package report breakdown will show different attribution for new entries after deploy. No schema change. No data migration. |
| G7 — security review if PII/auth/permissions touched | N/A | No auth/PII/permission changes; selection logic only. Verified by `security` sub-agent in investigation phase. |

## Known drift (declared per G6)

- `apps/user-app/src/modules/deduction/deduction-logic.js` is a drifted v1 copy that was NOT updated in this PR (per architect decision). User App reads client data optimistically; backend is the source of truth for deduction. Divergence is documented and acceptable.
- `overrideActive` propagation in `legal_procedure` deduction paths is a pre-existing feature gap (since 2026-03-15 — verified by `data-investigator` sub-agent). Not a regression from any recent PR. Tracked separately as PR-DED-2.

## Test plan

- [x] 18 new tests in `functions/tests/get-active-package.test.js` — imports real exported function (no inline mock). Covers Miri PROD repro, FIFO tie-break, override + fresh-first priority preservation, -10h boundary, BC single-package overdraft, empty/null edge cases.
- [x] Jest functions test suite: 617 passed (599 existing + 18 new), 0 failed.
- [x] Vitest repo suite: 293 passed, 2 skipped, 0 failed.
- [x] ESLint clean on changed files.
- [ ] **DEV smoke** (post-merge): retry hours-log on client 2026065 stage_a; verify success without override. Verify report breakdown shows new entry attributed to `pkg_additional`.
- [ ] **PROD watch list** (post-deploy): Firestore query for clients with `depleted` + `active hours>0` package combos. Identify newly-unblocked clients.

## Rollback

Trivial code-only revert:

```bash
git revert <merge-commit-sha>
git push origin production-stable
```

No data migration. New entries written between deploy and revert are data-correct (route to fresh package); revert preserves integrity.

If selective rollback needed without full revert: hot-patch `getActivePackage` to call `.find()` on the eligible-status set without the two-pass filter — restores old behavior.

## Agent trail (auditable)

Investigation + verification: gatekeeper → effort-scaler → backend → security → devils-advocate → completeness-checker → navigator → data-investigator → reviewer → outcomes-grader (10 sub-agents, multiple parallel batches).

Key findings:
- Backend: confirmed safe; identified inline duplicates in trigger to fix.
- Security: PASS_WITH_WARNINGS — per-package floor "evasion" vector exists today via package stacking, NOT introduced by this PR.
- Devils-advocate: SHIP with G3 guard; per-package floor is intentional system-wide.
- Completeness-checker: flagged stale README + docblock + user-app drift; 3 addressed in PR, 1 deferred per architect decision.
- Navigator: confirmed 7 sites broken for override+legal_procedure — feature gap, tracked as PR-DED-2.
- Data-investigator: override for legal_procedure NEVER worked end-to-end — gap since 8b5f922 (2026-03-15). Scoped PR-DED-1 to selection priority only.
- Reviewer: APPROVE with nits — DRY trigger duplicates flagged with DO-NOT-EDIT comments; user-app drift declared above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)