### PR TITLE
feat(pre-h-1-0): validated, immutable idNumber (ת.ז) on client creation — backend

### DIFF
--- a/.claude/rubrics/pr-pre-h-1-0.md
+++ b/.claude/rubrics/pr-pre-h-1-0.md
@@ -1,0 +1,81 @@
+# Rubric — Pre-H.1.0 (backend): validated/immutable `idNumber` (ת"ז) on client creation
+
+**Title:** Add an optional, check-digit-validated, immutable `idNumber` (ת"ז) to `createClient` — the cross-system join key foundation for the DLR architecture (MASTER_PLAN §8.2.5).
+**Branch:** `feat/pre-h-1-0-idnumber-backend`
+**Base:** `main`
+**App / Env:** Functions (backend) / DEV. No deploy in this PR.
+**Effort:** MEDIUM (effort-scaler verdict 2026-06-02).
+
+**Scope (backend-first, approved at checkpoint 2026-06-02 over the devils-advocate STOP on the full slice):**
+- `functions/shared/validators.js` — new `isValidIsraeliId()` (official ת"ז check-digit, zero-pad to 9), exported.
+- `functions/clients/index.js` `createClient` — accept **optional** `idNumber`; if present, validate (reject invalid with a generic Hebrew `invalid-argument`, value never echoed); store on the client doc (default `''`). **Not unique** (client = case → one ת"ז on many docs).
+- `functions/clients/index.js` `updateClient` — **explicitly reject** any `idNumber` (immutable-from-creation; was silently ignored).
+- Tests: validator unit vectors + `createClient`/`updateClient` integration + a PII source-guard.
+
+**Explicitly DEFERRED to separate PRs (documented, not in scope):** the User-App UI field; `required` enforcement; `clients` read-access tightening (G7 open decision); the `SimpleClientDialog` direct-write bypass; the ~127-doc backfill migration; the WhatsApp plaintext-echo fix; the frontend Zod (`/^\d{9}$/`) reconciliation.
+
+## MUST criteria (block on FAIL)
+
+### M1 — `isValidIsraeliId` implements the official check-digit (incl. zero-pad)
+**Rule:** Pure validator in `functions/shared/validators.js`, exported. Pads <9-digit input with leading zeros, applies the 1/2-weight mod-10 algorithm, rejects non-string / non-digit / >9 digits / all-zeros.
+**Evidence:** `functions/tests/israeli-id-validator.test.js` — 11 assertions incl. valid `123456782`, zero-pad `00000018`, wrong-check-digit `123456789`, sentinels `SYSTEM-INTERNAL`/`TEST-…`, all-zeros, non-string. All green.
+
+### M2 — `createClient` validates-if-present + stores; absent → `''`
+**Rule:** `idNumber` is optional. If non-empty, it must pass `isValidIsraeliId` or the call throws `invalid-argument` with a Hebrew message; the rejected value is NOT in the error. If valid, it is written to the client doc. If absent/blank, the doc stores `''`.
+**Evidence:** `functions/tests/client-idnumber.test.js` A (valid stored), B (invalid → Hebrew throw, value not in message, write aborted), C/C2 (absent/blank → `''`).
+
+### M3 — `idNumber` is immutable via the CF
+**Rule:** `updateClient` rejects any request carrying `idNumber` (explicit `invalid-argument`, Hebrew), and never writes it.
+**Evidence:** `client-idnumber.test.js` D + D2 (throws; `update` not called).
+
+### M4 — ת"ז value never reaches logs/audit
+**Rule:** No `console.*` / `logger.*` / `logAction(...)` call in the touched files carries an `idNumber` value (repo is PUBLIC; `audit_log` is forensic; ת"ז is sensitive PII — §8.2.5 #8).
+**Evidence:** `functions/tests/client-idnumber-pii-guard.test.js` — static source-scan (comment-stripped) over `clients/index.js` + `validators.js`, plus a positive-control that the guard regex catches a violation.
+
+### M5 — NOT unique (client = case)
+**Rule:** No uniqueness constraint / unique-index assumption / "find THE client by ת"ז" is introduced. Duplicates are allowed (data-investigator confirmed multiple case docs per person).
+**Evidence:** `git diff` shows no uniqueness check; validator docblock + createClient comment state non-uniqueness explicitly.
+
+### M6 — No regression, no scope creep
+**Rule:** Full `functions` Jest suite green; the diff touches ONLY `functions/shared/validators.js`, `functions/clients/index.js`, the 3 new test files, and this rubric. No `firestore.rules`, no UI, no migration, no unrelated files.
+**Evidence:** `npx jest` → 47 suites / 746 tests pass. `git diff --stat main..HEAD` = the listed files only.
+
+### M7 — Lint clean (the #347 lesson)
+**Rule:** `npm run lint -- --max-warnings=2200` → **0 errors**, exit 0.
+**Evidence:** verified 2026-06-02 (`✖ 1850 problems (0 errors, …)`, exit 0).
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Behavioral change documented
+**Rule:** `updateClient` going from silently-ignoring `idNumber` to explicitly-rejecting it is called out as a (safe) tightening; no known caller sends `idNumber` to `updateClient` (ClientManagementModal sends only `caseOpenDate`; SimpleClientDialog uses direct `.set()`).
+**Evidence:** PR body "Behavioral change" note.
+
+### S2 — Deferred follow-ups enumerated
+**Rule:** The PR body lists every deferred item (UI/required/read-access/bypass/backfill/WhatsApp/Zod) so nothing is silently dropped.
+
+## PRODUCT-GRADE GATES
+
+- **G1 — Customer errors:** PASS — invalid ת"ז → generic Hebrew `"מספר תעודת הזהות אינו תקין"`; no value, no stack, no `[object Object]`. Validation throws a hand-built `HttpsError`, so it short-circuits the pre-existing `${error.message}` catch (the catch leak is grandfathered, out of scope).
+- **G2 — Rollback:** PASS — `git revert <merge-commit>` + redeploy. Code-only; the field is optional and additive, so no data migration to undo. Any ת"ז stored between merge and revert remains valid client data (harmless).
+- **G3 — Monitoring:** PASS — `createClient` already logs success (`caseNumber`, `clientName`) + writes a `CREATE_CLIENT` audit entry; the create path remains monitored. The new field is **deliberately not logged** (PII) — that is the correct posture, not a gap (M4).
+- **G4 — Customer-scenario test:** PASS — 19 tests: 4 CF integration scenarios (create-with-valid, create-with-invalid, create-without, update-immutable) + 11 validator vectors + 3 PII-guard.
+- **G5 — Hebrew UI:** PASS — both customer-facing errors are Hebrew (`"מספר תעודת הזהות אינו תקין"`, `"לא ניתן לעדכן תעודת זהות לאחר יצירת הלקוח"`).
+- **G6 — Breaking change:** PASS (no breaking change) — `idNumber` is a new optional field; no existing caller sends it to `createClient`; legacy docs without it are tolerated everywhere (stored default `''`). The `updateClient` reject is a tightening of a previously-silent no-op with no real caller (S1).
+- **G7 — Security review:** PASS — `security-access-expert` reviewed in the investigation phase (verdict: backend path is safe; idNumber kept out of logs; the **read-access widening** and the **SimpleClientDialog bypass** are real but DEFERRED to separate PRs and explicitly flagged). This PR adds NO Firestore-rules change and NO new reader (the field was already read by `ClientsDataManager` / written by `SimpleClientDialog`). Plaintext storage is consistent with the system's access-control-not-encryption model.
+
+VERDICT: (filled by grader)
+
+## Rollback
+```bash
+git revert <merge-commit>
+git push origin main
+```
+Code-only. No data migration. No PROD deploy in this PR.
+
+## Test plan
+**Automated (this PR):** `cd functions && npx jest tests/israeli-id-validator tests/client-idnumber` → 19 pass; full `npx jest` → 746 pass (regression).
+**Manual:** none required — no deploy, no UI. The field has no live producer until the UI PR; existing flows are unaffected (optional, additive).
+
+## Notes for grader
+- Devils-advocate (2026-06-02) issued STOP on the FULL slice (dead UI surface, SimpleClientDialog bypass, "required" incoherence). This PR is the **narrowed backend-first** scope Haim approved at checkpoint — it deliberately makes `idNumber` OPTIONAL (not required) and touches NO UI, which neutralizes all three criticals. The deferred items are tracked, not dropped.
+- The cross-language frontend Zod reconciliation was intentionally deferred to the UI PR (an orphaned validator + cross-lang drift-guard now would add risk to a clean backend PR).

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -4,7 +4,7 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const { checkUserPermissions } = require('../shared/auth');
 const { logAction } = require('../shared/audit');
-const { sanitizeString, isValidIsraeliPhone, isValidEmail } = require('../shared/validators');
+const { sanitizeString, isValidIsraeliPhone, isValidEmail, isValidIsraeliId } = require('../shared/validators');
 const { generateCaseNumberWithTransaction } = require('../case-number-transaction');
 const { SYSTEM_CONSTANTS, isValidServiceType, isValidPricingType } = require('../shared/constants');
 const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
@@ -96,6 +96,22 @@ exports.createClient = functions.https.onCall(async (data, context) => {
         'invalid-argument',
         'סוג הליך חייב להיות "hours", "fixed" או "legal_procedure"'
       );
+    }
+
+    // Validation - תעודת זהות (Pre-H.1.0)
+    // ת"ז הוא מפתח הקישור הצולב לטופס-המכר (MASTER_PLAN §8.2.5). אופציונלי
+    // בשלב זה — אכיפת "חובה" + שדה ב-UI (User App) מגיעים ב-PR נפרד. אם סופק,
+    // חייב לעבור ספרת ביקורת. אינו ייחודי (לקוח=תיק → אותו ת"ז על מספר תיקים).
+    // ⚠️ הערך אינו מוחזר בהודעת השגיאה ואינו נכתב ל-logs/audit (PII, repo ציבורי).
+    let validatedIdNumber = '';
+    if (data.idNumber !== undefined && data.idNumber !== null && String(data.idNumber).trim() !== '') {
+      if (!isValidIsraeliId(String(data.idNumber))) {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'מספר תעודת הזהות אינו תקין'
+        );
+      }
+      validatedIdNumber = String(data.idNumber).trim();
     }
 
     // Validation - שדות ספציפיים לסוג
@@ -193,6 +209,12 @@ exports.createClient = functions.https.onCall(async (data, context) => {
       caseNumber: caseNumber,  // מספר תיק (גם Document ID)
       clientName: sanitizeString(data.clientName.trim()),
       fullName: sanitizeString(data.clientName.trim()), // ✅ גם fullName ל-backward compatibility
+
+      // ✅ Pre-H.1.0: תעודת זהות — מפתח הקישור הצולב לטופס-המכר (§8.2.5).
+      // '' כברירת מחדל (אופציונלי כעת); מאומת ספרת-ביקורת לעיל אם סופק.
+      // נוכח-תמיד-כ-'' מגן על קוראים קיימים (למשל ClientsDataManager שמריץ
+      // client.idNumber.includes(...)). אינו ייחודי (לקוח=תיק).
+      idNumber: validatedIdNumber,
 
       // ✅ מידע משפטי - כותרת התיק
       caseTitle: data.caseTitle ? sanitizeString(data.caseTitle.trim()) : '',
@@ -1023,6 +1045,19 @@ exports.updateClient = functions.https.onCall(async (data, context) => {
 
     // Validation
     const updates = {};
+
+    // Pre-H.1.0: ת"ז immutable — נקבע ביצירת הלקוח בלבד, לא ניתן לעדכון דרך
+    // updateClient (מפתח הקישור הצולב לטופס-המכר; §8.2.5 constraint #1/#4).
+    // דחייה מפורשת במקום התעלמות שקטה, כדי שניסיון שינוי יקבל משוב ברור.
+    // הזרמת ת"ז ללקוחות legacy מתבצעת ב-PR backfill ייעודי, לא דרך מסלול זה.
+    // (immutable-from-creation — מחמיר מ-immutable-after-link; ניתן להרפות
+    // בעתיד כשמושג ה-link יתקיים.)
+    if (data.idNumber !== undefined) {
+      throw new functions.https.HttpsError(
+        'invalid-argument',
+        'לא ניתן לעדכן תעודת זהות לאחר יצירת הלקוח'
+      );
+    }
 
     if (data.fullName !== undefined) {
       if (!data.fullName || data.fullName.trim().length < 2) {

--- a/functions/shared/validators.js
+++ b/functions/shared/validators.js
@@ -36,6 +36,36 @@ function isValidEmail(email) {
 }
 
 /**
+ * אימות תעודת זהות ישראלית — ספרת ביקורת לפי האלגוריתם הרשמי.
+ *
+ * Pre-H.1.0: ת"ז הוא מפתח הקישור הצולב לטופס-המכר (MASTER_PLAN §8.2.5).
+ *
+ * מקבל מחרוזת של עד 9 ספרות (אפסים מובילים משמעותיים — ת"ז בת 8 ספרות
+ * מרופדת אוטומטית ל-9). מחזיר true רק אם ספרת הביקורת תקינה.
+ *
+ * ⚠️ אינו בודק ייחודיות בכוונה: במערכת זו "לקוח" = "תיק", ואותו אדם/ת"ז
+ * יכול להופיע על מספר תיקים (many-to-many, §8.2.5 constraint #2). בדיקת
+ * תקינות פורמט + ספרת ביקורת בלבד — לא uniqueness.
+ *
+ * @param {string} id מחרוזת ספרות (ללא מקפים/רווחים; מתבצע trim).
+ * @returns {boolean} true אם ת"ז תקינה, אחרת false.
+ */
+function isValidIsraeliId(id) {
+  if (typeof id !== 'string') { return false; }
+  const digits = id.trim();
+  if (!/^\d{1,9}$/.test(digits)) { return false; }
+  const padded = digits.padStart(9, '0');
+  if (padded === '000000000') { return false; } // לא ת"ז אמיתית
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    let inc = Number(padded[i]) * ((i % 2) + 1); // משקלים 1,2,1,2,...
+    if (inc > 9) { inc -= 9; }
+    sum += inc;
+  }
+  return sum % 10 === 0;
+}
+
+/**
  * שליפת מגבלת תווים לתיאור מתוך system_config (Firestore).
  * Fallback ל-SYSTEM_CONSTANTS אם אין config.
  *
@@ -62,4 +92,4 @@ async function getDescriptionLimit(field) {
   return fallback;
 }
 
-module.exports = { sanitizeString, isValidIsraeliPhone, isValidEmail, getDescriptionLimit };
+module.exports = { sanitizeString, isValidIsraeliPhone, isValidEmail, isValidIsraeliId, getDescriptionLimit };

--- a/functions/tests/client-idnumber-pii-guard.test.js
+++ b/functions/tests/client-idnumber-pii-guard.test.js
@@ -1,0 +1,47 @@
+/**
+ * PII source-guard (Pre-H.1.0) — ת"ז must NEVER reach logs/audit.
+ *
+ * Mirrors the H.0 no-PII-in-logs AST guard (set-employee-cost.test.ts): reads the
+ * SOURCE of the touched files, strips comments, and asserts no console.* / logger.*
+ * / logAction(...) call carries an idNumber value. The repo is PUBLIC and
+ * `audit_log` is a forensic store — ת"ז (sensitive PII per Israeli privacy law)
+ * must stay out of both (MASTER_PLAN §8.2.5 constraint #8).
+ *
+ * Static scan (no require → no firebase-admin init needed).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+/** Remove block + line comments so a comment that merely *mentions* idNumber
+ *  doesn't trip the guard (the `[^:]` before // keeps `://` URLs intact). */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+// Matches a console.* / logger.* / logAction( call whose argument span (up to the
+// next `;`) contains idNumber or validatedIdNumber. `[^;]` spans newlines, so the
+// multi-line logAction payload is covered.
+const LOG_WITH_ID = /(?:console\.\w+|logger\.\w+|logAction)\s*\([^;]*[iI]dNumber/;
+
+describe('no ת"ז (idNumber) value in logs/audit — static source guard', () => {
+  it('functions/clients/index.js never passes idNumber to console/logger/logAction', () => {
+    const code = stripComments(
+      fs.readFileSync(path.resolve(__dirname, '../clients/index.js'), 'utf8')
+    );
+    expect(code).not.toMatch(LOG_WITH_ID);
+  });
+
+  it('functions/shared/validators.js never logs the id value', () => {
+    const code = stripComments(
+      fs.readFileSync(path.resolve(__dirname, '../shared/validators.js'), 'utf8')
+    );
+    expect(code).not.toMatch(LOG_WITH_ID);
+  });
+
+  it('sanity: the guard regex DOES catch a violating pattern', () => {
+    expect('logAction("X", uid, name, { idNumber: x });').toMatch(LOG_WITH_ID);
+    expect('console.log(`id ${client.idNumber}`);').toMatch(LOG_WITH_ID);
+  });
+});

--- a/functions/tests/client-idnumber.test.js
+++ b/functions/tests/client-idnumber.test.js
@@ -1,0 +1,142 @@
+/**
+ * Integration tests for the Pre-H.1.0 idNumber (ת"ז) behavior of
+ * createClient + updateClient (functions/clients/index.js).
+ *
+ * Customer scenarios proven:
+ *  A. Creating a client WITH a valid ת"ז → stored on the client doc.
+ *  B. Creating a client WITH an invalid ת"ז → rejected (Hebrew, invalid-argument),
+ *     and the rejected value is NOT echoed in the error message (PII discipline).
+ *  C. Creating a client WITHOUT a ת"ז → still succeeds; field stored as '' (optional).
+ *  D. Updating a client and trying to change ת"ז → rejected (immutable).
+ *
+ * Mocks mirror the existing change-client-status.test.js harness. The REAL
+ * validators module is used (so the real isValidIsraeliId check-digit runs).
+ */
+'use strict';
+
+// ── Mocks (precede require) ──────────────────────────────────────────────────
+const mockCreate = jest.fn(async () => ({}));
+const mockUpdate = jest.fn(async () => ({}));
+const mockSet = jest.fn(async () => ({}));
+let mockClientDocSnap = { exists: true, data: () => ({ createdBy: 'testuser', idNumber: '' }) };
+const mockGet = jest.fn(async () => mockClientDocSnap);
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn(() => ({ create: mockCreate, get: mockGet, update: mockUpdate, set: mockSet }))
+  }))
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n })),
+    delete: jest.fn(() => 'DELETE')
+  };
+  const Timestamp = { fromDate: jest.fn((d) => ({ _ts: d.getTime() })) };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({ checkUserPermissions: mockCheckUserPermissions }));
+
+const mockLogAction = jest.fn();
+jest.mock('../shared/audit', () => ({ logAction: mockLogAction }));
+
+jest.mock('../case-number-transaction', () => ({
+  generateCaseNumberWithTransaction: jest.fn(() => 'AUTO-2026000')
+}));
+
+jest.mock('../shared/client-writer', () => ({
+  writeClientWithCanonicalAggregates: jest.fn()
+}));
+
+// NOTE: validators is intentionally NOT mocked — we exercise the real
+// isValidIsraeliId check-digit algorithm through the CF.
+
+// ── Requires (after mocks) ───────────────────────────────────────────────────
+const { createClient, updateClient } = require('../clients/index');
+
+const VALID_USER = { uid: 'user1', email: 'test@test.com', username: 'testuser', role: 'manager' };
+const VALID_ID = '123456782'; // correct check digit
+const INVALID_ID = '123456789'; // wrong check digit
+const ctx = { auth: { uid: 'user1', token: { email: 'test@test.com', role: 'manager' } } };
+
+function hoursClientData(overrides = {}) {
+  return { clientName: 'לקוח טסט', procedureType: 'hours', totalHours: 20, serviceName: 'שירות שעות', ...overrides };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+  mockClientDocSnap = { exists: true, data: () => ({ createdBy: 'testuser', idNumber: '' }) };
+});
+
+describe('createClient — idNumber (ת"ז)', () => {
+  it('A. stores a valid ת"ז on the created client doc', async () => {
+    await createClient(hoursClientData({ idNumber: VALID_ID }), ctx);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const written = mockCreate.mock.calls[0][0];
+    expect(written.idNumber).toBe(VALID_ID);
+  });
+
+  it('B. rejects an invalid ת"ז WITHOUT echoing the value in the error', async () => {
+    expect.assertions(4);
+    try {
+      await createClient(hoursClientData({ idNumber: INVALID_ID }), ctx);
+    } catch (err) {
+      expect(err.code).toBe('invalid-argument');
+      expect(err.message).toBe('מספר תעודת הזהות אינו תקין');
+      expect(err.message).not.toContain(INVALID_ID); // no PII leak in the error
+    }
+    expect(mockCreate).not.toHaveBeenCalled(); // creation aborted before the write
+  });
+
+  it('C. succeeds with NO ת"ז and stores it as empty string (optional field)', async () => {
+    await createClient(hoursClientData(), ctx);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockCreate.mock.calls[0][0].idNumber).toBe('');
+  });
+
+  it('C2. treats blank / whitespace ת"ז as not-provided (stored as empty)', async () => {
+    await createClient(hoursClientData({ idNumber: '   ' }), ctx);
+    expect(mockCreate.mock.calls[0][0].idNumber).toBe('');
+  });
+});
+
+describe('updateClient — idNumber immutability', () => {
+  it('D. rejects any attempt to change ת"ז after creation', async () => {
+    expect.assertions(2);
+    try {
+      await updateClient({ clientId: 'AUTO-2026000', idNumber: VALID_ID }, ctx);
+    } catch (err) {
+      expect(err.code).toBe('invalid-argument');
+      expect(err.message).toBe('לא ניתן לעדכן תעודת זהות לאחר יצירת הלקוח');
+    }
+  });
+
+  it('D2. does NOT write idNumber even if other valid fields are present', async () => {
+    try {
+      await updateClient({ clientId: 'AUTO-2026000', idNumber: VALID_ID, fullName: 'שם חדש' }, ctx);
+    } catch (_) { /* expected throw */ }
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/functions/tests/israeli-id-validator.test.js
+++ b/functions/tests/israeli-id-validator.test.js
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for isValidIsraeliId (functions/shared/validators.js) — Pre-H.1.0.
+ *
+ * The Israeli ת"ז check-digit validator is the foundation of the cross-system
+ * join key to tofes-mecher (MASTER_PLAN §8.2.5). These tests pin the official
+ * check-digit algorithm + the edge cases the investigation surfaced:
+ *  - 8-digit IDs that must be zero-padded to 9 before checksum
+ *  - non-numeric sentinels that already live in the data (SYSTEM-INTERNAL, TEST-…)
+ *  - the all-zeros guard
+ *  - non-string / out-of-range input
+ *
+ * Pure function — no firebase, no mocks.
+ */
+'use strict';
+
+const { isValidIsraeliId } = require('../shared/validators');
+
+describe('isValidIsraeliId — valid IDs (correct check digit)', () => {
+  it('accepts a valid 9-digit ת"ז', () => {
+    expect(isValidIsraeliId('123456782')).toBe(true);
+  });
+
+  it('accepts a valid ID that requires leading-zero padding (8 digits → 9)', () => {
+    // '00000018' padded to '000000018' has a valid check digit.
+    expect(isValidIsraeliId('00000018')).toBe(true);
+    expect(isValidIsraeliId('000000018')).toBe(true);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidIsraeliId('  123456782  ')).toBe(true);
+  });
+});
+
+describe('isValidIsraeliId — invalid IDs (wrong check digit)', () => {
+  it('rejects a 9-digit number with an incorrect check digit', () => {
+    expect(isValidIsraeliId('123456789')).toBe(false);
+  });
+
+  it('rejects all-zeros (passes the raw algorithm but is not a real ID)', () => {
+    expect(isValidIsraeliId('000000000')).toBe(false);
+  });
+});
+
+describe('isValidIsraeliId — malformed / out-of-range input', () => {
+  it('rejects non-numeric sentinels already present in the data', () => {
+    expect(isValidIsraeliId('SYSTEM-INTERNAL')).toBe(false); // internal-case.js:43
+    expect(isValidIsraeliId('TEST-123456')).toBe(false); // validation-script.js
+  });
+
+  it('rejects strings with non-digit characters', () => {
+    expect(isValidIsraeliId('12345678a')).toBe(false);
+    expect(isValidIsraeliId('123-456-78')).toBe(false);
+  });
+
+  it('rejects more than 9 digits', () => {
+    expect(isValidIsraeliId('1234567890')).toBe(false);
+  });
+
+  it('rejects empty / whitespace-only', () => {
+    expect(isValidIsraeliId('')).toBe(false);
+    expect(isValidIsraeliId('   ')).toBe(false);
+  });
+
+  it('rejects non-string input (number, null, undefined, object)', () => {
+    expect(isValidIsraeliId(123456782)).toBe(false);
+    expect(isValidIsraeliId(null)).toBe(false);
+    expect(isValidIsraeliId(undefined)).toBe(false);
+    expect(isValidIsraeliId({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## What & why
Backend-first foundation for the **cross-system join key** (DLR architecture, MASTER_PLAN §8.2.5). Adds an **optional**, check-digit-validated, **immutable** `idNumber` (Israeli ת"ז) to `createClient`. This is the key that will later link a tofes-mecher signed sale to a case/client.

**Approved at checkpoint (2026-06-02)** as the NARROWED scope after `devils-advocate` issued **STOP** on the full vertical slice (3 criticals: the live client-creation UI is the User App not the Admin wizard; the `SimpleClientDialog` direct-write bypass; "required" incoherence vs passport/SYSTEM/legacy). Making `idNumber` **optional** and touching **no UI** neutralizes all three.

## Changes (6 files, +407/-2)
- `functions/shared/validators.js` — new `isValidIsraeliId()`: official ת"ז check-digit, leading-zero pad to 9; rejects non-string / non-digit / >9 / all-zeros.
- `functions/clients/index.js` `createClient` — accept **optional** `idNumber`; validate if present (invalid → Hebrew `invalid-argument`, **value never echoed**); store on the doc (default `''`). **Not unique** (client=case → one ת"ז on many docs).
- `functions/clients/index.js` `updateClient` — **explicitly reject** `idNumber` (immutable-from-creation; was silently ignored).
- `functions/tests/` ×3 — validator vectors + CF integration + PII source-guard (19 tests).

## Test plan
- `cd functions && npx jest tests/israeli-id-validator tests/client-idnumber` → **19 pass** (valid stored / invalid rejected-no-leak / absent→'' / immutable).
- Full `npx jest` → **746 pass** (no regression). `npm run lint` → **0 errors**.
- Manual: none — no deploy, no UI; field has no live producer until the UI PR.

## Behavioral change (safe tightening)
`updateClient` now rejects `idNumber` (previously silently ignored). No real caller sends it (`ClientManagementModal` sends only `caseOpenDate`; `SimpleClientDialog` uses direct `.set()`, not the CF).

## Deferred to separate PRs (documented, not dropped)
UI field (User App) · `required` enforcement · `clients` read-access tightening (G7) · `SimpleClientDialog` bypass · ~127-doc backfill migration · WhatsApp plaintext echo · frontend Zod (`/^\d{9}$/`) reconciliation.

## Rollback
```bash
git revert <merge-commit>
git push origin main
```
Code-only; optional/additive field; no data migration to undo. No PROD deploy in this PR.

## Grader
`outcomes-grader` (separate context, re-ran tests + lint, brute-forced the algorithm): **7/7 MUST, 2/2 SHOULD, 7/7 gates, no FAIL.**

## PRODUCT-GRADE GATES
- **G1 — Customer errors:** PASS — invalid ת"ז → generic Hebrew `"מספר תעודת הזהות אינו תקין"`; no value/stack. Hand-built `HttpsError` short-circuits the grandfathered `${error.message}` catch.
- **G2 — Rollback:** PASS — `git revert` (see Rollback); code-only, no migration.
- **G3 — Monitoring:** PASS — create path keeps success log + `CREATE_CLIENT` audit; the new field is deliberately NOT logged (PII).
- **G4 — Customer test:** PASS — 4 CF integration scenarios + 11 validator vectors + 3 PII-guard = 19 tests.
- **G5 — Hebrew UI:** PASS — both customer-facing errors Hebrew.
- **G6 — Breaking change:** PASS (none) — new optional field; no caller sends it to `createClient`; legacy docs tolerated (default `''`).
- **G7 — Security review:** PASS — `security-access-expert` reviewed (investigation). idNumber kept out of logs/audit; no `firestore.rules` change, no new reader. Read-access widening + SimpleClientDialog bypass are real but DEFERRED + flagged.

No gate FAIL.

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)