### PR TITLE
fix: gatekeeper alerts on a failing PROD deploy run [incident follow-up]

### DIFF
--- a/.claude/hooks/work-session-gatekeeper.sh
+++ b/.claude/hooks/work-session-gatekeeper.sh
@@ -60,10 +60,27 @@ if git rev-parse --verify origin/production-stable >/dev/null 2>&1 && git rev-pa
   [ -z "$DEPLOY_DRIFT" ] && DEPLOY_DRIFT=0
 fi
 
+# PROD deploy HEALTH (not just commit drift). The gap that hid the 2026-06-04
+# incident: the ci-cd-production `deploy-production` job was RED on every merge
+# to main for 6 days (two stacked blockers — a 1st->2nd-Gen function conflict
+# + an unset secret), freezing ~6 days of Cloud Functions + firestore.rules out
+# of PROD, while commit-drift looked normal and no session noticed. We surface
+# the latest ci-cd-production run conclusion so the next session is ALERTED.
+# NOTE: a MANUAL `firebase deploy` is out-of-band and won't register as a run,
+# so a stale failed run can over-alert until the next code push to main — that
+# is intentional (over-alert > under-alert on PROD deploy health; the Lead Agent
+# verifies the actual state before acting).
+DEPLOY_RUN_FAILED=0
+if command -v gh >/dev/null 2>&1; then
+  DEPLOY_RUN_CONCLUSION=$(gh run list --workflow=ci-cd-production.yml --branch main --limit 1 --json conclusion 2>/dev/null \
+    | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const a=JSON.parse(d);process.stdout.write(String((a[0]&&a[0].conclusion)||""))}catch(e){process.stdout.write("")}})' 2>/dev/null || echo -n "")
+  [ "$DEPLOY_RUN_CONCLUSION" = "failure" ] && DEPLOY_RUN_FAILED=1
+fi
+
 # ── Build summary ──────────────────────────────────────────────
 SUMMARY=""
 
-if [ "$UNCOMMITTED_COUNT" = "0" ] && [ "$STASH_COUNT" = "0" ] && [ "$UNMERGED_BRANCHES" = "0" ] && [ "$EXTRA_WORKTREES" = "0" ] && [ "$AHEAD" = "0" ] && [ "$OPEN_PRS_COUNT" = "0" ] && [ "$DEPLOY_DRIFT" = "0" ]; then
+if [ "$UNCOMMITTED_COUNT" = "0" ] && [ "$STASH_COUNT" = "0" ] && [ "$UNMERGED_BRANCHES" = "0" ] && [ "$EXTRA_WORKTREES" = "0" ] && [ "$AHEAD" = "0" ] && [ "$OPEN_PRS_COUNT" = "0" ] && [ "$DEPLOY_DRIFT" = "0" ] && [ "$DEPLOY_RUN_FAILED" = "0" ]; then
   SUMMARY="🔒 Work Session Gatekeeper — clean state. Branch: $BRANCH. No open work detected. Safe to start new task."
 else
   SUMMARY="🔒 Work Session Gatekeeper — OPEN WORK DETECTED"
@@ -75,6 +92,7 @@ else
   [ "$AHEAD" != "0" ] && SUMMARY="$SUMMARY"$'\n'"- Commits ahead of origin: $AHEAD"
   [ "$OPEN_PRS_COUNT" != "0" ] && SUMMARY="$SUMMARY"$'\n'"- Open PRs: $OPEN_PRS_COUNT"$'\n'"$OPEN_PRS_SUMMARY"
   [ "$DEPLOY_DRIFT" != "0" ] && SUMMARY="$SUMMARY"$'\n'"- Deploy drift (commits on main not in production-stable): $DEPLOY_DRIFT"
+  [ "$DEPLOY_RUN_FAILED" = "1" ] && SUMMARY="$SUMMARY"$'\n'"- 🔴 LAST PROD PIPELINE RUN FAILED (ci-cd-production on main) — a Cloud Functions / firestore.rules deploy may be FROZEN in PROD. Investigate with \`gh run list --workflow=ci-cd-production.yml --branch main\` + the failed job's log BEFORE merging more code (this is the 2026-06-04 incident class)."
   SUMMARY="$SUMMARY"$'\n'$'\n'"⚠️ Lead Agent: before starting a new task, assess whether this open work overlaps with the new request. If yes — recommend continuing existing work instead. If no — flag the open work and ask Haim how to proceed."
 fi
 

