### PR TITLE
feat(h-3): רווחיות nav tab — reach the Profitability dashboard (PR5, closes H.3)

### DIFF
--- a/.claude/rubrics/pr-h-3-5-nav.md
+++ b/.claude/rubrics/pr-h-3-5-nav.md
@@ -1,0 +1,39 @@
+# Rubric — H.3 PR5: the רווחיות nav tab (closes H.3)
+
+**Title:** Add the `רווחיות` (profitability) tab to the admin Navigation so the PR4 dashboard (`profitability.html`) is reachable from the nav bar (it was direct-URL-only). A ONE-ITEM additive change to `Navigation.js` `navItems`. The final piece of H.3.
+**Branch:** `feat/h-3-pr5-nav`
+**Base:** `main` (PR4 #374 merged + deployed)
+**App / Env:** Admin Panel (frontend). DEV (`main`). Touches the shared `Navigation.js` (an admin-display change — additive only).
+**Effort:** LIGHT (<10 lines). No formal checkpoint (decision-point: tiny change, no architectural impact); no devils-advocate (frontend-only, no rules/auth/schema). PR4 investigation already mapped the Navigation.js surface.
+
+**Context:** `Navigation.js` renders a FIXED `navItems` array; a new page stays invisible until that array is edited (that edit IS this PR). `profitability.html` already calls `Navigation.init('profitability')` (PR4) → the new tab's `id` must be `'profitability'` for active-state to work.
+
+## MUST criteria (block on FAIL)
+
+### M1 — The nav item is correct + complete
+**Rule:** `Navigation.js` `navItems` gains `{ id: 'profitability', label: 'רווחיות', icon: 'fa-money-bill-trend-up', href: 'profitability.html' }`. The `id` is exactly `'profitability'` (matches the page's `Navigation.init('profitability')` for active-state); the `href` is `'profitability.html'`; the `label` is Hebrew; the icon is a valid Font Awesome 6.5.1 class distinct from the existing tabs (workload uses `fa-chart-line`).
+**Evidence:** the `Navigation.js` diff; the `navigation-profitability-tab.test.ts` static guard; `profitability.html` `Navigation.init('profitability')`.
+
+### M2 — Additive only; no existing tab/behavior changed
+**Rule:** The change ADDS one array entry; it does NOT modify/remove any existing tab (users/clients/workload/announcements), the nav buttons (approvals/audit-trail/settings/logout), the render template, the active-state logic, the approval-count listener, or the injected styles. No filtering/counts/states touched (ADMIN SAFETY).
+**Evidence:** `git diff` shows ONLY the one-line insertion in `navItems`; the test asserts the existing 4 tabs still present.
+
+### M3 — Scope clean; suite green
+**Rule:** The diff touches ONLY `apps/admin-panel/js/ui/Navigation.js` + the new test + the rubric — no `functions/`, no `firestore.rules`, no other page, no CRLF/dist drift staged. Root vitest green; lint 0 on the changed JS.
+**Evidence:** `git diff --name-only main...HEAD`; vitest + lint output.
+
+## SHOULD criteria (warn on FAIL)
+### S1 — Placement after `workload` (groups the analytical/management views); the page remains admin-gated by its own render gate (the nav tab is cosmetic — Navigation.js has no role-gating, so a non-admin clicking it still hits `profitability.html`'s fail-closed `role==='admin'` gate + the DB rule).
+### S2 — A supervised post-merge click-smoke (admin → nav shows the רווחיות tab → click → lands on `profitability.html` with the tab active) is documented in the PR body.
+
+## PRODUCT-GRADE GATES (G1–G7)
+- **G1 errors:** N/A — no error path added (a static nav link; the target page owns its own error/empty/access states).
+- **G2 rollback:** PASS — pure `git revert` (one additive array entry). ≤2 min, code-only.
+- **G3 monitoring:** N/A — no data mutation (a nav link).
+- **G4 customer test:** PASS — the static-scan test (the tab exists + correct href + id matches the page's active-state init + existing tabs intact) + a documented manual click-smoke.
+- **G5 Hebrew UI:** PASS — the label `רווחיות` is Hebrew; RTL nav.
+- **G6 breaking change:** PASS — additive (one nav item); no existing tab/route/behavior changed.
+- **G7 security:** N/A — no auth/permissions/PII/rules change. The nav link is cosmetic; access control stays at `profitability.html`'s render gate (PR4) + the firestore.rules `client_profitability` gate (PR3). Navigation.js has no role-gating (pre-existing — a nav link is not access control).
+
+## VERDICT
+`outcomes-grader` must return **PASS** / **PASS_WITH_WARNINGS** before `gh pr create`. Closes H.3 (PR1–PR5 all done).

--- a/apps/admin-panel/js/ui/Navigation.js
+++ b/apps/admin-panel/js/ui/Navigation.js
@@ -55,6 +55,7 @@ return;
                 { id: 'users', label: 'ניהול עובדים', icon: 'fa-users', href: 'index.html' },
                 { id: 'clients', label: 'ניהול לקוחות', icon: 'fa-briefcase', href: 'clients.html' },
                 { id: 'workload', label: 'ניתוח עומס', icon: 'fa-chart-line', href: 'workload.html' },
+                { id: 'profitability', label: 'רווחיות', icon: 'fa-money-bill-trend-up', href: 'profitability.html' },
                 { id: 'announcements', label: 'הודעות מערכת', icon: 'fa-bullhorn', href: 'system-announcements.html' }
             ];
 

--- a/tests/unit/admin-panel/navigation-profitability-tab.test.ts
+++ b/tests/unit/admin-panel/navigation-profitability-tab.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Nav tab guard (H.3 PR5) — the רווחיות tab is wired into the admin Navigation.
+ *
+ * PR4 shipped apps/admin-panel/profitability.html but the page was reachable only
+ * by direct URL (Navigation.js renders a FIXED navItems array — a new page is
+ * invisible until that array is edited). PR5 adds the one nav item. The render is
+ * DOM/auth-gated (not unit-testable headless), so this is a static-scan guard that
+ * the nav item exists + points to the right page + uses the canonical id the page
+ * passes to Navigation.init('profitability') for active-state. Static scan (no
+ * import → no DOM/Firebase). Runs in CI via root Vitest.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const ROOT = process.cwd();
+const NAV = readFileSync(resolve(ROOT, 'apps/admin-panel/js/ui/Navigation.js'), 'utf8');
+const PAGE = readFileSync(resolve(ROOT, 'apps/admin-panel/profitability.html'), 'utf8');
+
+describe('Navigation — רווחיות (profitability) nav tab (H.3 PR5)', () => {
+  it("navItems includes a 'profitability' entry pointing to profitability.html", () => {
+    // Find the profitability navItems object and assert its href + label.
+    const match = NAV.match(/\{[^}]*id:\s*'profitability'[^}]*\}/);
+    expect(match, "a navItems entry with id:'profitability' must exist").not.toBeNull();
+    const entry = match ? match[0] : '';
+    expect(entry).toContain("href: 'profitability.html'");
+    expect(entry).toContain("label: 'רווחיות'");
+  });
+
+  it('the nav id matches the active-state id the page passes to Navigation.init', () => {
+    // profitability.html calls Navigation.init('profitability') — the nav item id
+    // MUST equal that string or the tab never shows active on the page.
+    expect(PAGE).toContain("Navigation.init('profitability')");
+    expect(NAV).toMatch(/id:\s*'profitability'/);
+  });
+
+  it('does not break the existing tabs (users/clients/workload/announcements still present)', () => {
+    ['index.html', 'clients.html', 'workload.html', 'system-announcements.html'].forEach((href) => {
+      expect(NAV).toContain("href: '" + href + "'");
+    });
+  });
+});


