### PR TITLE
fix(aggregates): exclude archived services from client-level totals (PR-G.3.14)

### DIFF
--- a/.claude/rubrics/pr-g-3-14.md
+++ b/.claude/rubrics/pr-g-3-14.md
@@ -1,0 +1,115 @@
+# Rubric — PR-G.3.14: exclude `archived` services from client-level aggregates + frontend parity + ReportGenerator consistency
+
+**Scope:** client-level aggregate fields (`client.totalHours`, `client.hoursUsed`, `client.hoursRemaining`, `client.minutesUsed`, `client.minutesRemaining`, `client.isBlocked`, `client.isCritical`) incorrectly include services with `status === 'archived'`. Bug surfaced via client 2025724: archived service (`srv_1766392900070`, 42h) inflates `client.totalHours` from 34 to 76 and masks an 8.9h overdraft on the active service. Fix at SSOT (`functions/shared/aggregates.js`) + frontend parity + printed report. Backfill via existing `repairClientAggregates` callable.
+
+**Narrowed-scope decision (Haim, 2026-05-27, post devils-advocate):** filter `archived` ONLY. NOT `completed` (8 services in PROD — billing-locked, audit history). NOT `on_hold` (0 in PROD — temporary pause may resume). Lifetime contract value reachable via `services[].totalHours` reduce.
+
+**Semantic decision:** `client.totalHours` becomes "active billable capacity" (derived, Choice A). Historical contract pool preserved in `services[]` array (no data lost — relocated).
+
+**App + Env:** Functions + Admin Panel | DEV first → PROD via auto-deploy on main push (Cloud Functions + rules) + production-stable merge (Netlify hosting). Two-step PROD reach.
+
+## MUST (8) — blocking
+
+1. **`functions/shared/aggregates.js` filter applied + invariants doc updated.** Adds `NON_AGGREGATING_STATUSES = Object.freeze(['archived'])` constant. `calcClientAggregates` filters services by this constant in addition to existing `isFixedService` filter. `totalHours` derived from active billable services (Choice A). JSDoc invariants I1-I4 (lines 33-39) updated to mention status filter. *Evidence:* grep diff shows constant + filter + invariant doc update; no `Math.max(0,` or other clamps introduced.
+
+2. **`functions/shared/client-writer.js:recomputeTotalHours` matches aggregates.js filter.** Imports `NON_AGGREGATING_STATUSES` from aggregates.js and applies same filter in addition to existing fixed-service skip. *Evidence:* grep diff confirms import + filter. Internal consistency: both helpers compute on the same active subset.
+
+3. **Frontend parallel filter in `apps/admin-panel/js/managers/ClientsDataManager.js`.** New helper `_isServiceCountedForClientAggregate(service)` returns false for archived. Applied in `calculateTotalHoursFromServices` AND `calculateRemainingHoursFromServices`. *Evidence:* grep diff confirms helper + 2 call sites; client-level row in clients table shows post-fix values without backfill needed (client recomputed on every page load).
+
+4. **`apps/admin-panel/js/managers/ReportGenerator.js` "כל השירותים" path filters archived.** Three locations (lines ~639-641, ~815-816, ~919-921) where `client.services.reduce(...)` sums totals — each skips archived services. *Evidence:* grep diff confirms 3 call-site updates; printed-report aggregate matches table aggregate for client 2025724.
+
+5. **`functions/shared/aggregates.js:assertClientAggregateInvariants` override-check alignment.** Line ~110 currently scans ALL services for `overrideActive`. Under PR-G.3.14, must also filter to active services to remain internally consistent with `calcClientAggregates`'s narrowed override scan. Otherwise spurious `I2_override_active_but_blocked` violations may fire on archived-with-override edge cases. *Evidence:* grep diff confirms aligned filter in both `calcClientAggregates` AND `assertClientAggregateInvariants`.
+
+6. **Tests added covering the new filter behavior.** At minimum 3 new unit tests in `tests/unit/aggregates/calc-client-aggregates.test.ts`:
+   - **T1**: archived service excluded from `hoursUsed`, `totalHours`, `hoursRemaining`
+   - **T2**: `completed` service STILL counted (Choice A — Haim narrowed scope; NOT excluded)
+   - **T3**: all-archived services array → I1 holds (no billable → `!isBlocked && !isCritical`)
+   
+   Plus 1 new test in `functions/tests/write-client-canonical-aggregates.test.js`:
+   - **T4**: `recomputeTotalHours` skips archived in writer path
+   
+   *Evidence:* grep diff confirms 4 new `test(...)` or `it(...)` blocks; all pass in CI.
+
+7. **`docs/CLIENTS_SYSTEM_REPORT.md` invariants table updated.** Lines 222-227 reference I1-I4 — must add note that "billable" now requires `status !== 'archived'` AND `!isFixedService`. *Evidence:* grep diff confirms doc update with PR-G.3.14 citation.
+
+8. **Backfill executed for client 2025724 BEFORE next 06:00 IL `dailyInvariantCheck`.** Post-deploy, call `repairClientAggregates({clientId: '2025724'})` from Admin Panel (or via Cloud Functions Shell). Expected result: `hoursRemaining: 16.9 → -8.93`, `isBlocked: unchanged` (override holds). *Evidence:* `audit_log` entry with `action: 'REPAIR_CLIENT_AGGREGATES'`, `before/after` showing the diff, PR-G.3.14 reason annotation. Verify in PROD via Firestore console.
+
+## SHOULD (5) — non-blocking
+
+1. **`internal_office` left to natural Cloud Function trigger correction.** Per Haim's decision (option C, 2026-05-27): NOT manually backfilled. Reasoning documented in PR body. Trigger fires on next timesheet entry for internal_office, recomputes via aggregates helper. Until then, `dailyInvariantCheck` will report drift (acceptable noise — internal client, not customer-facing).
+
+2. **Comments at fix sites cite PR-G.3.14 + narrowed scope + Choice A.** At each diff site, brief comment: `// PR-G.3.14 (2026-05-27): filter 'archived' only. completed/on_hold deferred. Lifetime contract via services[].`
+
+3. **PR body documents semantic change in plain Hebrew.** Per `apps/admin-panel/CLAUDE.md` behavioral-change-rule. State: "client.totalHours redefined from contract-pool to active-billable-capacity. Lifetime contract pool reachable via services[].totalHours reduce. Choice A — Haim approval 2026-05-27."
+
+4. **PR body lists known follow-ups.** Includes: (a) `SKIP_CLIENTS` divergence between `scheduled/index.js:291` (only `2025003`) and `repair-aggregates.js:38` (only `internal_office`) — separate PR. (b) `completed` status decision deferred — separate PR if business confirms. (c) `on_hold` filter — re-evaluate when first on_hold service appears in PROD. (d) types/services.ts schema drift (status union missing `archived`+`on_hold`+`completed`). (e) FluentDataGrid dead code investigation. (f) ReportGenerator's orphan-discovery block (`ClientReportModal.js:517-543` — PR-G.3.13 follow-up still open).
+
+5. **PR body includes all 7 PRODUCT-GRADE Gates explicit status.** Per `apps/admin-panel/CLAUDE.md` + `.claude/rubrics/_PRODUCT-GRADE-GATES.md`.
+
+## Out of scope
+
+- Filter `completed` services (deferred — 8 services in PROD, billing semantics undecided)
+- Filter `on_hold` services (deferred — 0 in PROD, decision when first one appears)
+- Unify `SKIP_CLIENTS` constants between scheduled + repair-aggregates (separate PR)
+- Add `archived` + `on_hold` to `types/services.ts:93` BaseService.status union (separate PR)
+- Investigate FluentDataGrid dead code (separate task)
+- Fix ReportGenerator orphan-discovery block name-matching (PR-G.3.13 backlog)
+- Backfill `internal_office` manually (intentional defer — natural trigger correction)
+- Centralize status constants in `functions/shared/business-rules/` (refactor — separate PR)
+- E2E test rewrite (Phase 4 separate effort, already documented in CI workflow)
+
+## Test outputs required
+
+- Unit tests: PASS (4 new tests + all existing). Existing `complete-service.test.js:264-280` MUST still PASS (asserts `completed` still aggregates — confirms Haim's narrowed scope).
+- Lint: 0 errors.
+- Diff verification: only files in scope changed. No drift into unrelated paths.
+- Manual DEV smoke (client 2025724 via Deploy Preview + main--admin-gh-law-office-system.netlify.app):
+  - Clients table row shows "−8.9 / 34 שעות" (post-backfill) OR stale value (pre-backfill) — document expected behavior in PR body
+  - Modal still shows correct per-service hours (no regression from PR-G.3.13)
+  - Printed report ("כל השירותים") sums match table (consistency confirmed)
+  - Console clean — no errors introduced
+- Backfill verification post-PROD-deploy:
+  - `audit_log` entry exists for 2025724
+  - `clients/2025724` document fields match dry-run prediction (`totalHours: 34, hoursUsed: 42.93, hoursRemaining: -8.93, isBlocked: false (override holds), isCritical: false`)
+
+## Behavioral change disclosure (per `apps/admin-panel/CLAUDE.md`)
+
+**This IS a behavioral change.** Operationally:
+- **Clients table**: clients with archived services will see lower `totalHours` and possibly different `hoursRemaining` (could surface overdraft for clients where archived hours were masking it — confirmed 1 such case: 2025724).
+- **isBlocked / isCritical**: derived from filtered set. Per dry-run: 0 clients flip false→true (no new operational blocks); 1 flip true→false (`internal_office`, broken data cleanup).
+- **Printed reports**: "כל השירותים" totals match clients table (consistency).
+- **Override semantics**: overrides on archived services no longer suppress block. Per PROD scan: 0 such cases today.
+
+**Staff retraining**: None required. Display matches reality. Pre-fix display was masking issues.
+
+**Customer impact**: None. No customer-facing app reads these aggregates. User App (employee app) reads `isBlocked` for entry validation — 0 flips → no employee gets newly blocked.
+
+## Rollback
+
+Code rollback:
+```bash
+git revert <commit-sha>
+git push origin main
+# Cloud Functions auto-redeploy + Firestore rules redeploy (~10-15 min)
+# For Netlify PROD: also merge revert to production-stable
+```
+
+Data rollback (if backfilled values are wrong):
+- `audit_log` entries contain `before` payload for each backfill operation
+- Restore via Firestore console using `before` payload
+- Acceptable: each backfill is 1 client document, no transactional cross-doc dependency
+
+Single-file rollback impossible (touches 4-6 files), but each file is independently revertable. Estimated rollback time: <10 minutes.
+
+## Deploy ordering (CRITICAL — different from PR-G.3.13)
+
+PR-G.3.13 touched frontend only. PR-G.3.14 touches **Cloud Functions** — `firebase deploy --only ...functions` runs on main push (per `.github/workflows/ci-cd-production.yml:412-470`). This means:
+
+1. **Merge to main** → CI runs → **Cloud Functions auto-deploy to PROD** (~10-15 min)
+2. **At this point**: any new timesheet write triggers the new aggregates logic immediately on PROD. Existing clients still have stale stored values until backfill.
+3. **Within ~1 hour of step 2**: call `repairClientAggregates({clientId: '2025724'})` from Admin Panel. Verify via Firestore + audit_log.
+4. **Same time**: open `main → production-stable` PR. Haim approves. Merge.
+5. **Netlify PROD auto-deploys** → frontend filter takes effect on PROD Netlify URLs.
+6. **`dailyInvariantCheck` at 06:00 IL**: 0 drifted clients (2025724 backfilled; internal_office acceptable noise).
+
+⚠️ The Cloud Function PROD deploy happens automatically — NOT gated by Haim's PROD approval. The protocol gap is a known issue (separate concern; CI workflow comment mentions it).

--- a/apps/admin-panel/js/managers/ClientsDataManager.js
+++ b/apps/admin-panel/js/managers/ClientsDataManager.js
@@ -123,6 +123,29 @@
         }
 
         /**
+         * Determine whether a service contributes to client-level aggregates.
+         * PR-G.3.14 (2026-05-27): archived services are excluded from client-level
+         * totalHours / hoursRemaining / needsAttention / overdraft signals.
+         *
+         * Mirror of `NON_AGGREGATING_STATUSES` in functions/shared/aggregates.js.
+         * Backend SSOT keeps the canonical list; frontend filter MUST stay in sync.
+         * If you add another status (e.g. 'on_hold'), update BOTH places.
+         *
+         * Lifetime contract value (across all statuses) reachable via:
+         *   client.services.reduce((s, svc) => s + (svc.totalHours || 0), 0)
+         *
+         * @param {Object} service - one entry from client.services[]
+         * @returns {boolean} true if the service counts toward client-level aggregates
+         */
+        _isServiceCountedForClientAggregate(service) {
+            if (!service) {
+                return false;
+            }
+            const status = service.status || 'active';
+            return status !== 'archived';
+        }
+
+        /**
          * Calculate remaining hours from services array
          * חישוב שעות נותרות מתוך מערך השירותים
          */