--- a/.claude/rubrics/pr-gatekeeper-deploy-health.md
+++ b/.claude/rubrics/pr-gatekeeper-deploy-health.md
@@ -1,0 +1,65 @@
+# Rubric — Gatekeeper deploy-health check (incident follow-up)
+
+**Title:** Teach `work-session-gatekeeper.sh` to surface a FAILING `ci-cd-production` run — close the process gap that hid the 2026-06-04 PROD-deploy incident (functions/rules frozen in PROD for 6 days, undetected).
+**Branch:** `fix/gatekeeper-deploy-health-check`
+**Base:** `main`
+**App / Env:** Tooling (SessionStart hook) / DEV. No deploy-behavior change.
+**Effort:** LIGHT (single hook file, ~20 added lines — effort-scaler skipped, marked obvious-LIGHT).
+
+**Context:** The CI `deploy-production` job was RED on every push to `main` for 6 days (2026-05-28→06-04) on two stacked blockers, freezing ~6 days of Cloud Functions + `firestore.rules` out of PROD — while the gatekeeper's *commit-drift* check looked normal and no session noticed. The gatekeeper informed on uncommitted/stash/branches/PRs/commit-drift, but NOT on whether the deploy actually succeeded. This PR adds that signal.
+
+**Scope:** `.claude/hooks/work-session-gatekeeper.sh` only — add a `DEPLOY_RUN_FAILED` probe (latest `ci-cd-production.yml` run conclusion via `gh`), include it in the clean-state guard, and emit a 🔴 alert line when the last PROD pipeline run failed. Plus this rubric.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Detects a failed PROD pipeline run
+**Rule:** The hook queries the latest `ci-cd-production.yml` run on `main` and sets `DEPLOY_RUN_FAILED=1` iff its conclusion is `failure`; it emits a 🔴 alert naming the incident class + the investigate command.
+**Evidence:** local run of the hook (current state has a stale failed run) prints the `🔴 LAST PROD PIPELINE RUN FAILED` line. Verified 2026-06-04.
+
+### M2 — A failed run breaks "clean state"
+**Rule:** `DEPLOY_RUN_FAILED=1` excludes the "clean state — safe to start" path (added to the all-zero guard), so a broken PROD deploy can never read as "clean".
+**Evidence:** `git diff` shows `&& [ "$DEPLOY_RUN_FAILED" = "0" ]` in the clean-state condition.
+
+### M3 — Robust + non-blocking + no new failure mode
+**Rule:** The probe is guarded by `command -v gh`; parse failures / empty results default to `DEPLOY_RUN_FAILED=0` (never error); the hook still emits valid JSON and exits 0 under `set -uo pipefail`. The hook continues to INFORM, never blocks (per its design).
+**Evidence:** `bash -n` clean; the hook run emits VALID JSON; the `gh|node` pipe has `|| echo -n ""` + try/catch fallback.
+
+### M4 — Honest about the manual-deploy limitation
+**Rule:** A code comment documents that a manual `firebase deploy` is out-of-band (not a run) so a stale failed run can over-alert until the next code push — intentional (over-alert > under-alert); the Lead Agent verifies actual state.
+**Evidence:** the comment block above `DEPLOY_RUN_FAILED`.
+
+### M5 — No scope creep
+**Rule:** Diff touches ONLY `.claude/hooks/work-session-gatekeeper.sh` + this rubric. No workflow change, no other hook, no app code.
+**Evidence:** `git diff --stat main..HEAD`.
+
+## SHOULD criteria
+
+### S1 — Lead-Agent habit noted
+**Rule:** PR body recommends the complementary behavior (Lead Agent verifies `deploy-production` went green after each merge within the session) — the hook catches it at next SessionStart; the habit catches it immediately. (Not in this PR's diff; recommended follow-up.)
+
+## PRODUCT-GRADE GATES
+
+- **G1 — Customer errors:** N/A — internal tooling (SessionStart hook), no customer-facing path.
+- **G2 — Rollback:** PASS — `git revert <merge-commit>`; the hook reverts to the prior (commit-drift-only) behavior. Code-only.
+- **G3 — Monitoring:** N/A — this IS monitoring (it adds a deploy-health signal); no data mutation.
+- **G4 — Customer-scenario test:** PASS — the "scenario" is "a future session is alerted to a frozen PROD deploy"; verified by running the hook against the current stale-failed run (alert fires) + valid-JSON check. (Bash hook; manual-run evidence is the appropriate test layer.)
+- **G5 — Hebrew UI:** N/A — developer-only hook output (English, like the rest of the hook).
+- **G6 — Breaking change:** PASS (none) — purely additive signal; existing fields/behavior unchanged; the only behavioral delta is that a failed PROD run now (correctly) reads as not-clean.
+- **G7 — Security review:** N/A — no auth/PII/permissions/rules touched; read-only `gh run list`.
+
+VERDICT: (filled by grader)
+
+## Rollback
+```bash
+git revert <merge-commit>
+git push origin main
+```
+Code-only. No data, no deploy-behavior change.
+
+## Test plan
+**Automated/manual:** `bash -n` (syntax) + run the hook and assert valid JSON + the 🔴 line appears while a failed `ci-cd-production` run is latest. Both verified 2026-06-04.
+**Self-validating:** merging this PR (a `.claude/` change — NOT path-ignored) triggers `ci-cd-production`, which now deploys green (both incident blockers cleared), so the latest run flips to success and the alert self-clears.
+
+## Notes for grader
+- Direct follow-up to the 2026-06-04 incident (recorded in MASTER_PLAN §8.2 banner). The hook is the durable automated guard; the Lead-Agent post-merge-verify habit (S1) is the complement.
+- Adds one `gh run list` network call at SessionStart (~1-2s) — same class as the existing `gh pr list` call; acceptable.


### PR DESCRIPTION
## Gatekeeper deploy-health check — 2026-06-04 incident follow-up

**The gap this closes:** during the 2026-06-04 incident, `ci-cd-production`'s `deploy-production` job was RED on every push to `main` for 6 days (a 1st→2nd-Gen function conflict + an unset secret), freezing ~6 days of Cloud Functions + `firestore.rules` out of PROD — and a live unauthenticated admin endpoint stayed exposed. The `work-session-gatekeeper` hook reported uncommitted/stash/branches/PRs/**commit-drift**, but never whether the deploy actually **succeeded**, so every session started blind to a broken PROD pipeline.

### What changed (`.claude/hooks/work-session-gatekeeper.sh` only)
- New `DEPLOY_RUN_FAILED` probe: queries the latest `ci-cd-production.yml` run on `main` via `gh run list ... --json conclusion`; set to 1 iff the conclusion is `failure`.
- A failed run is added to the clean-state guard (so a broken PROD deploy can never read as "clean — safe to start").
- Emits a 🔴 alert naming the incident class + the exact investigate command.
- Guarded: `command -v gh`, parse/empty/junk → 0, `|| echo -n ""` + try/catch, still emits valid JSON + exits 0 under `set -uo pipefail`. **Inform-not-block** (the hook's design) preserved.
- Comments the honest caveat: a manual `firebase deploy` is out-of-band, so a stale failed run can over-alert until the next code push (intentional — over-alert > under-alert; the Lead Agent verifies actual state).

### Verification
- `bash -n` → syntax OK.
- Running the hook → valid JSON + the `🔴 LAST PROD PIPELINE RUN FAILED` line fires (against the current stale-failed run).
- `git diff --stat main` → only the hook + this rubric. No workflow/app/other-hook changes.
- **Self-validating:** merging this `.claude/` change (NOT path-ignored) triggers `ci-cd-production`, which now deploys green (both incident blockers cleared), flipping the latest run to success → the alert self-clears.

### Complementary habit (S1, not in this diff)
The hook catches a frozen deploy at the next SessionStart; the Lead Agent should also verify `deploy-production` went green immediately after each merge within the session (adopted going forward).

### Tracked nicety (non-blocking, grader-noted)
The probe flags `failure` only; `cancelled`/`timed_out` also mean "didn't deploy" but were left out to avoid false-alarms on concurrency-superseded runs. A future iteration may add `timed_out`.

### Rollback
`git revert <merge-commit>` — reverts to the prior commit-drift-only behavior. Code-only, no deploy-behavior change.

### Test plan
`bash -n` + run-the-hook (valid JSON + alert fires while a failed `ci-cd-production` run is latest). Both verified 2026-06-04.

### PRODUCT-GRADE GATES
- **G1 — Customer errors:** N/A — internal SessionStart hook, no customer path.
- **G2 — Rollback:** PASS — `git revert`; code-only.
- **G3 — Monitoring:** N/A — this IS a monitoring signal; no data mutation.
- **G4 — Customer-scenario test:** PASS — "a future session is alerted to a frozen PROD deploy"; verified by running the hook (alert fires) + valid-JSON.
- **G5 — Hebrew UI:** N/A — developer-only hook output.
- **G6 — Breaking change:** PASS (none) — purely additive signal; only delta = a failed run now reads as not-clean (intended).
- **G7 — Security review:** N/A — no auth/PII/permissions/rules; read-only `gh run list`, no secrets logged.

VERDICT: PASS

Rubric: `.claude/rubrics/pr-gatekeeper-deploy-health.md`. Grader: 5/5 MUST + 7/7 gates PASS/N-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
