### PR TITLE
fix(h-3): reconcile legal-hourly ratePerHour across both intake routes (no silent 800)

### DIFF
--- a/.claude/rubrics/pr-h-3-1-intake-rate.md
+++ b/.claude/rubrics/pr-h-3-1-intake-rate.md
@@ -1,0 +1,51 @@
+# Rubric — H.3 PR1-followup: reconcile legal-hourly `ratePerHour` across the two intake routes
+
+**Title:** Make `createClient` and `addServiceToClient` store a legal-hourly service's `ratePerHour` CONSISTENTLY — an explicitly-elected positive rate is stored; an un-elected rate stays ABSENT (the legacy silent `|| 800` default is removed) so the static Plan reports `pricing_missing`, never a fabricated 800×hours. Closes the intake asymmetry the H.3 PR1 grader flagged (2026-06-11).
+**Branch:** `fix/pr-h-3-1-intake-rate`
+**Base:** `main`
+**App / Env:** Functions (`clients/index.js` + `services/index.js`) + User App & Admin Panel intake dialogs. DEV (`main`). Additive / data-shape fix.
+**Effort:** LIGHT–MEDIUM. Investigation: backend + data (this session) + Haim checkpoint (2026-06-11, Option B: un-elected placeholder; backfill deferred to a separate PR).
+
+**Context:** MASTER_PLAN §8.5 **D-B** (locked 2026-06-10, re-confirmed 2026-06-11) + the H.3 PR1 rubric **M2** both mandate "NEVER a silent 800". The Plan helper already honors this (it never fabricates a rate). The bug is upstream intake-data asymmetry: `createClient:422` baked `ratePerHour: data.ratePerHour || 800` while `addServiceToClient` set no rate → the same legal-hourly case yielded `expectedRevenue = 800×hours` via one route and `null + pricing_missing` via the other. Both intake UIs hardcoded `data.ratePerHour = 800` ("default") with no rate input field; nothing reads `service.ratePerHour` except the new Plan helper (repo-wide verified). The real rate is sourced from the tofes `amountBeforeVat` snapshot at H.6 (§8.2.5 D1).
+
+## MUST criteria (block on FAIL)
+
+### M1 — Symmetric storage: store an elected rate, omit an un-elected one, on BOTH routes
+**Rule:** `createClient` (legal_procedure HOURLY) stores `ratePerHour` ONLY when `data.ratePerHour` is a positive finite number; the `|| 800` default is removed. `addServiceToClient` (legal_procedure HOURLY) stores `ratePerHour` under the identical condition (previously stored none). Neither route ever writes a default rate.
+**Evidence:** `git diff` of `clients/index.js` + `services/index.js`; tests B + the elected-rate cases.
+
+### M2 — No silent default → absent rate yields `pricing_missing` (D-B / PR1 M2)
+**Rule:** A legal-hourly service created with no elected rate carries NO `ratePerHour`; `computeServicePlan` returns `expectedRevenue:null` + `revenueSource:'unknown'`, and the client Plan increments `pricingMissingCount` / flips `pricingComplete:false`. NEVER 800×hours, NEVER 0-for-unknown.
+**Evidence:** `legal-hourly-rate-reconciliation.test.js` A1/B1 assert `plan.expectedRevenue===0` (null-aware sum), `pricingMissingCount===1`.
+
+### M3 — Intake UIs no longer hardcode 800
+**Rule:** Neither `apps/user-app/js/modules/case-creation/case-creation-dialog.js` nor `apps/admin-panel/js/modules/case-creation-dialog.js` assigns `data.ratePerHour = 800`. (Admin dialog is the dead path — changed for drift-prevention.)
+**Evidence:** `git diff` of both dialogs; repo grep for `ratePerHour = 800` returns nothing.
+
+### M4 — Additive; hours SSOT + Plan helper untouched; no regression
+**Rule:** No change to hours/minutes/aggregate computation, the canonical writer's derivation, or `client-plan.ts/.js`. Full functions suite green.
+**Evidence:** `git diff` touches no aggregate/helper logic; full functions suite **880/880** (was 870 → +10 new).
+
+### M5 — Reconciliation proven by test
+**Rule:** A test asserts that identical no-rate legal-hourly input produces an IDENTICAL Plan from both routes (the grader-flagged seam), plus: elected rate honored (rate_x_hours) and malformed elected rate rejected.
+**Evidence:** `legal-hourly-rate-reconciliation.test.js` group C (both routes equal) + A/B.
+
+## SHOULD criteria (warn on FAIL)
+
+### S1 — Malformed elected rate rejected, not silently dropped
+**Rule:** A present-but-invalid `ratePerHour` (non-number / ≤0 / non-finite) throws `invalid-argument` with a Hebrew message, on both routes.
+
+### S2 — Forward seam to H.6 noted
+**Rule:** Code/comments mark that the authoritative rate is the tofes `amountBeforeVat` snapshot swapped in at H.6 (§8.2.5 D1), and that existing-data backfill is a separate PR.
+
+## PRODUCT-GRADE GATES (G1–G7)
+- **G1 errors:** PASS — the only new customer-facing path is the validate-if-present throw, a Hebrew `invalid-argument` ("תעריף שעתי חייב להיות מספר חיובי"); no stack trace / undefined / English.
+- **G2 rollback:** PASS — `git revert <sha>` restores the prior code; the only effect is new legal-hourly intakes regaining a stored rate. Existing docs untouched. Code-only, ≤5 min.
+- **G3 monitoring:** PASS — no new mutation path. createClient still audits `CREATE_CLIENT`; addServiceToClient still writes via the canonical writer + audits `ADD_SERVICE_TO_CLIENT`. The change only omits one fabricated field; no write/log behavior added or removed.
+- **G4 customer test:** PASS — `legal-hourly-rate-reconciliation.test.js` exercises BOTH real callables end-to-end (the written `.create`/`transaction.update` payload incl. the real `computeClientPlan`); 10 tests; full suite 880/880.
+- **G5 Hebrew UI:** PASS — new validation message is Hebrew; dialog comments Hebrew; no rendered string changed (no rate UI exists).
+- **G6 breaking change:** PASS — documented behavioral change, consumer-safe. The legal-hourly default behavior changes (no more silent 800). The ONLY reader of `service.ratePerHour` is the Plan helper (repo-wide verified), which is by-design tolerant of absence (→ pricing_missing). No field is renamed/removed from any consumed contract; callable return shapes carry one fewer (fabricated) field that no caller reads. Existing data is forward-only (untouched); the ~existing-cohort backfill is a Haim-approved SEPARATE PR. See the PR-body "Behavioral change" section.
+- **G7 security:** N/A — no auth / PII / permissions / `firestore.rules` change. `ratePerHour` is non-PII billing metadata already on the (world-readable) client doc; no new surface. devils-advocate NOT mandatory (no rules/security/migration/new-collection; same basis as PR1) — adversarial review applied inline (sole-consumer verification, malformed-rate rejection, dead-dialog drift landmine).
+
+## VERDICT
+`outcomes-grader` must return **PASS** / **PASS_WITH_WARNINGS** before `gh pr create`.