### PR DESCRIPTION
## H.3 PR5 — the רווחיות nav tab (the final piece — closes H.3)

PR4 shipped `profitability.html` but it was reachable **only by direct URL** (`Navigation.js` renders a FIXED `navItems` array — a new page is invisible until that array is edited). This PR adds the one nav item, so the Profitability dashboard is reachable from the admin nav bar.

### What changed (3 files, additive)
- **`Navigation.js`** — ONE new `navItems` entry (after `workload`):
  `{ id: 'profitability', label: 'רווחיות', icon: 'fa-money-bill-trend-up', href: 'profitability.html' }`. Active-state auto-works — `profitability.html` already calls `Navigation.init('profitability')` (PR4), and the `id` matches. The icon is distinct from `workload`'s `fa-chart-line`.
- **`navigation-profitability-tab.test.ts`** — a static-scan guard: the tab exists + correct `href` + the `id` matches the page's `Navigation.init('profitability')` (active-state) + the 4 existing tabs are intact.
- **the rubric**.

### Notes
- **Additive only** — no existing tab / button / template / active-state logic / styles changed (ADMIN SAFETY preserved). +1 line in `Navigation.js`.
- The nav link is **cosmetic** — `Navigation.js` has no role-gating (pre-existing). Access control stays at `profitability.html`'s fail-closed `role==='admin'` render gate (PR4) + the `client_profitability` firestore.rules gate (PR3).
- Frontend-only, no rules/auth/schema → **no devils-advocate**.

### Reviews
- **outcomes-grader = PASS** (M1–M3, gates, 0 blockers). The `id`/`href` verified exact (a typo'd id would silently break active-state).

### Test plan
- `npx vitest run tests/unit/admin-panel/navigation-profitability-tab.test.ts` → 3/3.
- Root `npm test` → 445 green (no regression). `npx eslint apps/admin-panel/js/ui/Navigation.js` → 0 errors (4 pre-existing warnings on untouched grandfathered lines).
- **Supervised post-merge click-smoke (Haim's hands):** an admin opens any admin page → the nav bar shows the **רווחיות** tab → click → lands on `profitability.html` with the tab active (the honest-empty grid).

### Rollback
Pure `git revert <merge commit>` + redeploy (one additive array entry). ≤2 min, code-only.

## PRODUCT-GRADE GATES
- **G1 errors:** N/A — a static nav link adds no error path (the target page owns its states).
- **G2 rollback:** PASS — pure `git revert` of one additive line.
- **G3 monitoring:** N/A — no data mutation.
- **G4 customer test:** PASS — the static-scan test (tab exists + href + id matches the page init + existing tabs intact) + the documented click-smoke.
- **G5 Hebrew UI:** PASS — label `רווחיות` is Hebrew, RTL nav.
- **G6 breaking change:** PASS — additive; no existing tab/route/behavior changed.
- **G7 security:** N/A — no auth/rules/PII change; access control stays at the page render gate + the firestore.rules gate.

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)