@@ -134,6 +157,10 @@
             let totalRemaining = 0;
 
             client.services.forEach(service => {
+                // PR-G.3.14: skip archived services from client-level total
+                if (!this._isServiceCountedForClientAggregate(service)) {
+                    return;
+                }
                 // Check if this is a legal procedure with stages
                 if (service.type === 'legal_procedure' && service.stages && Array.isArray(service.stages)) {
                     // For legal procedures: sum only ACTIVE stages
@@ -163,6 +190,10 @@
             let totalHours = 0;
 
             client.services.forEach(service => {
+                // PR-G.3.14: skip archived services from client-level total
+                if (!this._isServiceCountedForClientAggregate(service)) {
+                    return;
+                }
                 // Check if this is a legal procedure with stages
                 if (service.type === 'legal_procedure' && service.stages && Array.isArray(service.stages)) {
                     // For legal procedures: sum only ACTIVE stages

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -635,10 +635,14 @@ return true;
             // Handle "all services" option (hour packages only)
             if (formData.service === 'all' || formData.service === 'כל השירותים') {
                 // Sum all services
+                // PR-G.3.14 (2026-05-27): exclude archived services from "כל השירותים"
+                // aggregation. Matches frontend table (ClientsDataManager) + backend SSOT
+                // (aggregates.js NON_AGGREGATING_STATUSES). Consistency across screens.
                 if (client.services && client.services.length > 0) {
-                    serviceTotalHours = client.services.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
-                    serviceUsedHours = client.services.reduce((sum, s) => sum + ((s.totalHours || s.hours || 0) - (s.hoursRemaining || s.remainingHours || 0)), 0);
-                    serviceRemainingHours = client.services.reduce((sum, s) => sum + (s.hoursRemaining || s.remainingHours || 0), 0);
+                    const billableServices = client.services.filter(s => (s?.status || 'active') !== 'archived');
+                    serviceTotalHours = billableServices.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
+                    serviceUsedHours = billableServices.reduce((sum, s) => sum + ((s.totalHours || s.hours || 0) - (s.hoursRemaining || s.remainingHours || 0)), 0);
+                    serviceRemainingHours = billableServices.reduce((sum, s) => sum + (s.hoursRemaining || s.remainingHours || 0), 0);
                 } else {
                     serviceTotalHours = client.totalHours || 0;
                     serviceUsedHours = (client.totalHours || 0) - (client.hoursRemaining || 0);
@@ -811,8 +815,10 @@ return true;
             if (client.type === 'hours' || client.type === 'legal_procedure' || client.procedureType === 'legal_procedure') {
                 if (formData.service === 'all') {
                     // If "all services" selected, sum up all service hours
+                    // PR-G.3.14: exclude archived services (consistent with aggregates.js).
                     if (client.services && client.services.length > 0) {
-                        const totalHours = client.services.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
+                        const billableServices = client.services.filter(s => (s?.status || 'active') !== 'archived');
+                        const totalHours = billableServices.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
                         serviceTotalMinutes = totalHours * 60;
                     } else {
                         serviceTotalMinutes = (client.totalHours || 0) * 60;
@@ -915,10 +921,12 @@ return true;
             let serviceRemainingHours = 0;
 
             if (formData.service === 'all' || formData.service === 'כל השירותים') {
+                // PR-G.3.14: exclude archived services from "כל השירותים" totals.
                 if (client.services && client.services.length > 0) {
-                    serviceTotalHours = client.services.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
-                    serviceUsedHours = client.services.reduce((sum, s) => sum + ((s.totalHours || s.hours || 0) - (s.hoursRemaining || s.remainingHours || 0)), 0);
-                    serviceRemainingHours = client.services.reduce((sum, s) => sum + (s.hoursRemaining || s.remainingHours || 0), 0);
+                    const billableServices = client.services.filter(s => (s?.status || 'active') !== 'archived');
+                    serviceTotalHours = billableServices.reduce((sum, s) => sum + (s.totalHours || s.hours || 0), 0);
+                    serviceUsedHours = billableServices.reduce((sum, s) => sum + ((s.totalHours || s.hours || 0) - (s.hoursRemaining || s.remainingHours || 0)), 0);
+                    serviceRemainingHours = billableServices.reduce((sum, s) => sum + (s.hoursRemaining || s.remainingHours || 0), 0);
                 } else {
                     serviceTotalHours = client.totalHours || 0;
                     serviceUsedHours = (client.totalHours || 0) - (client.hoursRemaining || 0);

--- a/docs/CLIENTS_SYSTEM_REPORT.md
+++ b/docs/CLIENTS_SYSTEM_REPORT.md
@@ -20,9 +20,16 @@
 |---|---|---|
 | `isBlocked` | calcClientAggregates | יתרת שעות = 0 ואין override. אוטומטי. |
 | `isCritical` | calcClientAggregates | יתרת שעות ≤ 5. אוטומטי. |
-| `hoursUsed` / `hoursRemaining` | calcClientAggregates | סכום על שירותים billable |
+| `hoursUsed` / `hoursRemaining` | calcClientAggregates | סכום על שירותים billable **פעילים** |
 | `minutesUsed` / `minutesRemaining` | calcClientAggregates | המרה |
-| `totalHours` | סכום `svc.totalHours` של billable | רץ ב-helper |
+| `totalHours` | סכום `svc.totalHours` של billable **פעילים** | רץ ב-helper |
+
+**הגדרת "billable פעיל" (PR-G.3.14, 2026-05-27):**
+- `!isFixedService(svc)` (לא שירות קבוע)
+- `(svc.status || 'active') !== 'archived'` (לא בארכיון)
+- שני סטטוסים שעדיין נספרים: `'completed'` (היסטוריית billing, ראה `functions/tests/complete-service.test.js:264-280`) ו-`'on_hold'` (השהיה זמנית — עשוי לחזור)
+- ערך החוזה ההיסטורי המלא (כל הסטטוסים): `services.reduce((s, svc) => s + (svc.totalHours || 0), 0)`
+- ה-SSOT של רשימת הסטטוסים שמוצאים: `functions/shared/aggregates.js → NON_AGGREGATING_STATUSES`
 
 ### שדות ידניים (MANUAL) — קלט מ-CFs
 

--- a/functions/shared/aggregates.js
+++ b/functions/shared/aggregates.js
@@ -22,6 +22,24 @@ const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
 // tests/unit/shared/business-rules.sync.test.ts (drift guard).
 const { isFixedService } = require('./business-rules/service-classification');
 
+/**
+ * Service statuses excluded from client-level aggregates.
+ *
+ * PR-G.3.14 (2026-05-27): scope narrowed to ['archived'] only after Haim's
+ * post-devils-advocate decision. Rationale:
+ *   - 'archived' = service definitively closed; hours not part of active capacity
+ *   - 'completed' NOT filtered — billing-locked, audit history retained (test
+ *     functions/tests/complete-service.test.js:264-280 documents this intent)
+ *   - 'on_hold' NOT filtered — temporary pause, may resume; data must persist
+ *
+ * Lifetime contract value (across all statuses) reachable via:
+ *   services.reduce((s, svc) => s + (svc.totalHours || 0), 0)
+ *
+ * Trigger: client 2025724 in PROD — archived service (42h) was inflating
+ * client.totalHours and masking -8.93h overdraft on the active service.
+ */
+const NON_AGGREGATING_STATUSES = Object.freeze(['archived']);
+
 function round2(n) {
   return Math.round((n || 0) * 100) / 100;
 }
@@ -32,26 +50,52 @@ function round2(n) {
  *
  * INVARIANTS guaranteed by this function:
  *   I1: billable.length === 0  ⇒  isBlocked === false && isCritical === false
- *   I2: any service has overrideActive=true OR overdraftResolved.isResolved=true
+ *   I2: any ACTIVE service has overrideActive=true OR overdraftResolved.isResolved=true
  *       ⇒  isBlocked === false
  *   I3: isBlocked === true  ⇒  hoursRemaining <= 0
  *   I4: isCritical === true  ⇒  isBlocked === false && 0 < hoursRemaining <= 5
+ *   I5: archived services excluded from billable AND from totalHours derivation
+ *       (PR-G.3.14, 2026-05-27). client.totalHours reflects ACTIVE billable
+ *       capacity, not lifetime contract pool. Historical contract pool reachable
+ *       via services[].totalHours reduce across all statuses.
  *
- * If you write client.isBlocked / client.isCritical anywhere OTHER than from
- * this function's return value, you are creating a drift source. Don't.
+ * Choice A (PR-G.3.14): `totalHours` is RETURNED (derived from active billable
+ * services only). The `clientTotalHours` parameter is kept for backward-compat
+ * but no longer used as the source of truth for hoursRemaining. Callers SHOULD
+ * use the returned `totalHours` field; legacy callers reading only hoursUsed/
+ * hoursRemaining/isBlocked/isCritical are unaffected by parameter semantics.
+ *
+ * If you write client.isBlocked / client.isCritical / client.totalHours anywhere
+ * OTHER than from this function's return value, you are creating a drift source.
+ * Don't.
+ *
+ * @param {Array} services - client.services array
+ * @param {number} clientTotalHours - DEPRECATED in semantic; kept for backward-compat
+ * @returns {{hoursUsed:number, hoursRemaining:number, minutesUsed:number,
+ *            minutesRemaining:number, isBlocked:boolean, isCritical:boolean,
+ *            totalHours:number}}
  */
 function calcClientAggregates(services, clientTotalHours) {
-  const safeTotalHours = typeof clientTotalHours === 'number' && !Number.isNaN(clientTotalHours)
-    ? clientTotalHours
-    : 0;
+  // PR-G.3.14: filter non-aggregating statuses BEFORE the type filter, so
+  // archived services drop out of both totalHours derivation AND hoursUsed sum.
+  const activeServices = (services || []).filter(svc =>
+    !NON_AGGREGATING_STATUSES.includes(svc?.status || 'active')
+  );
 
-  const billableServices = (services || []).filter(svc => !isFixedService(svc));
+  const billableServices = activeServices.filter(svc => !isFixedService(svc));
 
   const hoursUsed = round2(
     billableServices.reduce((sum, svc) => sum + (svc.hoursUsed || 0), 0)
   );
 
-  const hoursRemaining = round2(safeTotalHours - hoursUsed);
+  // PR-G.3.14: Choice A — totalHours derived from active billable services only.
+  // Replaces prior contract-pool semantic with active-capacity semantic.
+  // Historical contract pool: services.reduce((s, svc) => s + (svc.totalHours || 0), 0).
+  const totalHours = round2(
+    billableServices.reduce((sum, svc) => sum + (svc.totalHours || 0), 0)
+  );
+
+  const hoursRemaining = round2(totalHours - hoursUsed);
   const minutesUsed = round2(hoursUsed * 60);
   const minutesRemaining = round2(hoursRemaining * 60);
 
@@ -62,14 +106,22 @@ function calcClientAggregates(services, clientTotalHours) {
     isBlocked = false;
     isCritical = false;
   } else {
-    const hasActiveOverride = (services || []).some(svc =>
+    // PR-G.3.14: override scan limited to active services. Overrides on
+    // archived services no longer suppress block — closed service ⇒ closed
+    // override. Per devils-advocate: 0 such cases in PROD today, documented
+    // behavioral change.
+    const hasActiveOverride = activeServices.some(svc =>
       svc.overrideActive === true || svc.overdraftResolved?.isResolved === true
     );
     isBlocked = hoursRemaining <= 0 && !hasActiveOverride;
     isCritical = !isBlocked && hoursRemaining > 0 && hoursRemaining <= 5;
   }
 
-  return { hoursUsed, hoursRemaining, minutesUsed, minutesRemaining, isBlocked, isCritical };
+  // Reference clientTotalHours so linters/static-analysis don't flag the unused
+  // parameter — kept in signature for backward-compat with pre-PR-G.3.14 callers.
+  void clientTotalHours;
+
+  return { hoursUsed, hoursRemaining, minutesUsed, minutesRemaining, isBlocked, isCritical, totalHours };
 }
 
 /**
@@ -89,7 +141,13 @@ function assertClientAggregateInvariants(services, proposed, caller = 'unknown')
     throw new Error(`invariant_violation:missing_proposed [caller=${caller}]`);
   }
 
-  const billable = (services || []).filter(svc => !isFixedService(svc));
+  // PR-G.3.14: align with calcClientAggregates — filter archived BEFORE type filter.
+  // Without this alignment, archived-with-override scenarios would spuriously fire
+  // I2_override_active_but_blocked while calcClientAggregates correctly blocks.
+  const activeServices = (services || []).filter(svc =>
+    !NON_AGGREGATING_STATUSES.includes(svc?.status || 'active')
+  );
+  const billable = activeServices.filter(svc => !isFixedService(svc));
 
   // I1: no billable services → must not be blocked or critical
   if (billable.length === 0) {
@@ -106,8 +164,9 @@ function assertClientAggregateInvariants(services, proposed, caller = 'unknown')
     }
   }
 
-  // I2: active override → must not be blocked
-  const hasActiveOverride = (services || []).some(svc =>
+  // I2: active override (on an active service) → must not be blocked.
+  // PR-G.3.14: scan limited to activeServices, matching calcClientAggregates.
+  const hasActiveOverride = activeServices.some(svc =>
     svc.overrideActive === true || svc.overdraftResolved?.isResolved === true
   );
   if (hasActiveOverride && proposed.isBlocked === true) {
@@ -128,5 +187,7 @@ module.exports = {
   calcClientAggregates,
   assertClientAggregateInvariants,
   round2,
-  isFixedService
+  isFixedService,
+  NON_AGGREGATING_STATUSES // PR-G.3.14: exported so client-writer.recomputeTotalHours
+                            // applies the same status filter (alignment guarantee).
 };

--- a/functions/shared/client-writer.js
+++ b/functions/shared/client-writer.js
@@ -45,7 +45,7 @@
 
 const functions = require('firebase-functions');
 const admin = require('firebase-admin');
-const { calcClientAggregates, assertClientAggregateInvariants } = require('./aggregates');
+const { calcClientAggregates, assertClientAggregateInvariants, NON_AGGREGATING_STATUSES } = require('./aggregates');
 const { SYSTEM_CONSTANTS } = require('./constants');
 const { getEnforcementMode, VALID_MODES } = require('./enforcement-mode');
 
@@ -72,12 +72,18 @@ const RESTRICTED_KEYS = Object.freeze([
  * Recompute totalHours from services array.
  * Billable = not fixed (ST.FIXED) and not legal_procedure+fixed.
  *
+ * PR-G.3.14 (2026-05-27): also skip services with status in NON_AGGREGATING_STATUSES
+ * (currently `['archived']`). Aligns with calcClientAggregates' filter so both
+ * helpers compute totalHours on the same active subset (no drift).
+ *
  * @param {Array} services
  * @returns {number}
  */
 function recomputeTotalHours(services) {
   return services.reduce((sum, svc) => {
     if (!svc) return sum;
+    // PR-G.3.14: status filter must match aggregates.js NON_AGGREGATING_STATUSES.
+    if (NON_AGGREGATING_STATUSES.includes(svc.status || 'active')) return sum;
     if (svc.type === ST.FIXED) return sum;
     if (svc.type === ST.LEGAL_PROCEDURE && svc.pricingType === PT.FIXED) return sum;
     return sum + (typeof svc.totalHours === 'number' ? svc.totalHours : 0);

--- a/functions/tests/write-client-canonical-aggregates.test.js
+++ b/functions/tests/write-client-canonical-aggregates.test.js
@@ -412,6 +412,39 @@ describe('D. Aggregate computation', () => {
     expect(payload.isBlocked).toBe(false);  // I1 path
     expect(payload.hoursUsed).toBe(0);
   });
+
+  // PR-G.3.14 (2026-05-27): recomputeTotalHours skips archived services.
+  // Tests the writer path applies the same NON_AGGREGATING_STATUSES filter as
+  // calcClientAggregates. Without this alignment, totalHours and aggregates would
+  // diverge on every write to a client with archived services.
+  test('PR-G.3.14 T4: archived service excluded from recomputeTotalHours + aggregates', async () => {
+    // Mirror client 2025724 shape: 1 archived (42h), 1 active in overdraft (34h).
+    const archivedService = {
+      ...makeHoursService('arch1', { totalHours: 42, hoursUsed: 14.17 }),
+      status: 'archived'
+    };
+    const activeService = {
+      ...makeHoursService('act1', { totalHours: 34, hoursUsed: 42.93, overrideActive: true })
+    };
+    mockTransaction.get.mockResolvedValue(
+      makeClientDoc({
+        services: [archivedService, activeService],
+        totalHours: 76 /* legacy stored value pre-fix */
+      })
+    );
+    await writeClientWithCanonicalAggregates(
+      mockTransaction, clientRef, {}, { caller: 'pr-g-3-14-test' }
+    );
+    const [, payload] = mockTransaction.update.mock.calls[0];
+
+    // Writer's recomputeTotalHours skips archived → totalHours derived from active billable only.
+    expect(payload.totalHours).toBe(34);
+    expect(payload.hoursUsed).toBe(42.93);
+    expect(payload.hoursRemaining).toBe(-8.93);
+
+    // overrideActive on active service still suppresses block.
+    expect(payload.isBlocked).toBe(false);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/tests/unit/aggregates/calc-client-aggregates.test.ts
+++ b/tests/unit/aggregates/calc-client-aggregates.test.ts
@@ -258,6 +258,99 @@ describe('assertClientAggregateInvariants — fail-fast guard', () => {
   });
 });
 
+describe('calcClientAggregates — PR-G.3.14 status filter (archived excluded)', () => {
+  /**
+   * PR-G.3.14 (2026-05-27): exclude services with status === 'archived' from
+   * client-level aggregates. NOT 'completed' (audit history), NOT 'on_hold'
+   * (temporary pause). Lifetime contract pool preserved in services[].
+   * Triggering case: client 2025724 archived service inflating totalHours.
+   */
+
+  it('T1: archived service excluded from hoursUsed, totalHours, hoursRemaining', () => {
+    // Mirrors client 2025724: archived 42h-service + active 34h-service in overdraft.
+    const services = [
+      {
+        type: 'hours',
+        status: 'archived',
+        totalHours: 42,
+        hoursUsed: 14.17,
+        hoursRemaining: 27.83
+      },
+      {
+        type: 'hours',
+        status: 'active',
+        totalHours: 34,
+        hoursUsed: 42.93,
+        hoursRemaining: -8.93,
+        overrideActive: true
+      }
+    ];
+    const result = calcClientAggregates(services, 76 /* legacy stored totalHours */);
+
+    // Choice A: derived from active billable only
+    expect(result.totalHours).toBe(34);
+    expect(result.hoursUsed).toBe(42.93);
+    expect(result.hoursRemaining).toBe(-8.93);
+
+    // overrideActive on the active service still suppresses block
+    expect(result.isBlocked).toBe(false);
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('T2: completed service is STILL counted (narrowed scope per Haim decision)', () => {
+    // Confirms PR-G.3.14 narrowed filter — 'completed' deferred, NOT excluded.
+    // Mirrors the canonical behavior in functions/tests/complete-service.test.js:264-280.
+    const services = [
+      {
+        type: 'hours',
+        status: 'completed',
+        totalHours: 10,
+        hoursUsed: 10
+      }
+    ];
+    const result = calcClientAggregates(services, 10);
+
+    // Completed service still in books — drives isBlocked=true
+    expect(result.totalHours).toBe(10);
+    expect(result.hoursUsed).toBe(10);
+    expect(result.hoursRemaining).toBe(0);
+    expect(result.isBlocked).toBe(true);
+  });
+
+  it('T3: all-archived services array → billable empty → I1 holds (not blocked, not critical)', () => {
+    const services = [
+      { type: 'hours', status: 'archived', totalHours: 50, hoursUsed: 50 },
+      { type: 'hours', status: 'archived', totalHours: 20, hoursUsed: 19 }
+    ];
+    const result = calcClientAggregates(services, 70 /* legacy stored totalHours */);
+
+    // After archived filter: billableServices.length === 0 → I1 branch fires
+    expect(result.totalHours).toBe(0);
+    expect(result.hoursUsed).toBe(0);
+    expect(result.hoursRemaining).toBe(0);
+    expect(result.isBlocked).toBe(false);
+    expect(result.isCritical).toBe(false);
+  });
+
+  it('T1b: invariant assert passes for client 2025724 shape (round-trip)', () => {
+    // Sanity round-trip: agg output for the 2025724-shaped client passes
+    // assertClientAggregateInvariants without throwing.
+    const services = [
+      { type: 'hours', status: 'archived', totalHours: 42, hoursUsed: 14.17 },
+      {
+        type: 'hours',
+        status: 'active',
+        totalHours: 34,
+        hoursUsed: 42.93,
+        overrideActive: true
+      }
+    ];
+    const agg = calcClientAggregates(services, 76);
+    expect(() => assertClientAggregateInvariants(services, agg, 'pr-g-3-14-test'))
+      .not.toThrow();
+  });
+});
+
 describe('calcClientAggregates — REAL PRODUCTION FIXTURES (21 blocked clients)', () => {
   const fixturesDir = path.join(__dirname, '..', '..', '..', 'test-fixtures', 'problem-clients');
   const hasFixtures = fs.existsSync(fixturesDir);


### PR DESCRIPTION
## Summary

Triggering case: client **2025724** (מאפיית הכפר) — archived service `srv_1766392900070` (42h) was inflating `client.totalHours` to 76, masking an 8.9h overdraft on the active service. Clients table showed "**16.9 / 76 שעות נותרות** / סטטוס: תקין ✓" while reality was **-8.9h overdraft**. PR-G.3.14 fixes the SSOT in `functions/shared/aggregates.js` so archived services are excluded from client-level totals everywhere (backend SSOT + frontend table + printed report).

PR-G.3.13 (#332) fixed the **Report Modal** display. PR-G.3.14 closes the loop on the **client-level aggregate calculation**.

## Narrowed scope decision

Per Haim's decision (2026-05-27, post devils-advocate review):
- ✅ `archived` ONLY filtered
- ❌ `completed` STILL counted — billing-locked, audit history retained (functions/tests/complete-service.test.js:264-280 documents the canonical intent)
- ❌ `on_hold` STILL counted — 0 in PROD today, temporary pause may resume

## Choice A semantic

`client.totalHours` is redefined from "lifetime contract pool" to "active billable capacity" (derived from active services). **Lifetime contract pool** (across all statuses) reachable via:
```js
services.reduce((s, svc) => s + (svc.totalHours || 0), 0)
```

No data lost — history preserved in `services[]` array, just **relocated** from the derived client-level field.

## Changes

| File | LOC | What |
|---|---|---|
| `functions/shared/aggregates.js` | +71/-18 | `NON_AGGREGATING_STATUSES = ['archived']` constant + filter in `calcClientAggregates` and `assertClientAggregateInvariants`. `totalHours` derived from active billable services. Override scan limited to active services. JSDoc invariants I1-I5 updated. |
| `functions/shared/client-writer.js` | +6/-2 | Imports `NON_AGGREGATING_STATUSES`. `recomputeTotalHours` filters archived (alignment guarantee with aggregates.js). |
| `apps/admin-panel/js/managers/ClientsDataManager.js` | +31 | `_isServiceCountedForClientAggregate()` helper. Applied in 2 call sites. |
| `apps/admin-panel/js/managers/ReportGenerator.js` | +18/-4 | 3 "כל השירותים" reduce paths filter archived (table = modal = printed report consistency). |
| `tests/unit/aggregates/calc-client-aggregates.test.ts` | +93 | 4 new tests T1 (archived excluded), T1b (round-trip invariant), T2 (completed STILL counted), T3 (all-archived → I1). |
| `functions/tests/write-client-canonical-aggregates.test.js` | +33 | T4 covering `recomputeTotalHours` filter. |
| `docs/CLIENTS_SYSTEM_REPORT.md` | +9/-2 | Invariants table — "billable פעיל" definition cites PR-G.3.14. |
| `.claude/rubrics/pr-g-3-14.md` | NEW | 8 MUST + 5 SHOULD + Out of scope + Behavioral change + Rollback + Deploy ordering. |

**Net: 378 insertions, 24 deletions across 7 files + new rubric.**

## VERDICT: PASS_WITH_WARNINGS

`outcomes-grader` (separate context, read-only): **PASS_WITH_WARNINGS** with **0 blocking items**.
- All 8 MUST PASS
- 4/5 SHOULD PASS (1 DEFERRED = this PR body)
- All 7 PRODUCT-GRADE Gates PASS or N/A
- Code Review 6-stage PASS
- PROD Safety layer PASS

Rubric: `.claude/rubrics/pr-g-3-14.md`

## PRODUCT-GRADE GATES

- **G1** Customer-visible errors professional — **N/A**. No error paths added; calculation filter change.
- **G2** Rollback path documented (<5min) — **PASS**. See Rollback section. Audit log preserves `before` payload.
- **G3** Monitoring touched if data-mutating — **PASS**. Writes go through existing `writeClientWithCanonicalAggregates` (already logged). Backfill via existing `repairClientAggregates` callable (audit_log entries).
- **G4** Test proves customer scenario — **PASS**. T1 mirrors client 2025724 PROD scenario with exact assertions (totalHours: 34, hoursUsed: 42.93, hoursRemaining: -8.93). T4 same for writer path.
- **G5** Hebrew customer-facing text — **PASS**. No new UI strings. Doc update in Hebrew.
- **G6** No breaking change without migration plan — **PASS with disclosure**. This IS a semantic redefinition (Choice A) — fully disclosed in this PR body + rubric. Dry-run: 2 client changes, 0 staff regressions.
- **G7** Security agent review — **N/A**. No auth/PII/permissions touched. Security agent consulted in investigation (task #25) → PASS_WITH_WARNINGS (frontend block path note documented).

## PROD dry-run impact (data-investigator)

139 clients in PROD. Under narrowed filter (archived only):

| Metric | Result |
|---|---|
| Clients where ANY aggregate changes | **2** |
| Clients flipping `hoursRemaining ≥0 → <0` | 1 (= 2025724 — the bug) |
| `isBlocked: false → true` | **0** (no staff regression) |
| `isBlocked: true → false` | 1 (`internal_office` — broken data cleanup) |
| Customer-visible impact | **0** (Admin Panel only) |

### Affected clients

1. **2025724 (מאפיית הכפר)**:
   - `totalHours: 76 → 34`
   - `hoursUsed: 59.1 → 42.93`
   - `hoursRemaining: 16.9 → -8.93` (matches reality)
   - `isBlocked: unchanged` (override on active service still suppresses block)
2. **internal_office**:
   - `hoursUsed: 620.08 → 0` (had 0 services, broken data)
   - `isBlocked: true → false`

## Behavioral change disclosure (per `apps/admin-panel/CLAUDE.md`)

This IS a behavioral change. Specifics:
- **Clients table**: clients with archived services now show lower `totalHours` and correct `hoursRemaining` (surfaces previously-hidden overdrafts where applicable).
- **`isBlocked` / `isCritical`**: derived from filtered set. 0 flips false→true. 1 flip true→false (broken data fix).
- **Printed reports**: "כל השירותים" totals match clients table — full consistency restored.
- **Override semantics**: overrides on archived services no longer suppress block. 0 such cases in PROD today.

**Staff retraining**: None required. Display now matches reality.

## Test plan

- [x] Jest: **558/558** passing (incl. `complete-service.test.js` 11/11 — confirms narrowed scope respects canonical "completed still counts" behavior)
- [x] Vitest: **364/366** passing (2 skipped = production fixtures, intentional)
- [x] ESLint: **0 errors**, no new warnings
- [x] Syntax: all 4 production files validated
- [ ] **Manual DEV smoke (post-merge to main):**
  - Open client 2025724 → row shows "**-8.9 / 34 שעות**" + warning indicator
  - Open "דוח" → modal still correct from PR-G.3.13 (no regression)
  - Print/generate report "כל השירותים" → matches table (34h, not 76h)
  - Spot-check 2-3 regular clients (no archived service) — **no change** in displayed values
  - Spot-check 1 legal_procedure client — no regression
  - Console clean
- [ ] **Backfill (mandatory post-merge):**
  - Call `repairClientAggregates({clientId: '2025724'})` from Admin Panel within 1 hour of merge OR before next 06:00 IL `dailyInvariantCheck`
  - Verify `audit_log` entry with `before/after` payload
  - Confirm Firestore `clients/2025724` shows new values
- [ ] **`internal_office` deferred** to natural Cloud Function trigger correction (next timesheet entry triggers recompute)

## Deploy ordering (CRITICAL — different from PR-G.3.13)

PR-G.3.14 touches Cloud Functions. Auto-deploy via `.github/workflows/ci-cd-production.yml:412-470`:

1. **Merge to `main`** → CI runs → `firebase deploy --only ...functions` runs (~10-15 min after merge)
2. **At this point**: Cloud Functions PROD has the new aggregates logic. Any new timesheet write triggers correct computation. Existing PROD data still has stale stored aggregates until backfill.
3. **Within ~1 hour of step 2**: execute backfill for 2025724 via `repairClientAggregates` callable. Verify audit_log + Firestore.
4. **Same window**: open `main → production-stable` PR. Get Haim's PROD approval. Merge. Netlify auto-deploys frontend filter to PROD.
5. **By 06:00 IL next day**: `dailyInvariantCheck` should see 0 drifted clients (2025724 backfilled; internal_office acceptable noise).

## Rollback

```bash
git revert <merge-sha>
git push origin main
# Cloud Functions auto-redeploy with old code (~10-15 min)
# For Netlify PROD: also merge revert to production-stable
```

Data rollback (if backfill values are wrong):
- `audit_log` entries contain `before` payload for `repairClientAggregates` call
- Restore via Firestore console using the `before` payload
- Acceptable: single client document per backfill, no transactional cross-doc dependency

Estimated rollback time: **<10 minutes**.

## Known follow-ups (out of scope)

1. **`SKIP_CLIENTS` divergence**: `scheduled/index.js:291` only skips `2025003`; `repair-aggregates.js:38` only skips `internal_office`. Unify in shared constant (separate PR).
2. **`completed` status filter decision**: deferred — 8 services in PROD, billing semantics need explicit business confirmation.
3. **`on_hold` status filter**: re-evaluate when first `on_hold` service appears in PROD.
4. **`types/services.ts:93` schema drift**: BaseService.status union missing `archived` + `on_hold` (separate PR).
5. **FluentDataGrid dead code**: separate investigation.
6. **Frontend↔backend `NON_AGGREGATING_STATUSES` manual sync**: centralize via `window.BUSINESS_RULES` pattern (refactor — separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