--- a/apps/admin-panel/js/modules/case-creation-dialog.js
+++ b/apps/admin-panel/js/modules/case-creation-dialog.js
@@ -2332,7 +2332,10 @@ return;
         data.pricingType = formData.service.pricingType;
         // ✅ שדות חדשים עבור המבנה החדש
         data.legalProcedureName = formData.case.title;  // שם ��הליך המשפטי
-        data.ratePerHour = 800;  // תעריף שעתי ברירת מחדל
+        // H.3 D-B (2026-06-11): אין יותר תעריף 800 קשיח. תעריף שלא נבחר חייב להישאר
+        // נעדר כדי שה-Plan של התיק ידווח pricing_missing (לעולם לא 800×שעות מפוברק).
+        // (דיאלוג זה אינו מסלול היצירה החי — היוצר החי הוא ה-User App; השינוי כאן
+        // למניעת מוקש-drift עתידי, §8.2.5.)
         data.stages = [
           { id: 'stage_a', ...formData.service.stageA },
           { id: 'stage_b', ...formData.service.stageB },

--- a/apps/user-app/js/modules/case-creation/case-creation-dialog.js
+++ b/apps/user-app/js/modules/case-creation/case-creation-dialog.js
@@ -2640,7 +2640,10 @@ return text;
         data.pricingType = formData.service.pricingType;
         // ✅ שדות חדשים עבור המבנה החדש
         data.legalProcedureName = formData.case.title;  // שם ההליך המשפטי
-        data.ratePerHour = 800;  // תעריף שעתי ברירת מחדל
+        // H.3 D-B (2026-06-11): אין יותר תעריף 800 קשיח. תעריף שלא נבחר חייב להישאר
+        // נעדר כדי שה-Plan של התיק ידווח pricing_missing (לעולם לא 800×שעות מפוברק).
+        // כשהמשרד יבחר תעריף שעתי אמיתי — להציב כאן data.ratePerHour. (מקור אמיתי:
+        // tofes amountBeforeVat ב-H.6.)
         data.stages = [
           { id: 'stage_a', ...formData.service.stageA },
           { id: 'stage_b', ...formData.service.stageB },

--- a/functions/clients/index.js
+++ b/functions/clients/index.js
@@ -153,6 +153,21 @@ exports.createClient = functions.https.onCall(async (data, context) => {
         );
       }
 
+      // H.3 D-B (2026-06-11): תעריף שעתי אופציונלי נבחר (legal-hourly בלבד).
+      // Validate-if-present — תעריף נבחר פגום נדחה (לא מושמט בשקט). כשאינו מסופק,
+      // לא מיושמת ברירת מחדל (ראה בניית השירות למטה — אין יותר `|| 800`).
+      if (
+        data.pricingType === PT.HOURLY &&
+        data.ratePerHour !== undefined &&
+        data.ratePerHour !== null &&
+        (typeof data.ratePerHour !== 'number' || !Number.isFinite(data.ratePerHour) || data.ratePerHour <= 0)
+      ) {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'תעריף שעתי חייב להיות מספר חיובי'
+        );
+      }
+
       // בדיקת כל שלב - תלוי בסוג התמחור
       data.stages.forEach((stage, index) => {
         if (!stage.description || stage.description.trim().length < 2) {
@@ -419,7 +434,14 @@ exports.createClient = functions.https.onCall(async (data, context) => {
             type: 'legal_procedure',
             name: sanitizeString(data.legalProcedureName || 'הליך משפטי'),
             pricingType: PT.HOURLY,
-            ratePerHour: data.ratePerHour || 800,
+            // H.3 D-B (2026-06-11): store an hourly rate ONLY when one was explicitly
+            // elected (a positive number). The legacy `|| 800` silent default is REMOVED —
+            // an un-elected rate stays absent so the Plan reports pricing_missing (never a
+            // fabricated 800×hours; mirrors addServiceToClient). Real source: tofes
+            // amountBeforeVat at H.6 (§8.2.5 D1).
+            ...(typeof data.ratePerHour === 'number' && data.ratePerHour > 0
+              ? { ratePerHour: data.ratePerHour }
+              : {}),
             status: 'active',
             stages: stages,
 

--- a/functions/services/index.js
+++ b/functions/services/index.js
@@ -70,6 +70,20 @@ exports.addServiceToClient = functions.https.onCall(async (data, context) => {
           'סוג תמחור חייב להיות "hourly" או "fixed"'
         );
       }
+      // H.3 D-B (2026-06-11): תעריף שעתי אופציונלי נבחר (legal-hourly בלבד).
+      // Validate-if-present; כשאינו מסופק — אין ברירת מחדל (השירות נשמר ללא
+      // ratePerHour → ה-Plan מדווח pricing_missing). מסונכרן עם createClient.
+      if (
+        data.pricingType === PT.HOURLY &&
+        data.ratePerHour !== undefined &&
+        data.ratePerHour !== null &&
+        (typeof data.ratePerHour !== 'number' || !Number.isFinite(data.ratePerHour) || data.ratePerHour <= 0)
+      ) {
+        throw new functions.https.HttpsError(
+          'invalid-argument',
+          'תעריף שעתי חייב להיות מספר חיובי'
+        );
+      }
     } else if (data.serviceType === ST.FIXED) {
       if (data.fixedPrice == null || typeof data.fixedPrice !== 'number' || data.fixedPrice < 0) {
         throw new functions.https.HttpsError(
@@ -174,6 +188,12 @@ exports.addServiceToClient = functions.https.onCall(async (data, context) => {
           newService.totalHours = newService.stages.reduce((sum, s) => sum + (s.totalHours || 0), 0);
           newService.hoursUsed = 0;
           newService.hoursRemaining = newService.totalHours;
+          // H.3 D-B (2026-06-11): store an elected hourly rate when supplied (validated
+          // above). No silent 800 default — absent rate → Plan reports pricing_missing
+          // (mirrors createClient; real rate from tofes amountBeforeVat at H.6).
+          if (typeof data.ratePerHour === 'number' && data.ratePerHour > 0) {
+            newService.ratePerHour = data.ratePerHour;
+          }
         } else {
           newService.totalPrice = newService.stages.reduce((sum, s) => sum + (s.fixedPrice || 0), 0);
           newService.totalPaid = 0;

--- a/functions/tests/legal-hourly-rate-reconciliation.test.js
+++ b/functions/tests/legal-hourly-rate-reconciliation.test.js
@@ -1,0 +1,258 @@
+/**
+ * H.3 D-B intake reconciliation (2026-06-11)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The two client-intake routes must store a legal-hourly service's `ratePerHour`
+ * CONSISTENTLY:
+ *   - an explicitly-elected positive rate is STORED;
+ *   - an un-elected rate stays ABSENT (the legacy silent `|| 800` default is gone),
+ *     so the static Plan reports `pricing_missing` — NEVER a fabricated 800×hours.
+ *
+ * Before this fix: `createClient` baked `ratePerHour: data.ratePerHour || 800`
+ * while `addServiceToClient` set no rate → the same legal-hourly case yielded
+ * `expectedRevenue = 800×hours` via one route and `null + pricing_missing` via the
+ * other (the divergence the H.3 PR1 grader flagged; MASTER_PLAN §8.5 D-B + rubric M2).
+ *
+ * These tests exercise BOTH real callables and assert on the real `computeClientPlan`
+ * output stamped on each route's written payload (createClient → `.create(clientData)`,
+ * addServiceToClient → the canonical writer's `transaction.update` payload).
+ */
+
+// ─── shared capture + mocks (support both .create() and runTransaction paths) ───
+const captured = { created: null };
+
+const mockTransaction = {
+  get: jest.fn(),
+  set: jest.fn(),
+  update: jest.fn()
+};
+const mockRunTransaction = jest.fn(async (fn) => fn(mockTransaction));
+
+const mockDb = {
+  collection: jest.fn(() => ({
+    doc: jest.fn((id) => ({
+      id: id || 'auto_id',
+      // createClient writes here:
+      create: jest.fn(async (d) => { captured.created = d; }),
+      // tolerate any incidental reads (e.g. enforcement-mode config) → defaults apply:
+      get: jest.fn(async () => ({ exists: false })),
+      set: jest.fn(async () => {})
+    }))
+  })),
+  runTransaction: mockRunTransaction
+};
+
+jest.mock('firebase-admin', () => {
+  const FieldValue = {
+    serverTimestamp: jest.fn(() => 'SERVER_TIMESTAMP'),
+    increment: jest.fn((n) => ({ _increment: n }))
+  };
+  const Timestamp = { now: jest.fn(() => 'NOW') };
+  return {
+    initializeApp: jest.fn(),
+    firestore: Object.assign(() => mockDb, { FieldValue, Timestamp }),
+    auth: jest.fn(() => ({ getUser: jest.fn() }))
+  };
+});
+
+jest.mock('firebase-functions', () => {
+  class HttpsError extends Error {
+    constructor(code, message, details) {
+      super(message);
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    https: { onCall: jest.fn((fn) => fn), HttpsError },
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() }
+  };
+});
+
+const mockCheckUserPermissions = jest.fn();
+jest.mock('../shared/auth', () => ({
+  checkUserPermissions: mockCheckUserPermissions
+}));
+
+jest.mock('../shared/audit', () => ({
+  logAction: jest.fn()
+}));
+
+jest.mock('../shared/validators', () => ({
+  sanitizeString: jest.fn((s) => s),
+  isValidIsraeliPhone: jest.fn(() => true),
+  isValidEmail: jest.fn(() => true),
+  isValidIsraeliId: jest.fn(() => true)
+}));
+
+jest.mock('../case-number-transaction', () => ({
+  generateCaseNumberWithTransaction: jest.fn(async () => '2099999')
+}));
+
+const { createClient } = require('../clients/index');
+const { addServiceToClient } = require('../services/index');
+const { SYSTEM_CONSTANTS } = require('../shared/constants');
+const ST = SYSTEM_CONSTANTS.SERVICE_TYPES;
+const PT = SYSTEM_CONSTANTS.PRICING_TYPES;
+
+const VALID_USER = { uid: 'u1', email: 't@t', username: 'tester', role: 'manager' };
+function makeCtx() { return { auth: { uid: 'u1', token: { email: 't@t' } } }; }
+
+// legal-hourly stage triples → totalHours = 18 in BOTH routes
+const STAGES_CREATE = [
+  { description: 'שלב א', hours: 5 },
+  { description: 'שלב ב', hours: 10 },
+  { description: 'שלב ג', hours: 3 }
+];
+const STAGES_ADD = [{ hours: 5 }, { hours: 10 }, { hours: 3 }];
+const TOTAL_HOURS = 18;
+
+function createClientData(extra = {}) {
+  return {
+    clientName: 'לקוח טסט',
+    caseNumber: '2099001', // provided → skips generateCaseNumber
+    procedureType: ST.LEGAL_PROCEDURE,
+    pricingType: PT.HOURLY,
+    legalProcedureName: 'תביעה',
+    stages: STAGES_CREATE,
+    ...extra
+  };
+}
+
+function addServiceData(extra = {}) {
+  return {
+    clientId: 'c1',
+    serviceType: ST.LEGAL_PROCEDURE,
+    serviceName: 'תביעה',
+    pricingType: PT.HOURLY,
+    stages: STAGES_ADD,
+    ...extra
+  };
+}
+
+function emptyClientDoc() {
+  return {
+    exists: true,
+    data: () => ({ fullName: 'לקוח', status: 'active', services: [], totalHours: 0, totalServices: 0, activeServices: 0 })
+  };
+}
+function setupAddTx() {
+  mockTransaction.get.mockReset();
+  mockTransaction.get
+    .mockResolvedValueOnce(emptyClientDoc())  // CF body read
+    .mockResolvedValueOnce(emptyClientDoc()); // canonical-writer internal read
+}
+
+// last service in a payload's services[]
+function lastService(services) { return services[services.length - 1]; }
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  captured.created = null;
+  mockCheckUserPermissions.mockResolvedValue(VALID_USER);
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A. createClient — the route that used to bake `|| 800`
+// ═══════════════════════════════════════════════════════════════════════════
+describe('A. createClient legal-hourly: no silent 800', () => {
+  test('no elected rate → service has NO ratePerHour; plan = pricing_missing (not 800×hours)', async () => {
+    await createClient(createClientData(), makeCtx());
+    const svc = lastService(captured.created.services);
+    expect(svc.type).toBe('legal_procedure');
+    expect(svc.pricingType).toBe('hourly');
+    expect('ratePerHour' in svc).toBe(false);     // ← the bug: was 800
+
+    const plan = captured.created.plan;
+    expect(plan.expectedHours).toBe(TOTAL_HOURS);
+    expect(plan.expectedRevenue).toBe(0);          // null-aware sum (NOT 800×18=14400)
+    expect(plan.pricingMissingCount).toBe(1);
+    expect(plan.pricingComplete).toBe(false);
+    expect(plan.serviceCount).toBe(1);
+  });
+
+  test('explicitly-elected rate → stored + Plan = rate_x_hours', async () => {
+    await createClient(createClientData({ ratePerHour: 1200 }), makeCtx());
+    const svc = lastService(captured.created.services);
+    expect(svc.ratePerHour).toBe(1200);
+
+    const plan = captured.created.plan;
+    expect(plan.expectedRevenue).toBe(1200 * TOTAL_HOURS); // 21600
+    expect(plan.pricingMissingCount).toBe(0);
+    expect(plan.pricingComplete).toBe(true);
+  });
+
+  test.each([[-50], [0], ['abc'], [NaN]])(
+    'malformed elected rate (%p) → invalid-argument (not silently dropped)',
+    async (bad) => {
+      await expect(createClient(createClientData({ ratePerHour: bad }), makeCtx()))
+        .rejects.toMatchObject({ code: 'invalid-argument' });
+    }
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// B. addServiceToClient — the route that set NO rate
+// ═══════════════════════════════════════════════════════════════════════════
+describe('B. addServiceToClient legal-hourly: symmetric rate handling', () => {
+  test('no elected rate → service has NO ratePerHour; plan = pricing_missing', async () => {
+    setupAddTx();
+    await addServiceToClient(addServiceData(), makeCtx());
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = lastService(payload.services);
+    expect(svc.type).toBe('legal_procedure');
+    expect('ratePerHour' in svc).toBe(false);
+
+    expect(payload.plan.expectedHours).toBe(TOTAL_HOURS);
+    expect(payload.plan.expectedRevenue).toBe(0);
+    expect(payload.plan.pricingMissingCount).toBe(1);
+    expect(payload.plan.pricingComplete).toBe(false);
+  });
+
+  test('explicitly-elected rate → stored + Plan = rate_x_hours', async () => {
+    setupAddTx();
+    await addServiceToClient(addServiceData({ ratePerHour: 1200 }), makeCtx());
+    const [, payload] = mockTransaction.update.mock.calls[0];
+    const svc = lastService(payload.services);
+    expect(svc.ratePerHour).toBe(1200);
+    expect(payload.plan.expectedRevenue).toBe(1200 * TOTAL_HOURS);
+    expect(payload.plan.pricingMissingCount).toBe(0);
+  });
+
+  test('malformed elected rate → invalid-argument', async () => {
+    await expect(addServiceToClient(addServiceData({ ratePerHour: -5 }), makeCtx()))
+      .rejects.toMatchObject({ code: 'invalid-argument' });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C. The reconciliation: both routes now AGREE for identical input
+// ═══════════════════════════════════════════════════════════════════════════
+describe('C. Drift-free reconciliation (the grader-flagged seam)', () => {
+  test('identical no-rate legal-hourly input → identical Plan from BOTH routes', async () => {
+    // createClient route
+    await createClient(createClientData(), makeCtx());
+    const planCreate = captured.created.plan;
+
+    // addServiceToClient route
+    setupAddTx();
+    await addServiceToClient(addServiceData(), makeCtx());
+    const [, addPayload] = mockTransaction.update.mock.calls[0];
+    const planAdd = addPayload.plan;
+
+    const shape = (p) => ({
+      expectedHours: p.expectedHours,
+      expectedRevenue: p.expectedRevenue,
+      pricingComplete: p.pricingComplete,
+      pricingMissingCount: p.pricingMissingCount,
+      serviceCount: p.serviceCount
+    });
+    expect(shape(planCreate)).toEqual(shape(planAdd));
+    expect(shape(planCreate)).toEqual({
+      expectedHours: TOTAL_HOURS,
+      expectedRevenue: 0,
+      pricingComplete: false,
+      pricingMissingCount: 1,
+      serviceCount: 1
+    });
+  });
+});


### PR DESCRIPTION
## What + why

The two client-intake routes stored the legal_procedure HOURLY ratePerHour inconsistently:
- functions/clients/index.js createClient baked the legacy 800 default (data.ratePerHour or 800).
- functions/services/index.js addServiceToClient set no ratePerHour at all.

Through the H.3 PR1 Plan layer (client.plan.expectedRevenue) the same legal-hourly case diverged: 800 x hours (rate_x_hours) via createClient vs null + pricing_missing via addServiceToClient. The Plan helper is correct (it never fabricates a rate); the bug was the upstream intake-data asymmetry.

Per MASTER_PLAN section 8.5 D-B (locked 2026-06-10, re-confirmed 2026-06-11) and the H.3 PR1 rubric M2 (NEVER a silent 800), the 800 is an un-elected placeholder: both intake dialogs hardcoded it as a default with no rate input field, and nothing reads service.ratePerHour except the Plan helper (repo-wide verified). Haim checkpoint decision: Option B (neither route bakes a default).

## Changes
- createClient + addServiceToClient: store ratePerHour only when an explicit positive rate is supplied; otherwise omit it. Symmetric across both routes.
- validate-if-present: a present-but-malformed rate throws invalid-argument (Hebrew), not silently dropped.
- both intake dialogs (User App live + Admin Panel dead) no longer hardcode the 800 default.
- result: an un-elected legal-hourly rate yields pricing_missing on BOTH routes (never 800 x hours). Real rate source: tofes amountBeforeVat at H.6 (section 8.2.5 D1).

## Behavioral change (G6)
The legal-hourly default behavior changes (no more silent 800). Consumer-safe: the ONLY reader of service.ratePerHour is the Plan helper, which is by-design tolerant of absence (pricing_missing). No consumed field renamed/removed; callable return shapes carry one fewer fabricated field that no caller reads. Existing data is forward-only (untouched). The existing-cohort backfill is a Haim-approved SEPARATE PR.

## Rollback
git revert 2cb9b63 then redeploy on push to main. Code-only, under 5 minutes. No data migration to undo (existing docs untouched).

## Test plan (G4)
functions/tests/legal-hourly-rate-reconciliation.test.js (10 tests) exercises BOTH real callables end-to-end via the written create/update payload including the real computeClientPlan:
- both routes, no rate: service has no ratePerHour, plan.pricingMissingCount 1, expectedRevenue 0.
- both routes, elected rate 1200: stored, plan rate_x_hours.
- malformed rate: invalid-argument.
- reconciliation: identical no-rate input yields identical Plan from both routes.
Full functions suite 880/880 (was 870, +10). ESLint 0 on changed files. No TypeScript touched.

## PRODUCT-GRADE GATES
G1 errors: PASS - new path is a Hebrew invalid-argument throw; no stack trace/undefined/English.
G2 rollback: PASS - git revert 2cb9b63, code-only, under 5 min, no data to undo.
G3 monitoring: PASS - no new mutation path; createClient audits CREATE_CLIENT, addServiceToClient audits ADD_SERVICE_TO_CLIENT via the canonical writer; only a fabricated field is omitted.
G4 customer test: PASS - 10 end-to-end tests on both callables; full suite 880/880.
G5 Hebrew UI: PASS - new validation message Hebrew; dialog comments Hebrew; no rendered string changed.
G6 breaking change: PASS - documented behavioral change, consumer-safe (sole reader is the tolerant Plan helper); existing data forward-only; backfill is a separate Haim-approved PR.
G7 security: N/A - no auth/PII/permissions/firestore.rules change; ratePerHour is non-PII billing metadata already on the client doc.

VERDICT: PASS