### PR TITLE
Pre-H.1.0b: optional check-digit idNumber (ת.ז) in User-App wizard

### DIFF
--- a/.claude/rubrics/pr-pre-h-1-0b.md
+++ b/.claude/rubrics/pr-pre-h-1-0b.md
@@ -1,0 +1,92 @@
+# Rubric — Pre-H.1.0b (UI, User App): optional check-digit-validated `idNumber` (ת"ז) at client creation
+
+**Title:** Capture an **optional**, check-digit-validated `idNumber` (ת"ז) in the LIVE User-App client-creation wizard — the UI producer for the cross-system join key (MASTER_PLAN §8.2.5). Backend half merged in #348 (Pre-H.1.0a).
+**Branch:** `feat/pre-h-1-0b-idnumber-userapp`
+**Base:** `main`
+**App / Env:** User App (frontend) / DEV. No deploy in this PR.
+**Effort:** MEDIUM (effort-scaler verdict 2026-06-03).
+
+**Scope (Option A — approved at checkpoint 2026-06-03 over the devils-advocate STOP on `required`):**
+- New `apps/user-app/js/modules/israeli-id.js` — exact frontend mirror of backend `isValidIsraeliId()` (check-digit + zero-pad), with a `window.IsraeliId` global (for the classic-script dialog) and an ESM `export` (for tests). NOT compiled to `dist` (hand-written module, served directly, like `tz-helper.js`).
+- `apps/user-app/js/modules/case-creation/case-creation-dialog.js`:
+  - New **optional** ת"ז `<input id="newClientIdNumber">` in `#step1_newClient` (no `*` required marker).
+  - `validateCurrentStep()` (new/step-1): **validate-if-present** — if the user typed a ת"ז it must pass `window.IsraeliId.isValidIsraeliId`, else a Hebrew error; empty → allowed (no regression).
+  - `collectFormData()` → `formData.client.idNumber`; `buildFirebaseData()` → `data.idNumber` (trimmed, default `''`).
+- `apps/user-app/index.html` — load `israeli-id.js` before the dialog.
+- `apps/user-app/js/schemas/index.ts` — reconcile the orphaned `idNumber` validator from `/^\d{9}$/` to a self-contained check-digit `.refine()` (corrected Hebrew message). **Documentation/drift-guard only** — this schema is NOT loaded at runtime; the runtime validator is `israeli-id.js`. `dist` intentionally NOT rebuilt (orphaned artifact; see Notes).
+- Tests (root Vitest, run in CI): a cross-language drift-guard (frontend ≡ backend 11 vectors) + a PII source-guard over the dialog.
+
+**Explicitly DEFERRED (documented, tracked, NOT in scope):** `required` enforcement + an `idType` model (ת"ז/passport/ח.פ.) with backend support; the `validation-script.js` browser harness fix (broken by #348 — Haim chose to defer); `clients` read-access tightening (G7); the Admin `SimpleClientDialog` unvalidated bypass; the ~127-doc backfill; the WhatsApp echo; the `logger.js` Error-branch sanitize hardening; frontend `dist` hygiene.
+
+## MUST criteria (block on FAIL)
+
+### M1 — `israeli-id.js` is an exact behavioral mirror of backend `isValidIsraeliId`
+**Rule:** Pure module: type-guard (non-string → false), `/^\d{1,9}$/` after trim, `padStart(9,'0')`, all-zeros guard, weights `1,2,1,2…` with `-9` fold, `sum % 10 === 0`. Exposes `window.IsraeliId.isValidIsraeliId` + ESM export.
+**Evidence:** `tests/unit/user-app/israeli-id-drift-guard.test.ts` — the same 11 vectors as backend `functions/tests/israeli-id-validator.test.js` (valid `123456782`, zero-pad `00000018`/`000000018`, wrong `123456789`, all-zeros, sentinels `SYSTEM-INTERNAL`/`TEST-…`, non-digit, >9 digits, empty, non-string) all agree. Green in CI.
+
+### M2 — Optional, validate-if-present, in the LIVE validator + payload
+**Rule:** ת"ז is **optional**. If non-empty it must pass the check-digit (Hebrew `invalid` message, value NOT echoed) before step advance; if empty/blank the wizard proceeds exactly as today (no regression). When provided+valid it is wired through `collectFormData` → `buildFirebaseData` → `createClient` as `idNumber` (trimmed). When absent → not sent (backend defaults `''`).
+**Evidence:** diff of `validateCurrentStep` new/step-1 (validate-if-present block), `collectFormData` (`formData.client.idNumber`), `buildFirebaseData` (`data.idNumber`). Manual-smoke steps in the PR body (DOM-bound).
+
+### M3 — NO `required`, NO regression on existing intake
+**Rule:** No `*`/required marker; no path blocks creating a client without a ת"ז. Corporate (ח.פ.) / foreign (passport) clients can still be created (the live-data driver for Option A: ≥2 of 139 clients are companies/nonprofits). The field is purely additive.
+**Evidence:** `git diff` shows no required gate; the validate block is guarded by `if (idNumber)`.
+
+### M4 — ת"ז value never reaches logs (frontend PII guard)
+**Rule:** No `console.*` / `Logger.*` call in `case-creation-dialog.js` carries an `idNumber` / `formData` / `firebaseData` value. (`logger.js` prod override nulls only `console.log/info/debug`; `console.error/warn/group/trace` survive — so a raw form/error dump would leak ת"ז in a PUBLIC-repo prod console.)
+**Evidence:** `tests/unit/user-app/idnumber-pii-guard.test.ts` — static source-scan (comment-stripped) + positive-control. Green in CI.
+
+### M5 — Cross-language drift-guard actually runs in CI
+**Rule:** The drift-guard lives in `tests/unit/user-app/` (root Vitest) so `pull-request.yml` Job `test` (`npm test`) executes it on every PR; it pins BOTH `israeli-id.js` AND `ClientSchema` to the backend's 11-vector verdicts.
+**Evidence:** test file path + a local `npm test` run showing it execute and pass.
+
+### M6 — No scope creep
+**Rule:** Diff touches ONLY: `israeli-id.js`, `case-creation-dialog.js`, `index.html`, `schemas/index.ts`, the 2 new test files, and this rubric. No `firestore.rules`, no backend, no migration, no `dist`, no `validation-script.js`, no unrelated files.
+**Evidence:** `git diff --stat main..HEAD`.
+
+### M7 — Lint + type-check clean
+**Rule:** `npm run lint` → 0 errors; `npm run type-check` (tsc --noEmit) → 0 errors.
+**Evidence:** command output, exit 0.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Honest framing of the orphaned Zod
+**Rule:** PR body states the Zod reconciliation is documentation/drift-guard (schema not loaded at runtime), the real validator is `israeli-id.js`, and `dist` is intentionally not rebuilt — with reason.
+
+### S2 — Deferred follow-ups enumerated
+**Rule:** PR body lists every deferred item (required+idType, harness, read-access, bypass, backfill, WhatsApp, logger Error-branch, dist hygiene) so nothing is silently dropped.
+
+### S3 — Immutability surfaced to the user
+**Rule:** Because ת"ז is immutable after creation (backend `updateClient` rejects it), the field has helper text or placeholder making clear it should be entered correctly (mitigates the "wrong once = stuck" trap). (SHOULD — nice-to-have UX.)
+
+## PRODUCT-GRADE GATES
+
+- **G1 — Customer errors:** PASS — invalid ת"ז → Hebrew `"מספר תעודת הזהות אינו תקין"` inline (pre-submit), value never echoed; the backend rejection is a Hebrew toast backstop. No stack/`undefined`/English.
+- **G2 — Rollback:** PASS — `git revert <merge-commit>` + redeploy. Code-only, additive optional field; nothing to migrate.
+- **G3 — Monitoring:** N/A — no NEW data-write path (the existing `createClient` success log/audit is preserved; ת"ז deliberately NOT logged — that is correct posture, M4). The field rides the already-monitored create call.
+- **G4 — Customer-scenario test:** PASS — drift-guard (valid accepted, invalid/wrong-check rejected with Hebrew, 8-digit zero-pad accepted, empty allowed) runs in CI; DOM-bound wizard interactions covered by documented manual-smoke in the PR body.
+- **G5 — Hebrew UI:** PASS — field label + error message Hebrew (`"תעודת זהות"`, `"מספר תעודת הזהות אינו תקין"`).
+- **G6 — Breaking change:** PASS (none) — purely additive optional field; no existing flow changes; `required` explicitly NOT introduced.
+- **G7 — Security review:** PASS — `security-access-expert` reviewed (investigation): no `firestore.rules` change, no new reader, `clients` read already all-authenticated (unchanged); the only new PII channel is the form/console, closed by M4. Read-access tightening + the SimpleClientDialog bypass are real but DEFERRED + flagged.
+
+VERDICT: (filled by grader)
+
+## Rollback
+```bash
+git revert <merge-commit>
+git push origin main
+```
+Code-only. No data migration. No PROD deploy in this PR.
+
+## Test plan
+**Automated (CI, root Vitest):** `npm test` → drift-guard (frontend ≡ backend 11 vectors, both `israeli-id.js` and `ClientSchema`) + PII source-guard. Full suite green (regression).
+**Manual smoke (DEV, documented in PR body — DOM-bound, not auto-covered):**
+1. New client + valid ת"ז (`123456782`) → advances + client created with `idNumber`.
+2. New client + invalid ת"ז (`123456789`) → inline Hebrew error, blocked before submit.
+3. New client + NO ת"ז → advances + creates (no regression; corporate/foreign intake preserved).
+4. New client + 8-digit ת"ז (`00000018`) → accepted (zero-pad parity).
+
+## Notes for grader
+- **Option A** (optional) was Haim-approved at the 2026-06-03 checkpoint over the devils-advocate **STOP** on `required` (3 criticals: `required` silently breaks corporate-ח.פ./foreign-passport intake — verified live: ≥2/139 clients are companies; `required` incoherent without an absent `idType` model; PII console-survival gap). `required` + `idType` is deferred to a designed PR with backend support.
+- The Zod change is on an **orphaned** schema (no runtime loader; grep: no HTML loads `dist/.../schemas/index.js`). It is delivered for contract/drift-guard correctness; the runtime enforcement is `israeli-id.js` via `validateCurrentStep`. `dist` is intentionally not rebuilt (the repo already tolerates dist drift; rebuilding would churn an unloaded artifact + sweep unrelated pre-existing drift).
+- The check-digit appears in two places (`israeli-id.js` + the Zod `.refine()`); this controlled duplication is **pinned by the drift-guard test**, which asserts both agree with the backend's canonical 11 vectors — a stronger guarantee than a fragile cross-build-boundary import (classic-script dialog ↔ ESM schema ↔ CJS backend).

--- a/apps/user-app/index.html
+++ b/apps/user-app/index.html
@@ -1335,6 +1335,8 @@
     <!-- Modern modular case creation system - currently in testing -->
     <script defer src="js/modules/case-creation/case-number-generator.js?v=esc5fix"></script>
     <script defer src="js/modules/case-creation/case-form-validator.js?v=esc5fix"></script>
+    <!-- Pre-H.1.0b: ת"ז (Israeli ID) check-digit validator. ES module → sets window.IsraeliId for the classic-script dialog below (read at click-time, so load order is safe). -->
+    <script type="module" src="js/modules/israeli-id.js?v=esc5fix"></script>
     <script defer src="js/modules/case-creation/case-creation-dialog.js?v=esc5fix"></script>
 
     <!-- ===== Smart Descriptions System ===== -->

--- a/apps/user-app/js/modules/case-creation/case-creation-dialog.js
+++ b/apps/user-app/js/modules/case-creation/case-creation-dialog.js
@@ -472,6 +472,32 @@
                       "></div>
                     </div>
                   </div>
+
+                  <!-- ת"ז (Israeli ID) — Pre-H.1.0b: OPTIONAL, check-digit validated (israeli-id.js). -->
+                  <div style="margin-bottom: 16px;">
+                    <label style="display: block; margin-bottom: 8px; font-weight: 500; color: #374151; font-size: 14px;">
+                      תעודת זהות <span style="color: #9ca3af; font-weight: 400;">(לא חובה)</span>
+                    </label>
+                    <input
+                      type="text"
+                      id="newClientIdNumber"
+                      inputmode="numeric"
+                      maxlength="9"
+                      placeholder="9 ספרות"
+                      autocomplete="off"
+                      style="
+                        width: 100%;
+                        padding: 10px 12px;
+                        border: 1px solid #d1d5db;
+                        border-radius: 6px;
+                        font-size: 14px;
+                        transition: all 0.2s;
+                      "
+                    >
+                    <div style="margin-top: 6px; font-size: 12px; color: #9ca3af;">
+                      לא ניתן לעדכן את מספר תעודת הזהות לאחר פתיחת התיק
+                    </div>
+                  </div>
                 </div>
 
                 <!-- Step 1: Select Client (Existing Client Mode) -->
@@ -913,6 +939,18 @@ serviceTitleField.style.display = 'block';
           } else {
             // טען מספר תיק אוטומטית לפני מעבר לשלב הבא
             await this.loadCaseNumber();
+          }
+
+          // ת"ז (Pre-H.1.0b): OPTIONAL — validate ONLY if the user entered something.
+          // Empty → wizard proceeds exactly as before (no regression for corporate/foreign clients).
+          // NEVER log idNumber (PUBLIC repo; console.error/warn survive the prod console override).
+          const idNumber = document.getElementById('newClientIdNumber')?.value?.trim();
+          if (idNumber) {
+            const idIsValid = window.IsraeliId?.isValidIsraeliId?.(idNumber);
+            // If the helper failed to load, idIsValid is undefined → skip (backend re-validates).
+            if (idIsValid === false) {
+              errors.push('מספר תעודת הזהות אינו תקין');
+            }
           }
         } else if (this.currentStep === 2) {
           // Step 2: Case Details
@@ -2216,7 +2254,9 @@ return text;
       // לקוח
       if (this.currentMode === 'new') {
         formData.client = {
-          name: document.getElementById('newClientName')?.value?.trim()
+          name: document.getElementById('newClientName')?.value?.trim(),
+          // ת"ז (Pre-H.1.0b): OPTIONAL — '' when not provided. Validated in validateCurrentStep.
+          idNumber: document.getElementById('newClientIdNumber')?.value?.trim() || ''
         };
       } else {
         const selectedClient = this.clientSelector?.getSelectedValues();
@@ -2582,6 +2622,8 @@ return text;
     buildFirebaseData(formData) {
       const data = {
         clientName: formData.client.name,
+        // ת"ז (Pre-H.1.0b): OPTIONAL join key; '' when not provided. Backend re-validates (#348).
+        idNumber: formData.client.idNumber || '',
         phone: formData.client.phone || '',
         email: formData.client.email || '',
         caseNumber: formData.case.caseNumber,

--- a/apps/user-app/js/modules/israeli-id.js
+++ b/apps/user-app/js/modules/israeli-id.js
@@ -1,0 +1,63 @@
+/**
+ * ═══════════════════════════════════════════════════════════════
+ * Israeli ID (ת"ז) check-digit validator — frontend (Pre-H.1.0b)
+ * ═══════════════════════════════════════════════════════════════
+ *
+ * The single frontend source of truth for ת"ז validation. It is an
+ * EXACT behavioral mirror of the backend `isValidIsraeliId()`
+ * (`functions/shared/validators.js`, merged in PR #348). The cross-system
+ * join key to tofes-mecher (MASTER_PLAN §8.2.5) is the ת"ז, so the
+ * frontend pre-check MUST agree with the backend bit-for-bit.
+ *
+ * SSOT note: backend is CJS (Cloud Functions); this is an ES module served
+ * directly to the browser (NOT compiled to dist). Cross-runtime sync is
+ * manual — if you change one, change the other. The agreement is PINNED by
+ * `tests/unit/user-app/israeli-id-drift-guard.test.ts`, which runs the same
+ * 11 canonical vectors as `functions/tests/israeli-id-validator.test.js`
+ * against BOTH sides and fails CI on any divergence.
+ *
+ * PII discipline (repo is PUBLIC): this module NEVER logs the value it
+ * validates. Callers must never pass a ת"ז into a raw `console.*`.
+ *
+ * Algorithm (official Israeli ת"ז / Luhn-like, weights 1,2,1,2…):
+ *   - non-string                → invalid
+ *   - not 1–9 digits after trim → invalid
+ *   - zero-pad to 9             → leading zeros are significant
+ *   - all-zeros                 → invalid (passes the raw checksum, not a real ID)
+ *   - Σ(folded digit*weight) mod 10 === 0 → valid
+ */
+
+/**
+ * @param {*} id - candidate ת"ז (string expected)
+ * @returns {boolean} true iff `id` is a valid Israeli ID number
+ */
+export function isValidIsraeliId(id) {
+  if (typeof id !== 'string') {
+    return false;
+  }
+  const digits = id.trim();
+  if (!/^\d{1,9}$/.test(digits)) {
+    return false;
+  }
+  const padded = digits.padStart(9, '0');
+  if (padded === '000000000') {
+    return false;
+  }
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    let inc = Number(padded[i]) * ((i % 2) + 1);
+    if (inc > 9) {
+      inc -= 9;
+    }
+    sum += inc;
+  }
+  return sum % 10 === 0;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Window mirror — for non-module (classic <script defer>) consumers
+// such as case-creation-dialog.js. Mirrors the tz-helper.js pattern.
+// ─────────────────────────────────────────────────────────────────
+if (typeof window !== 'undefined') {
+  window.IsraeliId = { isValidIsraeliId };
+}

--- a/apps/user-app/js/schemas/index.ts
+++ b/apps/user-app/js/schemas/index.ts
@@ -87,6 +87,37 @@ export const HebrewTextSchema = z.string().min(2, {
 // ==================== Client Schema ====================
 
 /**
+ * Israeli ID (ת"ז) check-digit — Pre-H.1.0b drift-guard.
+ *
+ * SELF-CONTAINED mirror of the backend `isValidIsraeliId()`
+ * (functions/shared/validators.js, #348) and the frontend runtime helper
+ * (js/modules/israeli-id.js). This schema is NOT loaded at runtime (the live
+ * validator is israeli-id.js via the wizard); it is kept correct as the
+ * documented contract. The three impls are PINNED to identical verdicts by
+ * tests/unit/user-app/israeli-id-drift-guard.test.ts (the backend's 11 vectors).
+ * If you change the algorithm, change all three.
+ */
+function isValidIsraeliIdChecksum(value: string): boolean {
+  const digits = value.trim();
+  if (!/^\d{1,9}$/.test(digits)) {
+    return false;
+  }
+  const padded = digits.padStart(9, '0');
+  if (padded === '000000000') {
+    return false;
+  }
+  let sum = 0;
+  for (let i = 0; i < 9; i++) {
+    let inc = Number(padded[i]) * ((i % 2) + 1);
+    if (inc > 9) {
+      inc -= 9;
+    }
+    sum += inc;
+  }
+  return sum % 10 === 0;
+}
+
+/**
  * Client data structure
  */
 export const ClientSchema = z.object({
@@ -95,9 +126,14 @@ export const ClientSchema = z.object({
   phone: PhoneSchema.optional(),
   email: EmailSchema.optional(),
   address: z.string().optional(),
+  // ת"ז (Pre-H.1.0b): OPTIONAL, check-digit validated (NOT the old 9-digits-only
+  // regex, which wrongly rejected valid 8-digit IDs and accepted bad check digits).
+  // Empty string is treated as "not provided" (optional). See isValidIsraeliIdChecksum.
   idNumber: z
     .string()
-    .regex(/^\d{9}$/, { message: 'תעודת זהות חייבת להכיל 9 ספרות' })
+    .refine((val) => val.trim() === '' || isValidIsraeliIdChecksum(val), {
+      message: 'מספר תעודת הזהות אינו תקין'
+    })
     .optional(),
   notes: z.string().optional(),
   createdAt: DateStringSchema.optional(),

--- a/tests/unit/user-app/idnumber-pii-guard.test.ts
+++ b/tests/unit/user-app/idnumber-pii-guard.test.ts
@@ -1,0 +1,55 @@
+/**
+ * PII source-guard (Pre-H.1.0b) — ת"ז must never reach the browser console.
+ *
+ * `logger.js`'s production override nulls only console.log/info/debug;
+ * console.error / warn / group / trace / dir / table SURVIVE in production and
+ * bypass Logger.sanitize(). The repo is PUBLIC and ת"ז is sensitive PII under
+ * Israeli privacy law. This static scan asserts that no console.* / Logger.*
+ * call in the touched files carries an `idNumber`, the `formData` object, or the
+ * `firebaseData`/CF payload — the realistic frontend leak vectors once the field
+ * is wired through collectFormData → buildFirebaseData.
+ *
+ * Mirrors the backend guard functions/tests/client-idnumber-pii-guard.test.js.
+ * Static scan (no import → no DOM/Firebase needed). Runs in CI via root Vitest.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/** Remove block + line comments so a comment that merely mentions idNumber
+ *  doesn't trip the guard (the `[^:]` before // keeps `://` URLs intact). */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+// A console.* / Logger.* call whose argument span (up to the next `;`) references
+// idNumber, the form object, or the CF payload. `[^;]` spans newlines so a
+// multi-line logging call is covered.
+const LOG_WITH_PII =
+  /(?:console\.\w+|[Ll]ogger\.\w+)\s*\([^;]*\b(?:idNumber|formData|firebaseData)\b/;
+
+const ROOT = process.cwd();
+const DIALOG = resolve(
+  ROOT,
+  'apps/user-app/js/modules/case-creation/case-creation-dialog.js'
+);
+const HELPER = resolve(ROOT, 'apps/user-app/js/modules/israeli-id.js');
+
+describe('no ת"ז (idNumber) value in the browser console — static source guard', () => {
+  it('case-creation-dialog.js never passes idNumber/formData/firebaseData to console.*/Logger.*', () => {
+    const code = stripComments(readFileSync(DIALOG, 'utf8'));
+    expect(code).not.toMatch(LOG_WITH_PII);
+  });
+
+  it('israeli-id.js never logs the value it validates', () => {
+    const code = stripComments(readFileSync(HELPER, 'utf8'));
+    expect(code).not.toMatch(LOG_WITH_PII);
+  });
+
+  it('sanity: the guard regex DOES catch a violating pattern', () => {
+    expect('console.error("save failed", formData);').toMatch(LOG_WITH_PII);
+    expect('console.log(`id ${client.idNumber}`);').toMatch(LOG_WITH_PII);
+    expect('Logger.warn("x", firebaseData);').toMatch(LOG_WITH_PII);
+  });
+});

--- a/tests/unit/user-app/israeli-id-drift-guard.test.ts
+++ b/tests/unit/user-app/israeli-id-drift-guard.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Cross-language drift-guard (Pre-H.1.0b) for the Israeli ID (ת"ז) validator.
+ *
+ * The frontend ת"ז check MUST agree with the backend `isValidIsraeliId`
+ * (functions/shared/validators.js, #348) — ת"ז is the cross-system join key to
+ * tofes-mecher (MASTER_PLAN §8.2.5). This test pins BOTH frontend impls — the
+ * runtime helper (js/modules/israeli-id.js, used by the wizard) AND the orphaned
+ * Zod ClientSchema — to the SAME canonical vectors the backend test uses
+ * (functions/tests/israeli-id-validator.test.js). Any divergence fails CI.
+ *
+ * Runs in CI via root Vitest ("Run Vitest (root, non-rules)" in pull-request.yml).
+ */
+import { describe, it, expect } from 'vitest';
+
+import { isValidIsraeliId } from '../../../apps/user-app/js/modules/israeli-id.js';
+import { ClientSchema } from '../../../apps/user-app/js/schemas/index';
+
+// Canonical [input, expected] vectors — identical set to the backend test
+// functions/tests/israeli-id-validator.test.js.
+const STRING_VECTORS: Array<[string, boolean]> = [
+  ['123456782', true], // valid 9-digit
+  ['00000018', true], // 8-digit → zero-padded to a valid ID
+  ['000000018', true], // explicit 9-digit zero-pad
+  ['  123456782  ', true], // surrounding whitespace trimmed
+  ['123456789', false], // wrong check digit
+  ['000000000', false], // all-zeros guard
+  ['SYSTEM-INTERNAL', false], // sentinel present in legacy data
+  ['TEST-123456', false], // harness sentinel
+  ['12345678a', false], // non-digit char
+  ['123-456-78', false], // dashes
+  ['1234567890', false], // more than 9 digits
+  ['', false], // empty
+  ['   ', false] // whitespace-only
+];
+
+// Non-string inputs the runtime helper must reject. (The Zod path rejects these
+// at z.string() before the refine, so they are asserted only on the helper.)
+const NON_STRING_VECTORS: unknown[] = [123456782, null, undefined, {}];
+
+describe('israeli-id.js (frontend runtime helper) ≡ backend isValidIsraeliId', () => {
+  it.each(STRING_VECTORS)('isValidIsraeliId(%j) === %s', (input, expected) => {
+    expect(isValidIsraeliId(input)).toBe(expected);
+  });
+
+  it('rejects non-string input (number, null, undefined, object)', () => {
+    for (const v of NON_STRING_VECTORS) {
+      expect(isValidIsraeliId(v as never)).toBe(false);
+    }
+  });
+
+  it('exposes a window.IsraeliId mirror for the classic-script dialog', () => {
+    const g = globalThis as Record<string, unknown>;
+    const scope = (g.window ?? g) as Record<string, unknown>;
+    const mirror = scope.IsraeliId as { isValidIsraeliId?: unknown } | undefined;
+    expect(typeof mirror?.isValidIsraeliId).toBe('function');
+  });
+});
+
+describe('ClientSchema.idNumber (orphaned Zod) ≡ the same check-digit verdicts', () => {
+  const IdOnly = ClientSchema.pick({ idNumber: true });
+
+  // For NON-EMPTY strings the refine applies the check digit — must match the helper.
+  const checkDigitVectors = STRING_VECTORS.filter(([s]) => s.trim() !== '');
+
+  it.each(checkDigitVectors)('safeParse({ idNumber: %j }).success === %s', (input, expected) => {
+    expect(IdOnly.safeParse({ idNumber: input }).success).toBe(expected);
+  });
+
+  it('treats absent (undefined) and blank string as valid (OPTIONAL semantics)', () => {
+    expect(IdOnly.safeParse({}).success).toBe(true); // not provided
+    expect(IdOnly.safeParse({ idNumber: '' }).success).toBe(true); // blank = not provided
+    expect(IdOnly.safeParse({ idNumber: '   ' }).success).toBe(true);
+  });
+
+  it('rejects an invalid ת"ז with the Hebrew message (value not echoed)', () => {
+    const res = IdOnly.safeParse({ idNumber: '123456789' });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      const msg = res.error.issues[0]?.message ?? '';
+      expect(msg).toBe('מספר תעודת הזהות אינו תקין');
+      expect(msg).not.toContain('123456789'); // no PII / value in the message
+    }
+  });
+});


### PR DESCRIPTION
## Pre-H.1.0b — optional check-digit idNumber (ת.ז) in the User-App client-creation wizard

The UI producer for the cross-system join key to tofes-mecher (MASTER_PLAN §8.2.5). The backend half (validate-if-present + immutable, optional) merged in #348 (Pre-H.1.0a). This PR makes the **live** User-App wizard capture the value.

**App/Env:** User App / DEV. No deploy. Base `main`.

### Scope = Option A (optional, NOT required) — Haim-approved at checkpoint
The plan literally said "enforce required", but investigation (4 workers + completeness + devils-advocate) proved `required` would **silently break corporate (ח.פ.) and foreign (passport) intake** on a live, commercially-sold CRM:
- `isValidIsraeliId` validates a **personal** ת.ז only — a company 9-digit ח.פ. mostly fails it, and the backend (#348) would reject it too.
- `required` is incoherent without an `idType` model, which exists nowhere (not backend, not Zod, not wizard).
- **Live data (aggregate, non-PII probe):** of **139** clients, **≥2** are companies/nonprofits and only **1** has any `idNumber` at all (not even a valid ת.ז shape).

Devils-advocate issued **STOP** on `required`; Haim approved **Option A**. `required` + a designed `idType` model is deferred to its own PR (needs backend support).

### What changed
- **NEW `apps/user-app/js/modules/israeli-id.js`** — exact frontend mirror of backend `isValidIsraeliId` (check-digit + zero-pad). `window.IsraeliId` global (for the classic-script dialog) + ESM `export` (for tests). Served directly — **no dist artifact** (like `tz-helper.js`).
- **`case-creation-dialog.js`** — optional ת.ז input in step 1 (no required marker, helper text on immutability); `validateCurrentStep` **validate-if-present** (empty → wizard proceeds exactly as before, zero regression); wired through `collectFormData` → `buildFirebaseData` → `createClient`. The value is never passed to `console.*`/`Logger.*`.
- **`index.html`** — loads `israeli-id.js` (module) before the dialog.
- **`schemas/index.ts`** — reconciles the orphaned `idNumber` Zod from `/^\d{9}$/` to a check-digit `.refine()` + corrected Hebrew message. **Documentation/drift-guard only** — this schema is not loaded at runtime; the real validator is `israeli-id.js`. **dist intentionally not rebuilt** (orphaned artifact; the repo already tolerates dist drift; rebuilding would only churn an unloaded file + sweep unrelated pre-existing drift).
- **Tests (root Vitest, run in CI):**
  - `israeli-id-drift-guard.test.ts` — pins BOTH `israeli-id.js` AND `ClientSchema` to the backend's **11 canonical vectors** (cross-language drift-guard; controlled duplication is test-pinned).
  - `idnumber-pii-guard.test.ts` — static guard: no `console.*`/`Logger.*` in the dialog carries `idNumber`/`formData`/`firebaseData` (mirrors the #348 backend guard; `logger.js` prod override does not null `console.error/warn/group`, so this matters on a PUBLIC repo).

### Verification
- `npx tsc --noEmit` → exit 0
- `npx eslint` (changed files) → **0 errors** (65 pre-existing warnings)
- `npx vitest run` → 20 files, **398 passed + 2 skipped** (incl. 31 new tests)
- `git diff --stat main` → only `index.html`, `case-creation-dialog.js`, `schemas/index.ts` (+ new `israeli-id.js`, 2 tests, rubric). No `dist`, no `firestore.rules`, no backend.

### Test plan
**Automated (CI):** the drift-guard exercises valid-accept (`123456782`), wrong-check-reject (`123456789`, Hebrew msg), 8-digit zero-pad (`00000018`), empty-allowed; PII guard + positive control.
**Manual smoke (DEV, DOM-bound):**
1. New client + valid ת.ז → advances + created with `idNumber`.
2. New client + invalid ת.ז → inline Hebrew error, blocked pre-submit.
3. New client + NO ת.ז → advances + creates (no regression — corporate/foreign preserved).
4. New client + 8-digit ת.ז → accepted.

### Rollback
`git revert <merge-commit>` + redeploy. Code-only, additive optional field; no data migration.

### Deferred (tracked, NOT in scope)
`required` + `idType` model (ת.ז/passport/ח.פ.) with backend support; `validation-script.js` harness fix (broken by #348 — Haim chose defer); `clients` read-access tightening (G7); Admin `SimpleClientDialog` unvalidated bypass; ~127-doc backfill; WhatsApp echo; `logger.js` Error-branch sanitize; frontend `dist` hygiene.

### PRODUCT-GRADE GATES
- **G1 — Customer errors:** PASS — inline Hebrew "מספר תעודת הזהות אינו תקין"; value never echoed; no stack/undefined/English.
- **G2 — Rollback:** PASS — `git revert` + redeploy; additive optional, nothing to migrate.
- **G3 — Monitoring:** N/A — no new write path (rides existing `createClient`); ת.ז deliberately not logged (correct posture).
- **G4 — Customer-scenario test:** PASS — drift-guard covers accept/reject/zero-pad/empty in CI; DOM steps in manual-smoke.
- **G5 — Hebrew UI:** PASS — label "תעודת זהות (לא חובה)", error + helper text Hebrew.
- **G6 — Breaking change:** PASS (none) — purely additive optional field; `required` not introduced.
- **G7 — Security review:** PASS — security-access-expert reviewed; no `firestore.rules` change, no new reader, `clients` read already all-authenticated (unchanged); the only new PII channel (form/console) is closed by the PII guard. Read-access tightening + SimpleClientDialog bypass DEFERRED + flagged.

VERDICT: PASS_WITH_WARNINGS

Rubric: `.claude/rubrics/pr-pre-h-1-0b.md`. Grader: 7/7 MUST PASS, 7/7 gates PASS-or-N/A. Warnings were process-only (don't commit pre-existing untracked dist noise — verified excluded; include this gates section — done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
