### PR TITLE
feat(h-3): H.3 PR4 — Profitability Dashboard UI (profitability.html)

### DIFF
--- a/.claude/rubrics/pr-h-3-4-dashboard.md
+++ b/.claude/rubrics/pr-h-3-4-dashboard.md
@@ -1,0 +1,52 @@
+# Rubric — H.3 PR4: the Profitability Dashboard UI
+
+**Title:** A NEW admin-only `apps/admin-panel/profitability.html` — the FIRST major visible bud: a real-time per-case Profitability dashboard. Reads the CF-only `client_profitability` collection LIVE via `onSnapshot` (PR3's rule permits an admin listener) and JOINs each Forecast doc to `client.plan` (PR1) by caseNumber. Per-row recompute + a per-case detail drawer via the audited `getProfitability` callable. FRONTEND-ONLY.
+**Branch:** `feat/h-3-pr4-dashboard`
+**Base:** `main` (PR3 #373 merged + deployed)
+**App / Env:** Admin Panel (frontend). DEV (`main`). A NEW page (NOT grandfathered → full Design Bar). NO backend/rules/claims change → **devils-advocate NOT required** (verified by the security lens: zero `.rules`/auth/claims/schema/PII-surface-on-doc change; PR3 built the rule + callables).
+**Effort:** MEDIUM. Investigation: 4-lens H.3-PR4 workflow (frontend/data/security/completeness, 2026-06-15) + Haim checkpoint (4 locked decisions).
+
+**Context:** §8.5 PR4. The dashboard renders confidential cost data to an admin; the new client JS is the unproven PII surface — the cost/profit VALUE must never reach the client console/log/DOM-storage/URL (§7.6, public repo). `client_profitability` is empty + `actualCost` system-wide `null` today (employee_costs=0, backfill un-run) → the dashboard MUST ship **honest-empty** (never ₪0/null/NaN).
+
+## MUST criteria (block on FAIL)
+
+### M1 — 🔴 null ≠ 0 (the load-bearing cost render rule)
+**Rule:** `actualCost===null` renders a clear Hebrew "עלות לא זמינה" / dash — NEVER ₪0 (a 0 would fabricate a "this case costs nothing" signal). A real 0 (free) IS shown as ₪0 (known). A client with no forecast doc shows "טרם חושב". `paidRevenue`/`projectedProfit` are null → the profit column is HIDDEN ("בהמשך H.6"), never computed against ~0 revenue. `actualHours=0` (a real value, "0.0") is distinct from `actualCost=null` (unknown, dash).
+**Evidence:** `profitability-format.js` `formatActualCost`/`coverageBadge`; the `profitability-format.test.ts` null≠0 + coverage tests; the row render in `ProfitabilityPage.js`.
+
+### M2 — Admin-only fail-closed render gate (not just authentication)
+**Rule:** After `initAuthGuard` (authentication-only), the page re-verifies `getIdTokenResult().claims.role === 'admin'` BEFORE attaching the `onSnapshot` listener or calling any callable. The gate FAILS CLOSED (any token error → non-admin → `renderAccessDenied`). The page gate is `role==='admin'` — STRICTER than the rule's `admin||partner` (the UI stays admin-only per D-E; a partner must not get the page). The listener is torn down on logout (`teardown()`).
+**Evidence:** `profitability.html` gate (mirrors employee-costs.html:132-149); the listener attaches only inside `ProfitabilityPage.init` (post-gate); `teardown()` unsubscribes.
+
+### M3 — 🔴 No cost/profit VALUE escapes the client (§7.6 never-regress)
+**Rule:** The new client JS NEVER `console.*`/`Logger.*` an `actualCost`/`projectedProfit`/`paidRevenue` value, the onSnapshot doc, or the `getProfitability` result; never writes one to `localStorage`/`sessionStorage`/a URL/a `data-` attribute; never echoes one into a toast/error (Hebrew message-by-code only). Row buttons carry only `data-case` (the non-PII caseNumber). A static PII source-guard (WIDENED COST_REF for cost AND profit AND revenue) enforces it over `ProfitabilityPage.js` + `profitability-format.js`.
+**Evidence:** `profitability-pii-guard.test.ts` (static scan, sanity cases incl. the page-name non-match); manual grep of the diff for `console`/`localStorage` near a value identifier.
+
+### M4 — Live onSnapshot + in-memory JOIN (no 2nd listener, no plan snapshot)
+**Rule:** ONE `onSnapshot` on `client_profitability`; the Plan/name comes from an in-memory clients load (`window.firebaseDB.collection('clients').get()`, with the SAME internal-client filter as `ClientsDataManager`) JOINed by caseNumber — NO 2nd live listener and NO plan copy into the forecast doc. The grid re-renders on each snapshot delta. The onSnapshot `onError` renders a Hebrew banner (never a raw FirebaseError).
+**Evidence:** `_attachListener` (single listener + unsub handle) + `_loadClients` (internal filter) + `_renderRow` (JOIN by caseNumber).
+
+### M5 — Design Bar: tokens only, ModalManager, RTL, a11y; honest-empty/loading/error states
+**Rule:** `profitability.html` mirrors the PR2 shell (RTL `lang="he" dir="rtl"`, `noindex`, the auth-guard + Navigation lifecycle); the detail drawer is a `ModalManager` modal (no inline `<div class="modal">`); CSS uses `design-system.css` tokens ONLY (color tints via the sanctioned channel-derivation with the explanatory comment + `-dark` accent text for AA — no new hex beyond that + `#fff`); every interactive element (sort headers, search, filter, row buttons, drawer) has a `:focus-visible` style + accessible name; one `<h1>`; transitions via `--transition-*`. Explicit LOADING (spinner), HONEST-EMPTY (banner "חישוב יומי 06:30" + per-row "טרם חושב"), and Hebrew ERROR states.
+**Evidence:** the 4 new files; grep the CSS for hex/px beyond the documented tints; grep for `class="modal"` (none).
+
+### M6 — Color on HOURS-vs-Plan only; per-row recompute; scope clean; suite + lint green
+**Rule:** The only color signal is hours-vs-Plan (`hoursStatus`) — NO cost/profit alert + NO invented X% threshold (cost is null today; deferred). Recompute is per-row `recomputeProfitability(caseNumber)` ONLY (no bulk callable) + a "חושב לאחרונה" timestamp; the onSnapshot repaints. The diff touches ONLY `apps/admin-panel/**` + the 2 tests + the rubric — no `functions/`, no `firestore.rules`, no claims; no CRLF/dist drift staged. Root vitest green; lint 0 on the new JS/CSS.
+**Evidence:** `git diff --name-only main...HEAD`; the `hoursStatus` usage; the per-row recompute; vitest + lint output in the PR body.
+
+## SHOULD criteria (warn on FAIL)
+### S1 — Sortable columns (caseNumber/name/expectedHours/actualHours), search, status filter (active default); works on first use (0 forecast docs) without looking broken.
+### S2 — The `רווחיות` nav tab is DEFERRED to PR5 (the page is reachable directly by URL meanwhile); the H.2 backfill `--apply` is a SEPARATE supervised step (does NOT gate the merge); the dashboard ships honest-empty until costs are entered.
+### S3 — A supervised post-merge live-smoke (admin opens `profitability.html` → sees the honest-empty grid → clicks "חשב מחדש" on a case → the row repaints) is documented in the PR body Test plan (the H.1.c "deploys-green-can-fail-at-runtime" lesson; client_profitability is empty until the job/recompute runs).
+
+## PRODUCT-GRADE GATES (G1–G7)
+- **G1 errors:** PASS — Hebrew loading/empty/error/access-denied states; `null` actualCost → "עלות לא זמינה" (never ₪0/NaN/undefined); onSnapshot/callable errors → Hebrew-by-code, never a raw FirebaseError/stack.
+- **G2 rollback:** PASS — `git revert` removes the new page + JS/CSS + tests (additive; no existing page/route/collection changed). Code-only, ≤5 min. (No CF/rules to delete — PR4 is pure frontend.)
+- **G3 monitoring:** N/A — the page only READS (onSnapshot) + INVOKES the existing audited callables (`getProfitability` audits server-side; `recomputeProfitability` is audit-first server-side); the client adds no data-mutation path of its own. No cost value may be client-logged (M3).
+- **G4 customer test:** PASS — the `profitability-format` unit tests (the null≠0 / coverage / hours-status customer-render rules) + the PII source-guard + a documented manual live-smoke (admin → honest-empty grid → recompute → repaint). Listed in the PR Test plan.
+- **G5 Hebrew UI:** PASS — every customer-facing string Hebrew, RTL; this is the heart of the gate for a new page.
+- **G6 breaking change:** PASS — additive (a new page + new JS/CSS); no existing page, route, callable, collection, or token changed/removed.
+- **G7 security:** PASS — **security-access-expert reviewed (4-lens investigation)**: admin-only at the render gate (fail-closed `role==='admin'`, stricter than the admin||partner rule) + the rule blocks non-admin/non-partner at the DB; the cost/profit VALUE never reaches the client console/log/DOM-storage/URL (M3, enforced by the widened guard); cost stays off the world-readable clients doc (PR4 only reads it). NO `firestore.rules`/auth/claims/PII-surface-on-doc change → **devils-advocate NOT required** (like PR2).
+
+## VERDICT
+`outcomes-grader` must return **PASS** / **PASS_WITH_WARNINGS** before `gh pr create`.

--- a/apps/admin-panel/css/profitability.css
+++ b/apps/admin-panel/css/profitability.css
@@ -1,0 +1,613 @@
+/* ═══════════════════════════════════════════
+   Profitability Dashboard (H.3 PR4)
+   ───────────────────────────────────────────
+   New page — clears the Design Bar from day one.
+   - design-system.css tokens ONLY (no hex/px literals beyond the documented
+     channel-derived tints + #fff, the same convention employee-costs.css uses).
+   - RTL Hebrew · :focus-visible on every interactive element (--blue ring).
+   - Color-coded status tints derived from the --green/--orange/--red channel
+     values the same way design-system.css derives its blue focus ring
+     (rgb(59 130 246 / 10%)) — no --*-bg token exists, so we express the 8% tint
+     from the channel values rather than introducing a parallel token. Status
+     TEXT uses the -dark accent variant for WCAG AA on white.
+   - Motion via --transition-* tokens (reduced-motion-safe), never literals.
+   ═══════════════════════════════════════════ */
+
+.pf-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4);
+}
+
+/* ── Header ─────────────────────────────────── */
+
+.pf-header {
+  margin-bottom: var(--space-5);
+}
+
+.pf-header h1 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-3xl);
+  font-weight: var(--font-bold);
+  color: var(--gray-900);
+  margin: 0 0 var(--space-1);
+}
+
+.pf-header h1 i {
+  color: var(--gray-500);
+  font-size: var(--text-2xl);
+}
+
+.pf-subtitle {
+  font-size: var(--text-base);
+  color: var(--gray-600);
+  margin: 0;
+  line-height: 1.5;
+}
+
+/* ── Banners (info / error) ─────────────────── */
+
+.pf-banner {
+  display: none;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  margin-bottom: var(--space-4);
+}
+
+.pf-banner--info {
+  display: flex;
+  background: rgb(59 130 246 / 8%);
+  border: 1px solid var(--blue-light);
+  color: var(--blue-dark);
+}
+
+.pf-banner--error {
+  background: rgb(239 68 68 / 8%);
+  border: 1px solid var(--red-light);
+  color: var(--red-dark);
+}
+
+.pf-banner--error.pf-banner--show {
+  display: flex;
+}
+
+.pf-banner--hidden {
+  display: none !important;
+}
+
+/* ── Toolbar (search + filter + count) ──────── */
+
+.pf-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.pf-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 220px;
+}
+
+.pf-search > i {
+  position: absolute;
+  inset-inline-start: var(--space-3);
+  color: var(--gray-400);
+  font-size: var(--text-base);
+  pointer-events: none;
+}
+
+.pf-search-input {
+  width: 100%;
+  padding: var(--space-3);
+  padding-inline-start: var(--space-9);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  color: var(--gray-900);
+  font-size: var(--text-base);
+  font-family: inherit;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.pf-search-input:hover {
+  border-color: var(--gray-400);
+}
+
+.pf-search-input:focus-visible {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 25%);
+}
+
+.pf-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.pf-filter-label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--gray-600);
+}
+
+.pf-select {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  color: var(--gray-900);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.pf-select:focus-visible {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 25%);
+}
+
+.pf-count {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--gray-600);
+  white-space: nowrap;
+  margin-inline-start: auto;
+}
+
+/* ── Table ──────────────────────────────────── */
+
+.pf-list-wrap {
+  background: #fff;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  overflow-x: auto;
+}
+
+.pf-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+}
+
+.pf-table thead th {
+  text-align: start;
+  padding: var(--space-3) var(--space-4);
+  background: var(--gray-50);
+  color: var(--gray-700);
+  font-weight: var(--font-semibold);
+  font-size: var(--text-sm);
+  border-bottom: 1px solid var(--gray-200);
+  white-space: nowrap;
+}
+
+.pf-sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--transition-fast);
+}
+
+.pf-sortable:hover {
+  background: var(--gray-100);
+}
+
+.pf-sortable:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgb(59 130 246 / 50%);
+}
+
+.pf-sort-arrow {
+  color: var(--blue-dark);
+  font-size: var(--text-xs);
+}
+
+.pf-table tbody td {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--gray-100);
+  color: var(--gray-900);
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.pf-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.pf-table tbody tr:hover td {
+  background: var(--gray-50);
+}
+
+.pf-case {
+  font-variant-numeric: tabular-nums;
+  color: var(--gray-600);
+}
+
+.pf-name {
+  font-weight: var(--font-semibold);
+}
+
+.pf-num {
+  font-variant-numeric: tabular-nums;
+}
+
+.pf-updated {
+  color: var(--gray-500);
+  font-size: var(--text-xs);
+}
+
+.pf-muted {
+  color: var(--gray-400);
+}
+
+.pf-cost {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-semibold);
+}
+
+.pf-actions-col {
+  text-align: end;
+  white-space: nowrap;
+  width: 1%;
+}
+
+/* hours-vs-Plan colored cell (the only color signal today) */
+.pf-hours {
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--font-semibold);
+}
+
+.pf-hours.pf-level-success { color: var(--green-dark); }
+
+.pf-hours.pf-level-warning { color: var(--orange-dark); }
+
+.pf-hours.pf-level-danger { color: var(--red-dark); }
+
+.pf-hours.pf-level-neutral { color: var(--gray-700); }
+
+/* ── Badges (coverage / pricing) — channel-derived tints, -dark text for AA ── */
+
+.pf-badge {
+  display: inline-block;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  white-space: nowrap;
+}
+
+.pf-badge.pf-level-success {
+  background: rgb(16 185 129 / 10%);
+  color: var(--green-dark);
+}
+
+.pf-badge.pf-level-warning {
+  background: rgb(249 115 22 / 10%);
+  color: var(--orange-dark);
+}
+
+.pf-badge.pf-level-danger {
+  background: rgb(239 68 68 / 10%);
+  color: var(--red-dark);
+}
+
+.pf-badge.pf-level-neutral {
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+
+/* ── Status pills ───────────────────────────── */
+
+.pf-status {
+  display: inline-block;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+
+.pf-status--active {
+  background: rgb(16 185 129 / 10%);
+  color: var(--green-dark);
+}
+
+.pf-status--archived,
+.pf-status--inactive {
+  background: var(--gray-100);
+  color: var(--gray-500);
+}
+
+.pf-status--blocked {
+  background: rgb(239 68 68 / 10%);
+  color: var(--red-dark);
+}
+
+.pf-status--on_hold {
+  background: rgb(249 115 22 / 10%);
+  color: var(--orange-dark);
+}
+
+/* ── Row action buttons ─────────────────────── */
+
+.pf-row-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  margin-inline-start: var(--space-1);
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  background: var(--gray-50);
+  color: var(--gray-700);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.pf-row-btn:hover {
+  background: #fff;
+  border-color: var(--gray-400);
+  box-shadow: var(--shadow-sm);
+}
+
+.pf-row-btn:focus-visible {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 25%);
+}
+
+.pf-row-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Empty / loading / error states ─────────── */
+
+.pf-empty-row td {
+  padding: 0;
+}
+
+.pf-empty,
+.pf-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-10) var(--space-4);
+  color: var(--gray-500);
+  text-align: center;
+}
+
+.pf-empty i {
+  font-size: var(--text-3xl);
+  color: var(--gray-300);
+}
+
+.pf-empty p,
+.pf-state p {
+  margin: 0;
+  font-size: var(--text-base);
+}
+
+.pf-state--error i {
+  font-size: var(--text-2xl);
+  color: var(--red-dark);
+}
+
+.pf-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--gray-200);
+  border-top-color: var(--blue);
+  border-radius: 50%;
+  animation: pf-spin var(--transition-slow) linear infinite;
+}
+
+.pf-spinner--inline {
+  width: 14px;
+  height: 14px;
+  border-width: 2px;
+  display: inline-block;
+  vertical-align: -2px;
+}
+
+@keyframes pf-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pf-spinner {
+    animation-duration: 1200ms;
+  }
+}
+
+/* ── Detail drawer (inside ModalManager) ────── */
+
+.pf-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.pf-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.pf-dt {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+}
+
+.pf-dt dt {
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--gray-500);
+}
+
+.pf-dt dd {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
+  color: var(--gray-900);
+  font-variant-numeric: tabular-nums;
+}
+
+.pf-detail-plan h3 {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--gray-600);
+  margin: 0 0 var(--space-2);
+}
+
+.pf-detail-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-6) var(--space-4);
+  text-align: center;
+  color: var(--gray-600);
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-md);
+}
+
+.pf-detail-empty i {
+  font-size: var(--text-2xl);
+  color: var(--gray-400);
+}
+
+.pf-detail-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ── Buttons ────────────────────────────────── */
+
+.pf-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-md);
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  font-family: inherit;
+  cursor: pointer;
+  border: 1px solid transparent;
+  text-decoration: none;
+  transition: background var(--transition-fast), border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.pf-btn--primary {
+  background: var(--blue-dark);
+  color: #fff;
+}
+
+.pf-btn--primary:hover {
+  background: var(--blue);
+}
+
+.pf-btn--secondary {
+  background: var(--gray-50);
+  color: var(--gray-900);
+  border-color: var(--gray-300);
+}
+
+.pf-btn--secondary:hover {
+  background: #fff;
+  border-color: var(--gray-400);
+  box-shadow: var(--shadow-sm);
+}
+
+.pf-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 25%);
+}
+
+/* ── Access-denied + load-error states ──────── */
+
+.pf-access-denied,
+.pf-load-error {
+  max-width: 480px;
+  margin: var(--space-12) auto;
+  padding: var(--space-8) var(--space-6);
+  text-align: center;
+  background: #fff;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+}
+
+.pf-access-denied i,
+.pf-load-error i {
+  font-size: var(--text-3xl);
+  color: var(--gray-400);
+  margin-bottom: var(--space-3);
+}
+
+.pf-load-error i {
+  color: var(--orange-dark);
+}
+
+.pf-access-denied h1,
+.pf-load-error h1 {
+  font-size: var(--text-2xl);
+  font-weight: var(--font-bold);
+  color: var(--gray-900);
+  margin: 0 0 var(--space-2);
+}
+
+.pf-access-denied p,
+.pf-load-error p {
+  font-size: var(--text-base);
+  color: var(--gray-600);
+  line-height: 1.5;
+  margin: 0 0 var(--space-5);
+}
+
+/* ── Responsive ─────────────────────────────── */
+
+@media (width <= 900px) {
+  .pf-updated,
+  .pf-num-col {
+    display: none;
+  }
+}
+
+@media (width <= 640px) {
+  .pf-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pf-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pf-count {
+    margin-inline-start: 0;
+  }
+}

--- a/apps/admin-panel/js/core/profitability-format.js
+++ b/apps/admin-panel/js/core/profitability-format.js
@@ -1,0 +1,150 @@
+/**
+ * profitability-format.js — pure render-decision helpers for the Profitability
+ * dashboard (H.3 PR4). NO DOM, NO Firebase — the LOAD-BEARING display rules
+ * (null≠0, coverage badge, hours-vs-Plan status) are extracted here so they are
+ * unit-tested directly (the customer scenario: "actualCost=null shows
+ * 'עלות לא זמינה', NEVER ₪0"). Dual-export: window.ProfitabilityFormat +
+ * CommonJS (so tests/unit/admin-panel/profitability-format.test.ts can require it).
+ *
+ * 🔴 PII (§7.6, PUBLIC repo): these helpers RETURN display strings for the
+ * admin-only page; the cost VALUE they format must never be logged / stored /
+ * url'd / put in a toast by the caller. This module itself only transforms.
+ *
+ * Backend contract (PR3, LIVE — do not re-derive): the client_profitability doc
+ * carries actualHours, actualCost (number|null — null = un-costed/unknown,
+ * NEVER 0), costedEntryCount, totalEntryCount, unCostedCoveragePercent
+ * (number|null), paidRevenue:null, projectedProfit:null (H.6 seams). The Plan
+ * side (client.plan) carries expectedHours, expectedRevenue, pricingComplete,
+ * pricingMissingCount.
+ */
+(function () {
+  'use strict';
+
+  const COST_UNAVAILABLE = 'עלות לא זמינה';
+
+  function isFiniteNum(v) {
+    return typeof v === 'number' && isFinite(v);
+  }
+
+  /** Integer-grouped ILS, e.g. 40000 -> "₪40,000". null/non-finite -> ''. */
+  function formatShekel(v) {
+    if (!isFiniteNum(v)) {
+      return '';
+    }
+    const rounded = Math.round(v);
+    const sign = rounded < 0 ? '-' : '';
+    const digits = String(Math.abs(rounded)).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return sign + '₪' + digits;
+  }
+
+  /** Hours to 1 decimal, e.g. 4.92 -> "4.9". null -> '—'. (0 is a REAL value -> "0.0".) */
+  function formatHours(v) {
+    if (!isFiniteNum(v)) {
+      return '—';
+    }
+    return (Math.round(v * 10) / 10).toFixed(1);
+  }
+
+  /**
+   * actualCost render — the #1 rule. A finite number -> formatted ₪ (INCLUDING a
+   * real 0 -> "₪0", a KNOWN free cost). null/undefined (un-costed/unknown) ->
+   * "עלות לא זמינה", NEVER ₪0 (a 0 would fabricate a "this case costs nothing"
+   * signal — the exact false reading the profitability layer exists to prevent).
+   * @returns {{ text:string, available:boolean }}
+   */
+  function formatActualCost(actualCost) {
+    if (isFiniteNum(actualCost)) {
+      return { text: formatShekel(actualCost), available: true };
+    }
+    return { text: COST_UNAVAILABLE, available: false };
+  }
+
+  /**
+   * Coverage badge from unCostedCoveragePercent (% of in-scope entries with an
+   * UNKNOWN cost) + totalEntryCount.
+   *  - no entries (totalEntryCount===0 or pct null) -> neutral 'אין רישומים'
+   *  - pct <= 0   (fully costed)                    -> success 'מתומחר מלא'
+   *  - 0 < pct < 100                                -> warning 'X% לא מתומחר'
+   *  - pct >= 100 (nothing costed — TODAY's state)  -> danger  'עלות טרם הוזנה'
+   * @returns {{ level:'neutral'|'success'|'warning'|'danger', label:string }}
+   */
+  function coverageBadge(unCostedCoveragePercent, totalEntryCount) {
+    if (totalEntryCount === 0 || !isFiniteNum(unCostedCoveragePercent)) {
+      return { level: 'neutral', label: 'אין רישומים' };
+    }
+    const pct = Math.round(unCostedCoveragePercent);
+    if (pct <= 0) {
+      return { level: 'success', label: 'מתומחר מלא' };
+    }
+    if (pct >= 100) {
+      return { level: 'danger', label: 'עלות טרם הוזנה' };
+    }
+    return { level: 'warning', label: pct + '% לא מתומחר' };
+  }
+
+  /**
+   * Hours-vs-Plan status — the ONLY color signal in PR4. actualCost is system-
+   * wide null today, so NO cost/profit alert is computed; we color the HOURS
+   * burn-rate vs the Plan's expectedHours (the locked PR4 checkpoint decision —
+   * the X% profit threshold is deferred to when costs exist).
+   *  - expectedHours not a positive number (e.g. fixed-price → 0) -> neutral 'אין תכנון'
+   *  - ratio <= 0.85       -> success 'בתכנון'
+   *  - 0.85 < ratio <= 1.0 -> warning 'מתקרב לתקרה'
+   *  - ratio > 1.0         -> danger  'חריגה משעות התכנון'
+   * @returns {{ level:string, label:string, ratio:number|null }}
+   */
+  function hoursStatus(actualHours, expectedHours) {
+    if (!isFiniteNum(expectedHours) || expectedHours <= 0) {
+      return { level: 'neutral', label: 'אין תכנון', ratio: null };
+    }
+    const actual = isFiniteNum(actualHours) ? actualHours : 0;
+    const ratio = actual / expectedHours;
+    if (ratio <= 0.85) {
+      return { level: 'success', label: 'בתכנון', ratio: ratio };
+    }
+    if (ratio <= 1.0) {
+      return { level: 'warning', label: 'מתקרב לתקרה', ratio: ratio };
+    }
+    return { level: 'danger', label: 'חריגה משעות התכנון', ratio: ratio };
+  }
+
+  /**
+   * Expected-revenue display from client.plan. An un-priced case
+   * (pricingComplete===false / pricingMissingCount>0) is FLAGGED 'תמחור חסר',
+   * never shown as a bare ₪0.
+   * @returns {{ text:string, flag:boolean, flagLabel:string }}
+   */
+  function planRevenue(plan) {
+    if (!plan || typeof plan !== 'object') {
+      return { text: '—', flag: false, flagLabel: '' };
+    }
+    const hasMissing = plan.pricingComplete === false ||
+      (isFiniteNum(plan.pricingMissingCount) && plan.pricingMissingCount > 0);
+    const text = isFiniteNum(plan.expectedRevenue) ? formatShekel(plan.expectedRevenue) : '—';
+    if (hasMissing) {
+      const n = isFiniteNum(plan.pricingMissingCount) ? plan.pricingMissingCount : 0;
+      return { text: text, flag: true, flagLabel: n > 0 ? ('תמחור חסר (' + n + ')') : 'תמחור חלקי' };
+    }
+    return { text: text, flag: false, flagLabel: '' };
+  }
+
+  const api = {
+    formatShekel: formatShekel,
+    formatHours: formatHours,
+    formatActualCost: formatActualCost,
+    coverageBadge: coverageBadge,
+    hoursStatus: hoursStatus,
+    planRevenue: planRevenue,
+    COST_UNAVAILABLE: COST_UNAVAILABLE
+  };
+
+  // Expose to window — admin-panel pattern (classic <script> load).
+  if (typeof window !== 'undefined') {
+    window.ProfitabilityFormat = api;
+  }
+
+  // CommonJS export — for vitest tests under Node.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/apps/admin-panel/js/ui/ProfitabilityPage.js
+++ b/apps/admin-panel/js/ui/ProfitabilityPage.js
@@ -1,0 +1,750 @@
+/**
+ * Profitability Dashboard (H.3 PR4)
+ * =================================
+ * Admin-only real-time per-case Profitability dashboard. Reads the CF-only
+ * `client_profitability` collection LIVE via onSnapshot (PR3 rule allows an
+ * admin/partner listener) and JOINs each Forecast doc to `client.plan` (PR1,
+ * carried on the world-readable clients doc) by caseNumber. FRONTEND ONLY — no
+ * backend / rules / claims change (PR3 built the rule + the callables).
+ *
+ * ─── Mirrors the PR2 gold-standard (EmployeeCostsPage.js) ─────────────────────
+ *  - `window.ProfitabilityPage = { init(sectionId), teardown() }`
+ *  - `_escapeHtml` on every interpolated value; Hebrew-error-by-code (`_errorMessage`)
+ *  - ModalManager loading→content for the per-case detail drawer
+ *
+ * ─── 🔴 COST/PROFIT PII DISCIPLINE (§7.6, PUBLIC repo) — #1 never-regress ──────
+ *  The cost/profit VALUE must NEVER escape this client surface:
+ *   - NO console.* of actualCost / projectedProfit / paidRevenue or any
+ *     onSnapshot doc / getProfitability result (log only counts + caseNumber +
+ *     error.code).
+ *   - NEVER put a cost/profit into a toast / error string / a data- attribute /
+ *     localStorage / sessionStorage / a URL.
+ *  Row buttons carry only `data-case` (the 7-digit caseNumber, a non-PII business
+ *  id). Error TOASTS carry only the Hebrew message-by-code.
+ *
+ * ─── Backend contracts (PR3, LIVE — do not change) ───────────────────────────
+ *  client_profitability/{caseNumber} (onSnapshot): { caseNumber, actualHours,
+ *    actualCost:number|null (null=un-costed, NEVER 0), costedEntryCount,
+ *    totalEntryCount, unCostedCoveragePercent:number|null, paidRevenue:null,
+ *    projectedProfit:null, status, schemaVersion, computedAt:Timestamp }.
+ *  getProfitability({caseNumber}) → {exists:false} | {exists:true, ...snapshot, computedAtIso}.
+ *  recomputeProfitability({caseNumber}) → {success, caseNumber, found} (audit-first mutation).
+ *
+ * Color signal: HOURS-vs-Plan only (actualCost is system-wide null today → no
+ * profit alert; the X% threshold is deferred to when costs exist — §8.5 PR4).
+ */
+
+(function () {
+  'use strict';
+
+  const PROFITABILITY_COLLECTION = 'client_profitability';
+  const CLIENTS_COLLECTION = 'clients';
+
+  // Status vocabulary (mirrors the clients table semantics).
+  const STATUS_LABELS = {
+    active: 'פעיל',
+    inactive: 'לא פעיל',
+    archived: 'בארכיון',
+    on_hold: 'מוקפא',
+    blocked: 'חסום'
+  };
+
+  const ProfitabilityPage = {
+    container: null,
+    // caseNumber -> { name, status, plan } (the Plan/name JOIN source).
+    clientsByCase: {},
+    // caseNumber -> forecast doc (from the live onSnapshot).
+    forecastsByCase: {},
+    unsub: null,
+    listening: false,
+    loadError: false,
+    searchTerm: '',
+    statusFilter: 'active',
+    sortKey: 'caseNumber',
+    sortDir: 'asc',
+    recomputing: {},
+
+    /**
+     * Entry point — called AFTER auth + the explicit admin role gate pass.
+     * Loads the clients (for the Plan JOIN), renders the shell, then attaches
+     * the live client_profitability onSnapshot.
+     */
+    init: function (sectionId) {
+      const self = this;
+      this.container = document.getElementById(sectionId);
+      if (!this.container) {
+        console.error('ProfitabilityPage: container not found:', sectionId);
+        return;
+      }
+
+      this._renderLoading();
+
+      this._loadClients()
+        .then(function () {
+          self.render();
+          self._attachListener();
+        })
+        .catch(function (err) {
+          // errorCode only — never the underlying data.
+          console.error('❌ [Profitability] clients load failed:', err && err.code);
+          self.loadError = true;
+          self._renderLoadError();
+        });
+    },
+
+    /** Tear down the live listener (called on logout / page leave). */
+    teardown: function () {
+      if (typeof this.unsub === 'function') {
+        try {
+          this.unsub();
+        } catch (e) {
+          // ignore
+        }
+      }
+      this.unsub = null;
+      this.listening = false;
+    },
+
+    // ═══════════════════════════════════════════
+    // Data: clients (Plan JOIN source) + live forecast listener
+    // ═══════════════════════════════════════════
+
+    /**
+     * Loads the clients list once (the Plan/name JOIN source). Mirrors
+     * ClientsDataManager.loadClients filter — excludes internal cases so the
+     * dashboard set matches the rest of the admin UI. Carries client.plan via
+     * the doc spread. NO cost data here (clients is world-readable).
+     */
+    _loadClients: function () {
+      const self = this;
+      const db = window.firebaseDB;
+      if (!db) {
+        return Promise.reject({ code: 'no-db' });
+      }
+      return db.collection(CLIENTS_COLLECTION).get().then(function (snap) {
+        const map = {};
+        snap.forEach(function (doc) {
+          const d = doc.data() || {};
+          // Same internal-client filter as ClientsDataManager (SOT for the set).
+          if (d.isInternal || d.clientType === 'internal') {
+            return;
+          }
+          map[doc.id] = {
+            caseNumber: doc.id,
+            name: d.fullName || d.clientName || doc.id,
+            status: d.status || 'active',
+            plan: d.plan || null
+          };
+        });
+        self.clientsByCase = map;
+      });
+    },
+
+    /**
+     * Attaches the live onSnapshot on client_profitability. The rule permits an
+     * admin listener; this runs ONLY after the page's admin gate passed.
+     * 🔴 PII: the snapshot docs carry actualCost — never console.* them.
+     */
+    _attachListener: function () {
+      const self = this;
+      const db = window.firebaseDB;
+      if (!db || this.listening) {
+        return;
+      }
+      this.listening = true;
+      this.unsub = db.collection(PROFITABILITY_COLLECTION).onSnapshot(
+        function (snap) {
+          const map = {};
+          snap.forEach(function (doc) {
+            map[doc.id] = doc.data() || {};
+          });
+          self.forecastsByCase = map;
+          self._refreshGrid();
+        },
+        function (error) {
+          // errorCode only — never the data. Render a Hebrew error banner.
+          console.error('❌ [Profitability] live listener error:', error && error.code);
+          self._renderListenerError();
+        }
+      );
+    },
+
+    // ═══════════════════════════════════════════
+    // Render
+    // ═══════════════════════════════════════════
+
+    _renderLoading: function () {
+      this.container.innerHTML =
+        '<div class="pf-page"><div class="pf-state" role="status" aria-live="polite">' +
+        '<div class="pf-spinner" aria-hidden="true"></div><p>טוען נתוני רווחיות...</p>' +
+        '</div></div>';
+    },
+
+    _renderLoadError: function () {
+      this.container.innerHTML =
+        '<div class="pf-page"><div class="pf-load-error" role="alert">' +
+        '<i class="fas fa-exclamation-triangle" aria-hidden="true"></i>' +
+        '<h1>שגיאה בטעינת נתונים</h1>' +
+        '<p>לא ניתן לטעון את רשימת התיקים כעת. בדוק את החיבור לאינטרנט ונסה שוב.</p>' +
+        '<button type="button" class="pf-btn pf-btn--secondary" onclick="window.location.reload()" aria-label="רענון הדף">רענון הדף</button>' +
+        '</div></div>';
+    },
+
+    _renderListenerError: function () {
+      const banner = document.getElementById('pf-listener-error');
+      if (banner) {
+        banner.classList.add('pf-banner--show');
+      }
+    },
+
+    render: function () {
+      const hasAnyForecast = Object.keys(this.forecastsByCase).length > 0;
+      const emptyBanner = hasAnyForecast ? '' :
+        '<div class="pf-banner pf-banner--info" role="status">' +
+        '<i class="fas fa-clock" aria-hidden="true"></i>' +
+        '<span>נתוני הרווחיות מחושבים אוטומטית — חישוב יומי ב-06:30. ניתן לחשב תיק מסוים ידנית בכפתור "חשב מחדש".</span>' +
+        '</div>';
+
+      this.container.innerHTML =
+        '<div class="pf-page">' +
+        '  <header class="pf-header">' +
+        '    <h1><i class="fas fa-chart-line" aria-hidden="true"></i> רווחיות תיקים</h1>' +
+        '    <p class="pf-subtitle">תכנון מול ביצוע לכל תיק — שעות ועלות. נתון פיננסי רגיש, נגיש למנהלים בלבד. רווח יוצג בהמשך (H.6).</p>' +
+        '  </header>' +
+        '  <div id="pf-listener-error" class="pf-banner pf-banner--error" role="alert">' +
+        '    <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>' +
+        '    <span>החיבור החי לנתוני הרווחיות נכשל. רענן את הדף כדי לנסות שוב.</span>' +
+        '  </div>' +
+        emptyBanner +
+        '  <div class="pf-toolbar">' +
+        '    <label class="pf-search" for="pf-search-input">' +
+        '      <i class="fas fa-search" aria-hidden="true"></i>' +
+        '      <input type="search" id="pf-search-input" class="pf-search-input" placeholder="חיפוש לפי שם או מספר תיק..." aria-label="חיפוש תיק לפי שם או מספר" autocomplete="off">' +
+        '    </label>' +
+        '    <label class="pf-filter" for="pf-status-filter">' +
+        '      <span class="pf-filter-label">סטטוס:</span>' +
+        '      <select id="pf-status-filter" class="pf-select" aria-label="סינון לפי סטטוס תיק">' +
+        '        <option value="active">פעילים</option>' +
+        '        <option value="all">הכל</option>' +
+        '        <option value="archived">בארכיון</option>' +
+        '      </select>' +
+        '    </label>' +
+        '    <span class="pf-count" id="pf-count" aria-live="polite"></span>' +
+        '  </div>' +
+        '  <div class="pf-list-wrap">' +
+        '    <table class="pf-table">' +
+        '      <thead><tr>' +
+        this._th('caseNumber', 'מס׳ תיק') +
+        this._th('name', 'לקוח') +
+        '        <th scope="col">סטטוס</th>' +
+        this._th('expectedHours', 'שעות מתוכננות') +
+        '        <th scope="col">הכנסה צפויה</th>' +
+        this._th('actualHours', 'שעות בפועל') +
+        '        <th scope="col">עלות בפועל</th>' +
+        '        <th scope="col">כיסוי עלות</th>' +
+        '        <th scope="col" class="pf-num-col">עודכן</th>' +
+        '        <th scope="col" class="pf-actions-col">פעולות</th>' +
+        '      </tr></thead>' +
+        '      <tbody id="pf-tbody">' + this._renderRows() + '</tbody>' +
+        '    </table>' +
+        '  </div>' +
+        '</div>';
+
+      // Restore the status filter selection + bind events.
+      const sel = document.getElementById('pf-status-filter');
+      if (sel) {
+        sel.value = this.statusFilter;
+      }
+      this._bindEvents();
+      this._updateCount();
+    },
+
+    _th: function (key, label) {
+      const active = this.sortKey === key;
+      const arrow = active ? (this.sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+      const ariaSort = active ? (this.sortDir === 'asc' ? 'ascending' : 'descending') : 'none';
+      return '<th scope="col" class="pf-sortable" data-sort="' + key + '" role="columnheader" aria-sort="' + ariaSort + '" tabindex="0">' +
+        this._escapeHtml(label) + '<span class="pf-sort-arrow" aria-hidden="true">' + arrow + '</span></th>';
+    },
+
+    /** The rows: every visible client (JOIN to its forecast doc, which may be absent). */
+    _rows: function () {
+      const self = this;
+      const term = this.searchTerm.trim().toLowerCase();
+      let rows = Object.keys(this.clientsByCase).map(function (caseNumber) {
+        const client = self.clientsByCase[caseNumber];
+        const forecast = self.forecastsByCase[caseNumber] || null;
+        return { caseNumber: caseNumber, client: client, forecast: forecast };
+      });
+
+      // Status filter (active default; archived; all).
+      rows = rows.filter(function (r) {
+        if (self.statusFilter === 'all') {
+          return true;
+        }
+        const status = (r.forecast && r.forecast.status) || r.client.status || 'active';
+        if (self.statusFilter === 'archived') {
+          return status === 'archived';
+        }
+        // 'active' = everything that is not archived/inactive.
+        return status !== 'archived' && status !== 'inactive';
+      });
+
+      // Search by name or caseNumber.
+      if (term) {
+        rows = rows.filter(function (r) {
+          const name = (r.client.name || '').toLowerCase();
+          return name.indexOf(term) !== -1 || r.caseNumber.toLowerCase().indexOf(term) !== -1;
+        });
+      }
+
+      // Sort.
+      const key = this.sortKey;
+      const dir = this.sortDir === 'asc' ? 1 : -1;
+      rows.sort(function (a, b) {
+        const av = self._sortValue(a, key);
+        const bv = self._sortValue(b, key);
+        if (av < bv) {
+ return -1 * dir;
+}
+        if (av > bv) {
+ return 1 * dir;
+}
+        return 0;
+      });
+      return rows;
+    },
+
+    _sortValue: function (r, key) {
+      if (key === 'caseNumber') {
+ return r.caseNumber;
+}
+      if (key === 'name') {
+ return (r.client.name || '').toLowerCase();
+}
+      if (key === 'expectedHours') {
+        return (r.client.plan && typeof r.client.plan.expectedHours === 'number') ? r.client.plan.expectedHours : -1;
+      }
+      if (key === 'actualHours') {
+        return (r.forecast && typeof r.forecast.actualHours === 'number') ? r.forecast.actualHours : -1;
+      }
+      return r.caseNumber;
+    },
+
+    _renderRows: function () {
+      const self = this;
+      const rows = this._rows();
+      if (rows.length === 0) {
+        return '<tr class="pf-empty-row"><td colspan="10"><div class="pf-empty">' +
+          '<i class="fas fa-folder-open" aria-hidden="true"></i>' +
+          '<p>' + (this.searchTerm ? 'לא נמצאו תיקים התואמים לחיפוש.' : 'אין תיקים להצגה.') + '</p>' +
+          '</div></td></tr>';
+      }
+      const F = window.ProfitabilityFormat;
+      return rows.map(function (r) {
+        return self._renderRow(r, F);
+      }).join('');
+    },
+
+    /** One row — JOIN the live forecast to the in-memory plan. */
+    _renderRow: function (r, F) {
+      const self = this;
+      const caseNumber = r.caseNumber;
+      const client = r.client;
+      const plan = client.plan || null;
+      const forecast = r.forecast;
+
+      const status = (forecast && forecast.status) || client.status || 'active';
+      const statusLabel = STATUS_LABELS[status] || status;
+
+      const expectedHours = (plan && typeof plan.expectedHours === 'number') ? F.formatHours(plan.expectedHours) : '—';
+      const rev = F.planRevenue(plan);
+
+      const hasForecast = !!forecast;
+      const actualHoursVal = hasForecast ? forecast.actualHours : null;
+      const actualHours = hasForecast ? F.formatHours(actualHoursVal) : '<span class="pf-muted">טרם חושב</span>';
+
+      // The hours-vs-Plan color signal (the only signal — cost is null today).
+      const hStatus = hasForecast ? F.hoursStatus(actualHoursVal, plan && plan.expectedHours)
+        : { level: 'neutral', label: '' };
+      const hoursCellClass = 'pf-hours pf-level-' + hStatus.level;
+
+      // actualCost — null≠0 (today: "עלות לא זמינה").
+      let costCell;
+      if (hasForecast) {
+        const c = F.formatActualCost(forecast.actualCost);
+        costCell = c.available
+          ? '<span class="pf-cost" dir="ltr">' + self._escapeHtml(c.text) + '</span>'
+          : '<span class="pf-cost pf-muted">' + self._escapeHtml(c.text) + '</span>';
+      } else {
+        costCell = '<span class="pf-muted">טרם חושב</span>';
+      }
+
+      // Coverage badge.
+      let covCell;
+      if (hasForecast) {
+        const cov = F.coverageBadge(forecast.unCostedCoveragePercent, forecast.totalEntryCount);
+        covCell = '<span class="pf-badge pf-level-' + cov.level + '">' + self._escapeHtml(cov.label) + '</span>';
+      } else {
+        covCell = '<span class="pf-muted">—</span>';
+      }
+
+      const updated = hasForecast ? self._relativeTime(forecast.computedAt) : '—';
+
+      const revCell = rev.flag
+        ? '<span dir="ltr">' + self._escapeHtml(rev.text) + '</span> <span class="pf-badge pf-level-warning">' + self._escapeHtml(rev.flagLabel) + '</span>'
+        : '<span dir="ltr">' + self._escapeHtml(rev.text) + '</span>';
+
+      const busy = this.recomputing[caseNumber];
+      const recomputeBtn = '<button type="button" class="pf-row-btn" data-action="recompute" data-case="' + self._escapeHtml(caseNumber) + '"' +
+        (busy ? ' disabled' : '') + ' aria-label="חשב מחדש תיק ' + self._escapeHtml(caseNumber) + '">' +
+        (busy ? '<span class="pf-spinner pf-spinner--inline" aria-hidden="true"></span>' : '<i class="fas fa-rotate" aria-hidden="true"></i>') +
+        '</button>';
+      const detailBtn = '<button type="button" class="pf-row-btn" data-action="detail" data-case="' + self._escapeHtml(caseNumber) + '" aria-label="פרטי רווחיות לתיק ' + self._escapeHtml(caseNumber) + '"><i class="fas fa-circle-info" aria-hidden="true"></i></button>';
+
+      return '<tr>' +
+        '<td class="pf-case" dir="ltr">' + self._escapeHtml(caseNumber) + '</td>' +
+        '<td class="pf-name">' + self._escapeHtml(client.name) + '</td>' +
+        '<td><span class="pf-status pf-status--' + self._escapeHtml(status) + '">' + self._escapeHtml(statusLabel) + '</span></td>' +
+        '<td class="pf-num" dir="ltr">' + self._escapeHtml(expectedHours) + '</td>' +
+        '<td class="pf-num">' + revCell + '</td>' +
+        '<td class="' + hoursCellClass + '" dir="ltr">' + actualHours + '</td>' +
+        '<td class="pf-num">' + costCell + '</td>' +
+        '<td>' + covCell + '</td>' +
+        '<td class="pf-num pf-updated">' + self._escapeHtml(updated) + '</td>' +
+        '<td class="pf-actions-col">' + detailBtn + recomputeBtn + '</td>' +
+        '</tr>';
+    },
+
+    _refreshGrid: function () {
+      // If the shell isn't rendered yet (first snapshot before render), render it.
+      if (!document.getElementById('pf-tbody')) {
+        this.render();
+        return;
+      }
+      const tbody = document.getElementById('pf-tbody');
+      if (tbody) {
+        tbody.innerHTML = this._renderRows();
+        this._bindRowButtons();
+      }
+      this._updateCount();
+      // Hide the "no data yet" info banner once any forecast arrives.
+      const info = this.container.querySelector('.pf-banner--info');
+      if (info && Object.keys(this.forecastsByCase).length > 0) {
+        info.classList.add('pf-banner--hidden');
+      }
+    },
+
+    _updateCount: function () {
+      const count = document.getElementById('pf-count');
+      if (count) {
+        const n = this._rows().length;
+        count.textContent = n === 1 ? 'תיק אחד' : n + ' תיקים';
+      }
+    },
+
+    // ═══════════════════════════════════════════
+    // Events
+    // ═══════════════════════════════════════════
+
+    _bindEvents: function () {
+      const self = this;
+      const search = document.getElementById('pf-search-input');
+      if (search) {
+        search.addEventListener('input', function (e) {
+          self.searchTerm = e.target.value || '';
+          self._refreshGrid();
+        });
+      }
+      const filter = document.getElementById('pf-status-filter');
+      if (filter) {
+        filter.addEventListener('change', function (e) {
+          self.statusFilter = e.target.value || 'active';
+          self._refreshGrid();
+        });
+      }
+      // Sortable headers (click + keyboard).
+      this.container.querySelectorAll('.pf-sortable').forEach(function (th) {
+        const apply = function () {
+          const key = th.getAttribute('data-sort');
+          if (self.sortKey === key) {
+            self.sortDir = self.sortDir === 'asc' ? 'desc' : 'asc';
+          } else {
+            self.sortKey = key;
+            self.sortDir = 'asc';
+          }
+          self.render();
+        };
+        th.addEventListener('click', apply);
+        th.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            apply();
+          }
+        });
+      });
+      this._bindRowButtons();
+    },
+
+    _bindRowButtons: function () {
+      const self = this;
+      const tbody = document.getElementById('pf-tbody');
+      if (!tbody) {
+        return;
+      }
+      tbody.querySelectorAll('[data-action="detail"]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          self._openDetail(btn.getAttribute('data-case'));
+        });
+      });
+      tbody.querySelectorAll('[data-action="recompute"]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          self._recompute(btn.getAttribute('data-case'));
+        });
+      });
+    },
+
+    // ═══════════════════════════════════════════
+    // Per-case detail drawer (getProfitability — the AUDITED single-case fetch)
+    // ═══════════════════════════════════════════
+
+    _openDetail: function (caseNumber) {
+      const self = this;
+      if (!caseNumber) {
+        return;
+      }
+      const client = this.clientsByCase[caseNumber] || { name: caseNumber, plan: null };
+      const modalId = window.ModalManager.create({
+        title: 'רווחיות — ' + this._escapeHtml(client.name || caseNumber),
+        size: 'medium',
+        content: '<div class="pf-state" role="status" aria-live="polite"><div class="pf-spinner" aria-hidden="true"></div><p>טוען פרטי רווחיות...</p></div>',
+        footer: null
+      });
+
+      const fn = window.firebase.functions().httpsCallable('getProfitability');
+      fn({ caseNumber: caseNumber })
+        .then(function (result) {
+          // 🔴 PII: NEVER console.* the result — it carries actualCost.
+          const data = (result && result.data) || {};
+          window.ModalManager.updateContent(modalId, self._renderDetail(caseNumber, client, data));
+          self._bindDetailButtons(modalId, caseNumber);
+        })
+        .catch(function (error) {
+          window.ModalManager.updateContent(modalId,
+            '<div class="pf-state pf-state--error" role="alert"><i class="fas fa-exclamation-triangle" aria-hidden="true"></i>' +
+            '<p>' + self._escapeHtml(self._errorMessage(error)) + '</p>' +
+            '<button type="button" class="pf-btn pf-btn--secondary" data-action="pf-close" aria-label="סגור">סגור</button></div>');
+          const el = window.ModalManager.getElement(modalId);
+          const close = el && el.querySelector('[data-action="pf-close"]');
+          if (close) {
+            close.addEventListener('click', function () {
+ window.ModalManager.close(modalId);
+});
+          }
+        });
+    },
+
+    _renderDetail: function (caseNumber, client, data) {
+      const F = window.ProfitabilityFormat;
+      const plan = client.plan || null;
+
+      if (!data.exists) {
+        return '<div class="pf-detail">' +
+          '<div class="pf-detail-empty" role="status"><i class="fas fa-clock" aria-hidden="true"></i>' +
+          '<p>הרווחיות לתיק זה טרם חושבה. לחץ "חשב מחדש" כדי לחשב כעת, או המתן לחישוב היומי (06:30).</p></div>' +
+          self._detailPlanBlock(plan, F) +
+          '<div class="pf-detail-actions"><button type="button" class="pf-btn pf-btn--primary" data-action="pf-recompute" aria-label="חשב מחדש"><i class="fas fa-rotate" aria-hidden="true"></i> חשב מחדש</button></div>' +
+          '</div>';
+      }
+
+      const cost = F.formatActualCost(data.actualCost);
+      const cov = F.coverageBadge(data.unCostedCoveragePercent, data.totalEntryCount);
+      const costedCount = (typeof data.costedEntryCount === 'number') ? data.costedEntryCount : 0;
+      const totalCount = (typeof data.totalEntryCount === 'number') ? data.totalEntryCount : 0;
+
+      return '<div class="pf-detail">' +
+        '<dl class="pf-detail-grid">' +
+        self._dt('שעות בפועל', '<span dir="ltr">' + self._escapeHtml(F.formatHours(data.actualHours)) + '</span>') +
+        self._dt('עלות בפועל', '<span dir="ltr" class="' + (cost.available ? '' : 'pf-muted') + '">' + self._escapeHtml(cost.text) + '</span>') +
+        self._dt('כיסוי עלות', '<span class="pf-badge pf-level-' + cov.level + '">' + self._escapeHtml(cov.label) + '</span>') +
+        self._dt('רישומים מתומחרים', '<span dir="ltr">' + self._escapeHtml(costedCount + ' / ' + totalCount) + '</span>') +
+        self._dt('רווח', '<span class="pf-muted">בהמשך (H.6)</span>') +
+        self._dt('חושב לאחרונה', self._escapeHtml(self._isoToRelative(data.computedAtIso))) +
+        '</dl>' +
+        self._detailPlanBlock(plan, F) +
+        '<div class="pf-detail-actions"><button type="button" class="pf-btn pf-btn--primary" data-action="pf-recompute" aria-label="חשב מחדש"><i class="fas fa-rotate" aria-hidden="true"></i> חשב מחדש</button></div>' +
+        '</div>';
+    },
+
+    _detailPlanBlock: function (plan, F) {
+      if (!plan) {
+        return '';
+      }
+      const rev = F.planRevenue(plan);
+      return '<div class="pf-detail-plan"><h3>תכנון (Plan)</h3><dl class="pf-detail-grid">' +
+        this._dt('שעות מתוכננות', '<span dir="ltr">' + this._escapeHtml(typeof plan.expectedHours === 'number' ? F.formatHours(plan.expectedHours) : '—') + '</span>') +
+        this._dt('הכנסה צפויה', '<span dir="ltr">' + this._escapeHtml(rev.text) + '</span>' + (rev.flag ? ' <span class="pf-badge pf-level-warning">' + this._escapeHtml(rev.flagLabel) + '</span>' : '')) +
+        '</dl></div>';
+    },
+
+    _dt: function (label, valueHtml) {
+      return '<div class="pf-dt"><dt>' + this._escapeHtml(label) + '</dt><dd>' + valueHtml + '</dd></div>';
+    },
+
+    _bindDetailButtons: function (modalId, caseNumber) {
+      const self = this;
+      const el = window.ModalManager.getElement(modalId);
+      if (!el) {
+        return;
+      }
+      const btn = el.querySelector('[data-action="pf-recompute"]');
+      if (btn) {
+        btn.addEventListener('click', function () {
+          window.ModalManager.close(modalId);
+          self._recompute(caseNumber);
+        });
+      }
+    },
+
+    // ═══════════════════════════════════════════
+    // Recompute (recomputeProfitability — audit-first mutation)
+    // ═══════════════════════════════════════════
+
+    _recompute: function (caseNumber) {
+      const self = this;
+      if (!caseNumber || this.recomputing[caseNumber]) {
+        return;
+      }
+      this.recomputing[caseNumber] = true;
+      this._refreshGrid();
+
+      const fn = window.firebase.functions().httpsCallable('recomputeProfitability');
+      fn({ caseNumber: caseNumber })
+        .then(function (result) {
+          self.recomputing[caseNumber] = false;
+          const found = result && result.data && result.data.found;
+          // The onSnapshot will repaint with the fresh doc; toast carries NO cost.
+          if (found === false) {
+            self._toast('error', 'התיק לא נמצא לחישוב.');
+          } else {
+            self._toast('success', 'חישוב הרווחיות עודכן.');
+          }
+          self._refreshGrid();
+        })
+        .catch(function (error) {
+          self.recomputing[caseNumber] = false;
+          self._refreshGrid();
+          // Hebrew message-by-code; never a cost value.
+          self._toast('error', self._errorMessage(error));
+        });
+    },
+
+    // ═══════════════════════════════════════════
+    // Helpers
+    // ═══════════════════════════════════════════
+
+    /** Firestore Timestamp → short relative Hebrew time. null → '—'. */
+    _relativeTime: function (ts) {
+      if (!ts || typeof ts.toDate !== 'function') {
+        return '—';
+      }
+      try {
+        return this._dateToRelative(ts.toDate());
+      } catch (e) {
+        return '—';
+      }
+    },
+
+    _isoToRelative: function (iso) {
+      if (!iso) {
+        return '—';
+      }
+      const d = new Date(iso);
+      if (isNaN(d.getTime())) {
+        return '—';
+      }
+      return this._dateToRelative(d);
+    },
+
+    _dateToRelative: function (date) {
+      const diffMs = Date.now() - date.getTime();
+      const min = Math.floor(diffMs / 60000);
+      if (min < 1) {
+ return 'לפני רגע';
+}
+      if (min < 60) {
+ return 'לפני ' + min + ' דק׳';
+}
+      const hr = Math.floor(min / 60);
+      if (hr < 24) {
+ return 'לפני ' + hr + ' שע׳';
+}
+      const days = Math.floor(hr / 24);
+      if (days < 30) {
+ return 'לפני ' + days + ' ימים';
+}
+      return date.toLocaleDateString('he-IL');
+    },
+
+    /**
+     * Hebrew error message by HttpsError code (mirrors EmployeeCostsPage). NEVER
+     * exposes a raw FirebaseError / English / stack, and never a cost value.
+     */
+    _errorMessage: function (error) {
+      const code = error && error.code ? String(error.code) : '';
+      switch (code) {
+        case 'unauthenticated':
+        case 'functions/unauthenticated':
+          return 'נדרשת התחברות מחדש למערכת. אנא התחבר ונסה שוב.';
+        case 'permission-denied':
+        case 'functions/permission-denied':
+          return 'אין לך הרשאה לצפות בנתוני רווחיות. רק מנהל מערכת רשאי.';
+        case 'invalid-argument':
+        case 'functions/invalid-argument':
+          return 'מספר התיק אינו תקין. נסה שוב.';
+        case 'unavailable':
+        case 'functions/unavailable':
+        case 'deadline-exceeded':
+        case 'functions/deadline-exceeded':
+          return 'השרת אינו זמין כעת. בדוק את החיבור לאינטרנט ונסה שוב.';
+        default:
+          if (error && error.message && /[֐-׿]/.test(error.message)) {
+            return error.message;
+          }
+          return 'אירעה שגיאה בעת ביצוע הפעולה. אנא נסה שוב או פנה לתמיכה.';
+      }
+    },
+
+    _toast: function (type, message) {
+      // message is a fixed Hebrew string by-code — NEVER a cost/profit value.
+      if (window.notify && typeof window.notify[type] === 'function') {
+        window.notify[type](message);
+        return;
+      }
+      if (window.NotificationsUI) {
+        if (type === 'success' && window.NotificationsUI.showSuccess) {
+          window.NotificationsUI.showSuccess(message);
+          return;
+        }
+        if (window.NotificationsUI.showError) {
+          window.NotificationsUI.showError(message);
+          return;
+        }
+      }
+    },
+
+    _escapeHtml: function (str) {
+      if (str === null || str === undefined) {
+        return '';
+      }
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+  };
+
+  window.ProfitabilityPage = ProfitabilityPage;
+})();

