### PR TITLE
chore(gitignore): ignore personal analysis xlsx in docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist/**/*.map
 
 # Uploaded presentations (use Firebase Storage)
 .claude/presentations/
+
+# Personal/draft analysis documents in docs/ (not part of the system)
+docs/LAW_OFFICE_SYSTEM_ניתוח_מקצועי.xlsx


### PR DESCRIPTION
## Summary

Adds one line to `.gitignore` so the personal/draft analysis document `docs/LAW_OFFICE_SYSTEM_ניתוח_מקצועי.xlsx` stops appearing as untracked in every `git status`. The file itself is NOT committed — only ignored.

## Context

The file has lived in the working tree since April 2026 (per filesystem metadata) but was never tracked. It's a personal analysis document (24KB xlsx), not part of the system. Surfaced during post-merge cleanup of PR #330.

## VERDICT: PASS

Trivial 3-line `.gitignore` addition. No code change. No test impact. No production risk.

## PRODUCT-GRADE GATES

| Gate | Status | Justification |
|------|--------|---------------|
| G1 Customer-visible errors | N/A | No code change. |
| G2 Rollback path < 5 min | PASS | `git revert <commit>` — single-line gitignore reversal. |
| G3 Monitoring on data mutations | N/A | No data. |
| G4 Test proves customer scenario | N/A | No customer-facing behavior. |
| G5 Hebrew customer-facing text | N/A | No UI. |
| G6 No breaking change without migration | PASS | No behavior change at all. |
| G7 Security agent review | N/A | No PII / auth / permissions. |

## Rollback

```bash
git revert <commit>
```

## Test plan

- [x] `git status` — file no longer listed as untracked
- [ ] CI lint + tests on PR (expected: pass, no code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)