### PR TITLE
fix(ci): harden pull-request.yml against PR-field script injection (env-indirection)

### DIFF
--- a/.claude/rubrics/pr-ci-1.md
+++ b/.claude/rubrics/pr-ci-1.md
@@ -1,0 +1,78 @@
+# Rubric — PR-CI-1: harden `pull-request.yml` against PR-field shell injection
+
+**Title:** fix(ci): pass user-controlled PR fields through `env:` instead of inlining `${{ github.event.* }}` into `run:` shells (script-injection hardening).
+**Branch:** `fix/ci-shell-injection-pr-ci-1`
+**Base:** `main`
+**App / Env:** CI / GitHub Actions. No app code, no deploy. Affects only `.github/workflows/pull-request.yml`.
+**Effort:** LIGHT (single file + rubric; the change is mechanical env-indirection).
+
+**Scope:** A PR title or branch name containing a double-quote breaks the `pr-info` step's shell quoting (observed on PR #348, where a gershayim ת"ז was typed as an ASCII `"`), and — more seriously — a crafted title/branch is an arbitrary-command **script-injection** vector, because `${{ … }}` is substituted into the script *source* before the shell parses it. This PR moves every user-controlled `${{ github.event.pull_request.* }}` value that feeds a `run:` block into a step-level `env:` map and references it as a quoted shell variable, so the runner never re-parses attacker-supplied text as shell code. Four `run:` steps are fixed (JOB 1 `pr-info`; JOB 2 `code-quality` ×2; JOB 4 `security` ×1). Reference: GitHub Docs — "Understanding the risk of script injections" / "Good practices for mitigating script injection attacks".
+
+**Explicitly OUT of scope (documented, not dropped):**
+- `ci-cd-production.yml` lines ~536/538 echo `github.ref_name` / `github.actor` in a `run:` block. Different event class (push, collaborator-controlled refs; `github.actor` login charset `[A-Za-z0-9-]` cannot carry shell metacharacters). Lower severity, not the `github.event.*`/`github.head_ref` pattern this task targets → recommended as a **separate defense-in-depth follow-up**, not bundled here.
+- `nightly-tests.yml` — clean (only integer `github.run_number`). No action.
+- Non-shell contexts in `pull-request.yml` left intentionally unchanged (NOT injection vectors): `concurrency.group: pr-${{ …number }}` (config, integer); `with: ref: ${{ …head.sha }}` (action input, 40-char hex SHA); `with: name: security-report-pr-${{ …number }}` (action input, integer).
+
+## MUST criteria (block on FAIL)
+
+### M1 — No user-controlled `github.event.*` inlined into any `run:` shell
+**Rule:** After the change, no `${{ github.event.* }}` (or `${{ github.head_ref }}`) appears inside a `run:` block in `pull-request.yml`. Every such value reaches the shell only via a step-level `env:` map.
+**Evidence:** grep of the file — the only `${{ github.event.* }}` occurrences are in `env:` maps (lines 71–77, 139, 149, 243), in `with:` action inputs (head.sha, artifact name), or in `concurrency.group`. Zero inside `run:`.
+
+### M2 — Env values referenced as quoted shell variables
+**Rule:** Each migrated value is referenced as `"${VAR}"` (echoes) or inside a quoted argument (`"origin/${PR_BASE_REF}...HEAD"`), so expansion is word-split-safe and never re-tokenized.
+**Evidence:** the four `run:` blocks use `${PR_NUMBER}`, `${PR_TITLE}`, … and `"origin/${PR_BASE_REF}...HEAD"`.
+
+### M3 — Injection neutralized
+**Rule:** A PR title / head-branch containing `"`, `$(…)`, backticks, `;`, `|`, `&` is printed/used literally and cannot execute. This is the GitHub-recommended mitigation: env-var contents expanded within double quotes are not parsed as shell syntax.
+**Evidence:** reasoning in PR body + security-agent review (G7). The previously-breaking `"` case now prints literally.
+
+### M4 — No behavior change for benign input
+**Rule:** The information echoed, the `git diff` ref-ranges, the TODO/secret grep logic, job graph, triggers, timeouts, and `needs:` are all unchanged. Only the substitution mechanism changed.
+**Evidence:** `git diff` shows added `env:` blocks + `${{ }}`→`${VAR}` swaps only; no step removed/reordered.
+
+### M5 — Workflow remains valid
+**Rule:** `pull-request.yml` is valid YAML and valid Actions syntax after the change.
+**Evidence:** actionlint (if available) clean, OR YAML parse clean; the workflow self-executes on this very PR (the `pr-info` step runs the new env path live).
+
+### M6 — Scope discipline
+**Rule:** The diff touches ONLY `.github/workflows/pull-request.yml` and this rubric. No other workflow, no app code, no `dist/` artifacts.
+**Evidence:** `git diff --stat main..HEAD`.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Rationale comment present
+**Rule:** A comment in the workflow explains WHY (injection risk + PR #348 trigger + link to GitHub guidance) so a future editor does not "simplify" it back to inline `${{ }}`.
+**Evidence:** comment block above the `pr-info` step + short pointers on the other three.
+
+### S2 — Sibling workflows audited, out-of-scope findings enumerated
+**Rule:** `ci-cd-production.yml` + `nightly-tests.yml` were swept; the `ci-cd-production.yml` `ref_name`/`actor` finding is recorded for follow-up, not silently dropped.
+**Evidence:** "Out of scope" above + PR body completeness note.
+
+## PRODUCT-GRADE GATES
+
+- **G1 — Customer-visible errors:** N/A — output is CI run-log only (developer-facing), never reaches a customer code path.
+- **G2 — Rollback:** PASS — `git revert <merge-commit>` + push; the change takes effect on the next PR run, no deploy/migration to undo. Documented in Rollback below.
+- **G3 — Monitoring:** N/A — no data mutation; CI workflow definition only.
+- **G4 — Test proves the scenario:** PASS — verification is the workflow executing on THIS PR: the `pr-info` step runs through the new `env:` indirection live, and (static) actionlint/YAML-parse confirms validity. There is no unit-test harness for workflow YAML in this repo; CI self-execution is the customer-equivalent test. Manual check: confirm the `📋 PR Information` job is green on this PR and prints Title/Author/branches correctly.
+- **G5 — Hebrew UI:** N/A — CI logs are internal/developer-facing English (explicitly allowed by G5).
+- **G6 — Breaking change:** PASS (none) — no schema/API/route/contract change; identical run-log output for benign input. Purely internal step mechanics.
+- **G7 — Security review:** PASS — this PR IS a security hardening (removes a CI script-injection vector + the quote-breakage on PR #348). Reviewed by the `security` agent (verdict cited in PR body). Net attack surface strictly decreases; no new surface added.
+
+VERDICT: PASS — outcomes-grader (2026-06-02): all MUST M1-M6 PASS, SHOULD S1-S2 PASS, gates G1-G7 PASS/N-A, zero blocking issues. Security review PASS (independently re-verified); completeness audit confirms full coverage, recommends merge.
+
+## Rollback
+```bash
+git revert <merge-commit>
+git push origin main
+```
+Code-only (a single workflow file). No data migration, no deploy. Effect applies to the next PR validation run.
+
+## Test plan
+**Static:** `actionlint .github/workflows/pull-request.yml` (or a YAML parse) — clean. grep confirms no `${{ github.event` inside any `run:`.
+**Live (self-test):** this PR's own `📋 PR Information` job runs the rewritten `pr-info` step; it must be green and print PR Number/Title/Author/Base/Head correctly. A future PR with a `"` in its title will no longer fail the step.
+
+## Notes for grader
+- This is a **spun-off local task** (MASTER_PLAN §8.2 "deferred & tracked" list — "the latent `pull-request.yml` PR-title shell-injection"), NOT a numbered Phase-1/2 PR. No MASTER_PLAN row is added (§11 requires Haim approval for new rows); the deferred-item line in §8.2 already tracks it.
+- `github.event.pull_request.base.ref` is repo-controlled (PR target = `main`), so its three sites are lower-risk than `title`/`head.ref`; they are migrated anyway for a single consistent rule ("no `github.event.*` in a shell") and because the user's instruction said to env every such value.
+- devils-advocate was NOT invoked: this is not a §3.8.4 high-stakes trigger (no `firestore.rules`/schema/PROD-merge/>100-line refactor/migration). Flag if you disagree.

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,18 +57,35 @@ jobs:
     timeout-minutes: 5
 
     steps:
+      # PR-CI-1: PR fields (title, head ref, author, …) are USER-CONTROLLED and
+      # must NOT be inlined as ${{ … }} into a run: shell. ${{ }} is substituted
+      # into the script *source* before the shell parses it, so a title that
+      # contains a double-quote breaks the step (this happened on PR #348 with a
+      # gershayim ת"ז written as ") and a crafted title/branch is an arbitrary-
+      # command injection vector. Pass each value through env: and reference it
+      # as a quoted shell variable — the runner sets the env var to the literal
+      # value and the shell never re-parses its contents as code.
+      # Ref: GitHub Docs — "Understanding the risk of script injections".
       - name: 📊 Display PR Details
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_CHANGED_FILES: ${{ github.event.pull_request.changed_files }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: |
           echo "════════════════════════════════════════"
           echo "📝 Pull Request Information"
           echo "════════════════════════════════════════"
-          echo "PR Number: #${{ github.event.pull_request.number }}"
-          echo "Title: ${{ github.event.pull_request.title }}"
-          echo "Author: ${{ github.event.pull_request.user.login }}"
-          echo "Base Branch: ${{ github.event.pull_request.base.ref }}"
-          echo "Head Branch: ${{ github.event.pull_request.head.ref }}"
-          echo "Changed Files: ${{ github.event.pull_request.changed_files }}"
-          echo "Commits: ${{ github.event.pull_request.commits }}"
+          echo "PR Number: #${PR_NUMBER}"
+          echo "Title: ${PR_TITLE}"
+          echo "Author: ${PR_AUTHOR}"
+          echo "Base Branch: ${PR_BASE_REF}"
+          echo "Head Branch: ${PR_HEAD_REF}"
+          echo "Changed Files: ${PR_CHANGED_FILES}"
+          echo "Commits: ${PR_COMMITS}"
           echo "════════════════════════════════════════"
 
   # ═════════════════════════════════════════════════════════════
@@ -115,17 +132,24 @@ jobs:
             echo "⏭️  Skipped — no .ts files in functions/src-ts/ yet."
           fi
 
+      # PR-CI-1: base ref via env: (see JOB 1) — never inline a github.event.*
+      # value into a shell command. The ref-range is quoted as a single arg.
       - name: 📊 Changed Files Statistics
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           echo "📊 Files Changed in This PR:"
-          git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | head -20
+          git diff --name-only "origin/${PR_BASE_REF}...HEAD" | head -20
           echo ""
-          echo "Total files changed: $(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD | wc -l)"
+          echo "Total files changed: $(git diff --name-only "origin/${PR_BASE_REF}...HEAD" | wc -l)"
 
+      # PR-CI-1: base ref via env: (see JOB 1).
       - name: 🔍 Check for New TODOs
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           echo "🔍 Checking for new TODO comments..."
-          NEW_TODOS=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -i "^+.*TODO\|^+.*FIXME\|^+.*XXX" | wc -l || echo "0")
+          NEW_TODOS=$(git diff "origin/${PR_BASE_REF}...HEAD" | grep -i "^+.*TODO\|^+.*FIXME\|^+.*XXX" | wc -l || echo "0")
           echo "📝 New TODO comments added: $NEW_TODOS"
           if [ "$NEW_TODOS" -gt 5 ]; then
             echo "⚠️ Warning: Many new TODOs added ($NEW_TODOS)"
@@ -213,10 +237,13 @@ jobs:
           echo "⏸️ npm audit deferred to Phase 1.5 (firebase 11→12 upgrade)."
           echo "Continuous coverage handled by Dependabot — see .github/dependabot.yml"
 
+      # PR-CI-1: base ref via env: (see JOB 1).
       - name: 🔍 Scan for Exposed Secrets
+        env:
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           echo "🔍 Scanning for exposed secrets in PR..."
-          if git diff origin/${{ github.event.pull_request.base.ref }}...HEAD | grep -i "password\|secret\|apikey.*:.*['\"]AIza" 2>/dev/null; then
+          if git diff "origin/${PR_BASE_REF}...HEAD" | grep -i "password\|secret\|apikey.*:.*['\"]AIza" 2>/dev/null; then
             echo "⚠️ Warning: Potential secrets detected in PR diff"
             echo "Please review and remove before merging!"
           else


### PR DESCRIPTION
## Summary

User-controlled PR fields (title, head ref, author, …) were interpolated as `${{ github.event.pull_request.* }}` **directly inside `run:` shell blocks** in `.github/workflows/pull-request.yml`. Because `${{ }}` is substituted into the script *source* before the shell parses it:

- a PR title containing a double-quote **breaks the `pr-info` step and fails the job** — this happened on PR #348, where a Hebrew gershayim in `ת"ז` was written as an ASCII `"`; and
- a crafted title or branch name is an arbitrary-command **script-injection** vector in CI.

This PR moves every user-controlled `github.event.pull_request.*` value that feeds a `run:` block into a **step-level `env:` map** and references it as a **double-quoted shell variable** (`echo "Title: ${PR_TITLE}"`). The runner assigns the literal value to the environment variable; the shell never re-parses its contents as code. A title like `$(curl evil)` or `"; rm -rf / #` now prints literally.

Reference: GitHub Docs — *Understanding the risk of script injections* / *Good practices for mitigating script injection attacks*.

## What changed

Four `run:` steps in `pull-request.yml` hardened via env-indirection:

| Job | Step | Values routed through `env:` |
|---|---|---|
| `pr-info` | Display PR Details | number, **title**, author login, base ref, **head ref**, changed_files, commits |
| `code-quality` | Changed Files Statistics | base ref |
| `code-quality` | Check for New TODOs | base ref |
| `security` | Scan for Exposed Secrets | base ref |

Git ref-ranges are now passed as a single quoted argument: `"origin/${PR_BASE_REF}...HEAD"`.

**Left intentionally unchanged** (not shell contexts, and non-injectable values): `with: ref: ${{ …head.sha }}` (actions/checkout input, 40-char hex SHA), `with: name: security-report-pr-${{ …number }}` (integer), `concurrency.group` (integer). The `${{ needs.*.result }}` expressions in `pr-summary` are GitHub-computed job-result enums (`success`/`failure`/…), not user input — correctly left inline.

No app code. No deploy. Only the workflow file + its rubric.

## Verification

- **Deterministic:** YAML parses cleanly (all 7 jobs intact); a grep over the file confirms **zero `${{ github.* }}` remains inside any `run:` block**.
- **`security` review → PASS:** env-indirection genuinely neutralizes injection (a double-quoted env expansion is not re-tokenized by POSIX `sh`); no working payload could be constructed; no new quoting / word-splitting / ref-range bug introduced; the unchanged contexts are all genuinely non-injectable.
- **`completeness` audit:** `pull-request.yml` fully covered, no missed sites; `nightly-tests.yml` + `dependabot.yml` clean.
- **`outcomes-grader` → VERDICT PASS:** M1–M6 PASS, S1–S2 PASS, all gates PASS / N/A, zero blocking issues.

## PRODUCT-GRADE GATES

- **G1 — Customer-visible errors:** N/A — output is CI run-log only (developer-facing); no customer code path.
- **G2 — Rollback:** PASS — `git revert <merge-commit>` + push; code-only, no deploy/migration to undo.
- **G3 — Monitoring:** N/A — no data mutation; CI workflow definition only.
- **G4 — Test proves the scenario:** PASS — the workflow self-executes on THIS PR (the rewritten `pr-info` step runs the new `env:` path live); YAML-parse validity confirmed (Node). No YAML unit-test harness exists in the repo; CI self-execution is the customer-equivalent test.
- **G5 — Hebrew UI:** N/A — CI logs are internal/developer-facing English (explicitly allowed).
- **G6 — Breaking change:** PASS (none) — run-log output is byte-identical for benign input; quoted `origin/main...HEAD` parses identically to the prior unquoted form. Internal step mechanics only.
- **G7 — Security review:** PASS — this PR *is* the security hardening (removes a CI script-injection vector + the PR #348 quote breakage). `security` agent reviewed and re-verified; net attack surface strictly decreases, no new surface added.

## Out of scope (tracked, not dropped)

- **`ci-cd-production.yml:536/538`** echo `github.ref_name` / `github.actor` inside a `run:` block — same anti-pattern, **lower severity** (push/dispatch path only, collaborator-controlled; `github.actor` login charset `[A-Za-z0-9-]` cannot carry shell metacharacters; `github.ref_name` can carry `$`/backtick/parens). Recommended as a **separate defense-in-depth follow-up PR**, kept out of here to preserve scope discipline (rubric MUST M6).
- Pre-existing `apps/user-app/dist/` working-tree drift (confirmed **not** in this PR diff) and the husky v9 `prepare: "husky install"` deprecation — each a separate chore PR.

## Rollback

```bash
git revert <merge-commit>
git push origin main
```

Code-only, single workflow file. No data migration, no deploy. Effect applies on the next PR validation run.

## Test plan

- **Static:** `actionlint`/YAML parse clean; grep confirms no `${{ github.event` inside any `run:`.
- **Live (self-test):** this PR's own `📋 PR Information` job runs the rewritten `pr-info` step — it must be green and print PR Number / Title / Author / Base / Head correctly. A future PR whose title contains a `"` will no longer fail the step.

---

Rubric: `.claude/rubrics/pr-ci-1.md`. Spun-off local task per MASTER_PLAN §8.2 ("the latent `pull-request.yml` PR-title shell-injection"); not a numbered Phase-1/2 PR, so no MASTER_PLAN row added.

VERDICT: PASS