--- a/apps/admin-panel/profitability.html
+++ b/apps/admin-panel/profitability.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>רווחיות תיקים | Admin Panel</title>
+
+    <!-- ===== UNIFIED AUTH GUARD (NO PRE-FLIGHT REDIRECT) ===== -->
+    <script>
+        (function() {
+            'use strict';
+            try {
+                var authState = sessionStorage.getItem('authState');
+                if (authState) {
+                    var state = JSON.parse(authState);
+                    var age = Date.now() - (state.timestamp || 0);
+                    window._profitabilityOptimistic = state.isAuthenticated && age < 5 * 60 * 1000;
+                } else {
+                    window._profitabilityOptimistic = false;
+                }
+            } catch (e) {
+                window._profitabilityOptimistic = false;
+            }
+        })();
+    </script>
+
+    <!-- ===== Firebase SDK ===== -->
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-auth-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.22.2/firebase-functions-compat.js"></script>
+
+    <!-- ===== Font Awesome Icons ===== -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    <!-- ===== Design System ===== -->
+    <link rel="stylesheet" href="css/design-system.css">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/components.css">
+    <link rel="stylesheet" href="css/profitability.css">
+</head>
+
+<body class="admin-page">
+    <!-- ===== Navigation Bar ===== -->
+    <div id="navigationContainer"></div>
+
+    <!-- ===== Main Content ===== -->
+    <main class="dashboard-main">
+        <div id="profitability-section" class="dashboard-content">
+            <!-- Profitability dashboard (or access-denied state) rendered here by JS -->
+        </div>
+    </main>
+
+    <!-- ===== Loading Overlay ===== -->
+    <div id="loadingOverlay" class="loading-overlay" style="display: none;">
+        <div class="loading-spinner">
+            <div class="spinner-circle"></div>
+            <p class="loading-text">טוען...</p>
+        </div>
+    </div>
+
+    <!-- ===== Core Scripts ===== -->
+    <script src="js/core/firebase.js"></script>
+    <script src="js/core/system-constants.js"></script>
+    <script src="js/core/config-loader.js"></script>
+    <script src="js/core/auth.js"></script>
+    <script src="js/core/constants.js"></script>
+
+    <!-- ===== Auth Guard ===== -->
+    <script src="js/core/auth-guard.js?v=20250103"></script>
+
+    <!-- ===== Navigation Component ===== -->
+    <script src="js/ui/Navigation.js"></script>
+
+    <!-- ===== Modals + Pure Formatters + Page + Notifications ===== -->
+    <script src="js/ui/Modals.js"></script>
+    <script src="js/core/profitability-format.js"></script>
+    <script src="js/ui/ProfitabilityPage.js"></script>
+    <script src="js/ui/Notifications.js"></script>
+
+    <!-- ===== Page Initialization ===== -->
+    <script>
+        window.addEventListener('storage', (e) => {
+            if (e.key === 'logoutEvent') {
+                // Tear down the live cost listener before leaving (no live financial
+                // listener should survive a cross-tab logout).
+                if (window.ProfitabilityPage && typeof window.ProfitabilityPage.teardown === 'function') {
+                    window.ProfitabilityPage.teardown();
+                }
+                sessionStorage.removeItem('authState');
+                window.location.replace('index.html');
+            }
+        });
+
+        /**
+         * Render a Hebrew access-denied state — used when the authenticated user
+         * is NOT an admin. NO cost UI is rendered and NO onSnapshot / getProfitability
+         * call is made in this branch.
+         */
+        function renderAccessDenied() {
+            const section = document.getElementById('profitability-section');
+            if (!section) {
+                return;
+            }
+            section.innerHTML = ''
+                + '<div class="pf-access-denied" role="alert">'
+                + '  <i class="fas fa-lock" aria-hidden="true"></i>'
+                + '  <h1>אין הרשאת גישה</h1>'
+                + '  <p>דף זה מיועד למנהלי מערכת בלבד. אם לדעתך זו טעות, פנה למנהל המערכת.</p>'
+                + '  <a class="pf-btn pf-btn--secondary" href="index.html" aria-label="חזרה לדף הבית">חזרה לדף הבית</a>'
+                + '</div>';
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            console.log('📊 Profitability Dashboard - Loading...');
+
+            window.initAuthGuard({
+                pageName: 'profitability',
+                timeoutMs: 5000,
+
+                onAuthenticated: async (user) => {
+                    console.log('✅ [Profitability] User authenticated, verifying admin role...');
+
+                    if (window.Navigation) {
+                        window.Navigation.init('profitability');
+                    }
+
+                    // ════════════════════════════════════════════════════════
+                    // EXPLICIT ADMIN ROLE GATE (render-time) — fail CLOSED
+                    // ════════════════════════════════════════════════════════
+                    // initAuthGuard only checks AUTHENTICATION. This page shows
+                    // confidential cost/profit data, so we re-verify the ADMIN ROLE
+                    // from the Firebase ID token claims BEFORE attaching the live
+                    // onSnapshot listener or calling any profitability callable.
+                    // The firestore.rules gate is admin||partner, but the UI stays
+                    // ADMIN-ONLY for now (MASTER_PLAN §8.5 D-E) — so this gate is
+                    // role==='admin' (STRICTER than the rule). Mirrors
+                    // employee-costs.html + js/core/auth.js checkIfAdmin Layer-1.
+                    let isAdmin = false;
+                    try {
+                        const tokenResult = await firebase.auth().currentUser.getIdTokenResult();
+                        const ADMIN_ROLE = (window.ADMIN_PANEL_CONSTANTS
+                            && window.ADMIN_PANEL_CONSTANTS.USER_ROLES
+                            && window.ADMIN_PANEL_CONSTANTS.USER_ROLES.ADMIN) || 'admin';
+                        isAdmin = tokenResult.claims.role === ADMIN_ROLE;
+                    } catch (err) {
+                        // Token read failed — fail CLOSED (treat as non-admin).
+                        console.error('❌ [Profitability] Admin role check failed:', err && err.code);
+                        isAdmin = false;
+                    }
+
+                    if (!isAdmin) {
+                        console.warn('🔒 [Profitability] Non-admin user blocked from the dashboard');
+                        renderAccessDenied();
+                        return;
+                    }
+
+                    console.log('✅ [Profitability] Admin verified, loading dashboard...');
+
+                    if (window.ProfitabilityPage) {
+                        // init() loads the clients (for the Plan JOIN) then attaches
+                        // the client_profitability onSnapshot — all AFTER this gate.
+                        window.ProfitabilityPage.init('profitability-section');
+                    }
+                    console.log('✅ Profitability Dashboard - Ready');
+                },
+
+                onUnauthenticated: () => {
+                    window.location.replace('index.html');
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/tests/unit/admin-panel/profitability-format.test.ts
+++ b/tests/unit/admin-panel/profitability-format.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests — ProfitabilityFormat (H.3 PR4)
+ * ──────────────────────────────────────────
+ * The LOAD-BEARING dashboard render rules as pure functions (no DOM/Firebase):
+ * null≠0 cost rendering, the coverage badge, the hours-vs-Plan color signal, and
+ * the un-priced flag. This is the "customer scenario" test (G4): "actualCost=null
+ * shows 'עלות לא זמינה', NEVER ₪0".
+ */
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore — CommonJS require from a TypeScript ESM test (dual-export module).
+import {
+  formatShekel,
+  formatHours,
+  formatActualCost,
+  coverageBadge,
+  hoursStatus,
+  planRevenue,
+  COST_UNAVAILABLE
+} from '../../../apps/admin-panel/js/core/profitability-format.js';
+
+describe('formatActualCost — null ≠ 0 (the #1 render rule)', () => {
+  it('null → "עלות לא זמינה" (NEVER ₪0), available:false', () => {
+    expect(formatActualCost(null)).toEqual({ text: COST_UNAVAILABLE, available: false });
+  });
+
+  it('undefined → "עלות לא זמינה", available:false', () => {
+    expect(formatActualCost(undefined)).toEqual({ text: COST_UNAVAILABLE, available: false });
+  });
+
+  it('a real 0 (free/intern) → "₪0", available:true (a KNOWN cost, distinct from null)', () => {
+    expect(formatActualCost(0)).toEqual({ text: '₪0', available: true });
+  });
+
+  it('a real cost → grouped ₪, available:true', () => {
+    expect(formatActualCost(9375)).toEqual({ text: '₪9,375', available: true });
+  });
+});
+
+describe('formatShekel + formatHours', () => {
+  it('formatShekel groups thousands; null → empty string', () => {
+    expect(formatShekel(40000)).toBe('₪40,000');
+    expect(formatShekel(1234567)).toBe('₪1,234,567');
+    expect(formatShekel(null)).toBe('');
+  });
+
+  it('formatHours: null → dash, 0 → "0.0" (a real value), 4.92 → "4.9"', () => {
+    expect(formatHours(null)).toBe('—');
+    expect(formatHours(0)).toBe('0.0');
+    expect(formatHours(4.92)).toBe('4.9');
+  });
+});
+
+describe('coverageBadge — un-costed coverage signal', () => {
+  it('no entries → neutral "אין רישומים"', () => {
+    expect(coverageBadge(null, 0)).toEqual({ level: 'neutral', label: 'אין רישומים' });
+  });
+
+  it('0% un-costed (fully costed) → success "מתומחר מלא"', () => {
+    expect(coverageBadge(0, 5)).toEqual({ level: 'success', label: 'מתומחר מלא' });
+  });
+
+  it('100% un-costed (TODAY: no costs entered) → danger "עלות טרם הוזנה"', () => {
+    expect(coverageBadge(100, 5)).toEqual({ level: 'danger', label: 'עלות טרם הוזנה' });
+  });
+
+  it('partial coverage → warning "X% לא מתומחר"', () => {
+    expect(coverageBadge(66.67, 3)).toEqual({ level: 'warning', label: '67% לא מתומחר' });
+  });
+});
+
+describe('hoursStatus — the ONLY color signal in PR4 (hours vs Plan; cost null today)', () => {
+  it('no/zero expectedHours (e.g. fixed-price) → neutral "אין תכנון"', () => {
+    expect(hoursStatus(5, 0).level).toBe('neutral');
+    expect(hoursStatus(5, null).level).toBe('neutral');
+  });
+
+  it('well within plan (ratio ≤ 0.85) → success', () => {
+    expect(hoursStatus(5, 10).level).toBe('success');
+  });
+
+  it('approaching the cap (0.85 < ratio ≤ 1.0) → warning', () => {
+    expect(hoursStatus(9, 10).level).toBe('warning');
+  });
+
+  it('over the planned hours (ratio > 1.0) → danger', () => {
+    expect(hoursStatus(11, 10).level).toBe('danger');
+  });
+
+  it('null actualHours with a plan → treated as 0 hours → success', () => {
+    expect(hoursStatus(null, 10).level).toBe('success');
+  });
+});
+
+describe('planRevenue — un-priced flagging (never a bare ₪0)', () => {
+  it('fully priced → value, no flag', () => {
+    expect(planRevenue({ expectedRevenue: 40000, pricingComplete: true, pricingMissingCount: 0 }))
+      .toEqual({ text: '₪40,000', flag: false, flagLabel: '' });
+  });
+
+  it('pricingMissingCount>0 → flagged "תמחור חסר (N)"', () => {
+    const r = planRevenue({ expectedRevenue: 40000, pricingComplete: false, pricingMissingCount: 2 });
+    expect(r.flag).toBe(true);
+    expect(r.flagLabel).toBe('תמחור חסר (2)');
+  });
+
+  it('no plan → dash, no flag', () => {
+    expect(planRevenue(null)).toEqual({ text: '—', flag: false, flagLabel: '' });
+  });
+});

--- a/tests/unit/admin-panel/profitability-pii-guard.test.ts
+++ b/tests/unit/admin-panel/profitability-pii-guard.test.ts
@@ -1,0 +1,83 @@
+/**
+ * PII source-guard (H.3 PR4) — a cost/profit value must never escape the client.
+ *
+ * `logger.js`'s production override nulls only console.log/info/debug;
+ * console.error / warn SURVIVE in production. The repo is PUBLIC and a case's
+ * actualCost / projectedProfit / paidRevenue is §7.6-confidential (a single-
+ * employee case's actualCost÷actualHours = that employee's exact cost rate).
+ * This static scan asserts the dashboard JS:
+ *   (1) never passes a cost/profit VALUE (actualCost / projectedProfit /
+ *       paidRevenue) to console.* / Logger.*, and
+ *   (2) never writes one to localStorage / sessionStorage / a URL.
+ *
+ * Mirrors tests/unit/admin-panel/employee-costs-pii-guard.test.ts — but the
+ * COST_REF is WIDENED for PR4's richer surface (cost AND profit AND revenue).
+ * Static scan (no import → no DOM/Firebase). Runs in CI via root Vitest.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+/** Strip block + line comments so a comment mentioning a value identifier
+ *  doesn't trip the guard (the `[^:]` before // keeps `://` URLs intact). */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+// The §7.6-sensitive VALUE identifiers — matched as WHOLE identifiers so the
+// page name "Profitability"/"ProfitabilityPage" (which contains "Profit") is
+// NOT flagged: only the exact value accessors actualCost / projectedProfit /
+// paidRevenue (e.g. `data.actualCost`, `forecast.projectedProfit`).
+const COST_REF = /\b(?:actualCost|projectedProfit|paidRevenue)\b/;
+const LOG_WITH_COST =
+  new RegExp('(?:console\\.\\w+|[Ll]ogger\\.\\w+)\\s*\\([^;]*' + COST_REF.source);
+const STORAGE_WITH_COST =
+  new RegExp('(?:localStorage|sessionStorage)\\.setItem\\s*\\([^;]*' + COST_REF.source);
+const URL_WITH_COST =
+  new RegExp(
+    '(?:searchParams\\.(?:set|append)|location\\.(?:href|hash|search)\\s*=)\\s*[^;]*' + COST_REF.source
+  );
+
+const ROOT = process.cwd();
+const FILES = [
+  resolve(ROOT, 'apps/admin-panel/js/ui/ProfitabilityPage.js'),
+  resolve(ROOT, 'apps/admin-panel/js/core/profitability-format.js')
+];
+
+describe('no cost/profit value escapes the client — static source guard', () => {
+  FILES.forEach((file) => {
+    const name = file.split(/[\\/]/).pop();
+    const code = stripComments(readFileSync(file, 'utf8'));
+
+    it(`${name} never passes a cost/profit value to console.*/Logger.*`, () => {
+      expect(code).not.toMatch(LOG_WITH_COST);
+    });
+
+    it(`${name} never writes a cost/profit value to localStorage/sessionStorage`, () => {
+      expect(code).not.toMatch(STORAGE_WITH_COST);
+    });
+
+    it(`${name} never writes a cost/profit value to a URL`, () => {
+      expect(code).not.toMatch(URL_WITH_COST);
+    });
+  });
+
+  it('sanity: the guard regexes DO catch violating patterns', () => {
+    expect('console.log(`x ${data.actualCost}`);').toMatch(LOG_WITH_COST);
+    expect('console.error("fail", forecast.projectedProfit);').toMatch(LOG_WITH_COST);
+    expect('Logger.warn("x", paidRevenue);').toMatch(LOG_WITH_COST);
+    expect("localStorage.setItem('c', actualCost);").toMatch(STORAGE_WITH_COST);
+    expect("sessionStorage.setItem('p', projectedProfit);").toMatch(STORAGE_WITH_COST);
+    expect('url.searchParams.set("c", actualCost);').toMatch(URL_WITH_COST);
+  });
+
+  it('sanity: the guard does NOT flag the page-name string "Profitability"', () => {
+    // The page legitimately logs '[Profitability] ...' + 'ProfitabilityPage: ...'
+    // — neither references a cost/profit VALUE, so the guard must not trip on the
+    // page name (which contains the substring "Profit").
+    expect("console.log('📊 Profitability Dashboard - Loading...');").not.toMatch(LOG_WITH_COST);
+    expect("console.error('ProfitabilityPage: container not found:', sectionId);").not.toMatch(LOG_WITH_COST);
+    expect("console.error('❌ [Profitability] live listener error:', error && error.code);").not.toMatch(LOG_WITH_COST);
+  });
+});


### PR DESCRIPTION
## H.3 PR4 — Profitability Dashboard UI

The FIRST major visible bud (§8.5): a NEW admin-only `apps/admin-panel/profitability.html` — a real-time per-case Profitability dashboard. Reads the CF-only `client_profitability` collection LIVE via `onSnapshot` (PR3's rule permits an admin listener) and JOINs `client.plan` (PR1) in-memory by caseNumber. **FRONTEND-ONLY** (PR3 #373 built the rule + the callables).

### What changed (7 files, additive)
- **`profitability.html`** — clones the PR2 employee-costs shell: RTL `lang="he" dir="rtl"`, `noindex`, the unified auth-guard + a **fail-closed admin render-gate** (`getIdTokenResult().claims.role==='admin'`, any token error → non-admin → `renderAccessDenied`, BEFORE any listener/callable). The gate is `role==='admin'` — **stricter** than the rule's `admin||partner` (the UI stays admin-only per D-E). `teardown()` unsubscribes the live listener on cross-tab logout.
- **`ProfitabilityPage.js`** — ONE `onSnapshot` on `client_profitability` + an in-memory JOIN to `client.plan` (a `clients.get()` with the same internal-client filter as `ClientsDataManager` — no 2nd listener, no plan snapshot). Sortable table, search, status filter (active default); per-row **recompute** (`recomputeProfitability`) + a per-case detail **drawer** (`getProfitability`, the audited single-case fetch); honest-empty / loading / Hebrew-error states.
- **`profitability-format.js`** — pure render rules (null≠0, coverage badge, hours-vs-Plan color, un-priced flag) extracted + unit-tested (dual-export window + CommonJS).
- **`profitability.css`** — design-system tokens only; color tints via the sanctioned channel-derivation (`rgb(.. / N%)` + the explanatory comment) with `-dark` accent text for AA; `:focus-visible` on every interactive element; `ModalManager` drawer.
- **Tests** — `profitability-format` (18) + `profitability-pii-guard` (8, COST_REF widened for `actualCost`/`projectedProfit`/`paidRevenue`).

### Locked checkpoint decisions (Haim, 2026-06-15)
1. Sortable table + per-row recompute + per-case detail drawer.
2. Per-row recompute ONLY + a "חושב לאחרונה" timestamp (no bulk callable exists).
3. **Color on HOURS-vs-Plan only** — actualCost is system-wide `null` today, so no profit alert + no invented X% threshold (deferred to when costs exist).
4. Ship **honest-empty** (`actualCost` → "עלות לא זמינה", NEVER ₪0; coverage badge) — costs + backfill come later (Haim's hands). Profit column HIDDEN ("בהמשך H.6").

### Reviews
- **4-lens investigation** (frontend / data / security / completeness, 2026-06-15).
- **security-access-expert**: admin-only fail-closed gate; cost/profit value never reaches client console/log/DOM-storage/URL (PII guard); zero rules/auth/claims/schema change → **devils-advocate NOT required** (like PR2).
- **outcomes-grader = PASS** (6/6 MUST, 7/7 gates, 3/3 SHOULD, 0 blockers).

### Test plan
- `npx vitest run tests/unit/admin-panel/profitability-format.test.ts tests/unit/admin-panel/profitability-pii-guard.test.ts` → 26/26.
- Root `npm test` → 442 green (no regression). `npx eslint apps/admin-panel/js/...` → 0.
- **Supervised post-merge live-smoke (Haim's hands — the render is auth+backend-gated, not locally observable):** an admin opens `profitability.html` (direct URL — PR5 adds the nav tab) → sees the honest-empty grid (Plan numbers + actualHours + "עלות לא זמינה" + the "חישוב יומי 06:30" banner) → clicks "חשב מחדש" on a case → the row repaints from the `onSnapshot`. A non-admin sees the Hebrew access-denied panel.

### Rollback
Pure `git revert <merge commit>` + redeploy (frontend/Netlify). All 7 files are additive — no existing page, route, collection, Cloud Function, or rule changed, so there is NOTHING to `firebase functions:delete` (unlike PR3). Code-only, ≤5 min.

## PRODUCT-GRADE GATES
- **G1 errors:** PASS — Hebrew loading/empty/error/access-denied; `null` actualCost → "עלות לא זמינה" (never ₪0/NaN/undefined); callable/listener errors → Hebrew-by-code, never a raw FirebaseError/stack.
- **G2 rollback:** PASS — pure `git revert` (additive frontend; no CF/rule to delete). ~5 min.
- **G3 monitoring:** N/A — read-only page + invokes the existing server-audited callables (`getProfitability` audits; `recomputeProfitability` is audit-first); the client adds no data-mutation path; no cost value client-logged.
- **G4 customer test:** PASS — 18 render-rule unit tests (null≠0 / coverage / hours-status) + 8 PII-guard tests + the documented post-merge live-smoke (the render is auth+backend-gated → not locally observable, same approach as PR2 #371).
- **G5 Hebrew UI:** PASS — every customer-facing string Hebrew, RTL.
- **G6 breaking change:** PASS — additive (new page + JS/CSS); nothing existing changed/removed.
- **G7 security:** PASS — security-access-expert reviewed; admin-only fail-closed gate (stricter than the admin||partner rule) + DB rule backstop; cost/profit VALUE never reaches client console/log/DOM-storage/URL (widened PII guard); cost stays off the world-readable clients doc; zero rules/auth/claims/schema change → devils-advocate NOT required.

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)