### PR TITLE
feat(security): cutover fee agreements to signed URLs + ACL-revocation migration (PR-SEC-2)

### DIFF
--- a/.claude/rubrics/pr-sec-2.md
+++ b/.claude/rubrics/pr-sec-2.md
@@ -1,0 +1,66 @@
+# Rubric — PR-SEC-2 (signed-URL cutover + ACL-revocation migration)
+
+**Title:** feat(security): cutover fee agreements to signed URLs — remove makePublic + ACL-revocation migration
+**Branch:** security/fee-agreement-cutover-pr-sec-2
+**Base:** main (after PR-SEC-1 #379 merged)
+**Scope:** The CUTOVER half of the 2-PR remediation. (1) Removes `file.makePublic()` + the permanent public `downloadUrl` from BOTH upload paths so NEW signed-PDF uploads are private. (2) Switches the admin viewer (`ClientManagementModal.viewFeeAgreement`) to fetch a short-lived signed URL on demand via the PR-SEC-1 `getFeeAgreementUrl` callable instead of opening a stored public URL. (3) Adds a one-time migration script that revokes the public ACL on EXISTING agreement objects (clients/ + cases/, incl. orphans) and nulls the stale stored `downloadUrl`. The `--apply` run is a SEPARATE supervised step (Haim's hands), AFTER deploy + the getFeeAgreementUrl live-smoke.
+
+## MUST criteria (block on FAIL)
+
+### M1 — makePublic removed from BOTH upload paths
+**Rule:** Neither `functions/fee-agreements/index.js` nor `functions/src/whatsapp-bot/WhatsAppBot.js` calls `file.makePublic()` anymore; new uploads stay private.
+**Evidence:** the two diffs; AST guard test "does NOT call makePublic()" (both files).
+
+### M2 — No permanent public downloadUrl stored
+**Rule:** Neither upload path constructs a `storage.googleapis.com` URL or writes a `downloadUrl` field into the agreement record; `storagePath` is preserved.
+**Evidence:** the diffs; AST guard "does NOT store a permanent public downloadUrl" (both files).
+
+### M3 — Viewer fetches a fresh signed URL via the callable
+**Rule:** `viewFeeAgreement` calls `getFeeAgreementUrl({entity:'clients', entityId, agreementId})` and opens the returned URL; it no longer reads `agreement.downloadUrl`. Popup-safe (opens the tab inside the click gesture, before the await). Hebrew error on failure.
+**Evidence:** `ClientManagementModal.js` diff; AST guard "viewFeeAgreement calls getFeeAgreementUrl, not a stored downloadUrl".
+
+### M4 — Migration is safe (dry-run default, backup, idempotent, per-record)
+**Rule:** `revoke-fee-agreement-public-acls.js` is DRY-RUN by default (`--apply` to mutate); writes a durable local JSON backup of the OLD state (rollback key) BEFORE any mutation; `makePrivate()` is idempotent (already-private = no-op); per-record try/catch; batched Firestore writes; NO PII in console.
+**Evidence:** the script; `planDocRevocation` unit tests; the gitignored `functions/security-migration-backups/` entry.
+
+### M5 — Old docs stay viewable with zero data backfill
+**Rule:** Every existing agreement record already carries `storagePath` (both writers wrote it), so the callable resolves the URL for historical docs without any backfill. Nulling `downloadUrl` does not remove `storagePath`.
+**Evidence:** `planDocRevocation` preserves storagePath (test "strips downloadUrl, preserves storagePath"); the callable resolves from storagePath (PR-SEC-1).
+
+### M6 — Tests: pure planner + AST regression guards
+**Rule:** Unit tests for `planDocRevocation` (strip/preserve/prefix/garbage/multi) + AST guards locking the leak out (makePublic absent, no downloadUrl stored, viewer uses the callable).
+**Evidence:** `functions/tests/revoke-fee-agreement-acls.test.js` — 11 tests pass.
+
+### M7 — No behavior regression
+**Rule:** Full functions test suite stays green; the upload flow still stores the agreement record + updates the doc (minus downloadUrl); rendering/badges unaffected (they never used downloadUrl).
+**Evidence:** full functions suite green; `renderFeeAgreements`/`ClientsTable`/`ClientsDataManager` use only id/length/meta (verified).
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Migration backup is gitignored (no PII committed)
+**Evidence:** `.gitignore` `functions/security-migration-backups/` entry (old arrays embed clientId/caseId + storagePath).
+
+### S2 — Migration script is testable (require.main guard + exported pure core)
+**Evidence:** `module.exports = { planDocRevocation, expectedPrefix }` + `if (require.main === module)` guard — requiring it does NOT run main / init admin.
+
+### S3 — Popup-blocker-safe viewer
+**Evidence:** opens `window.open('', '_blank')` synchronously, sets `.location` after the await; falls back if blocked.
+
+## Out of scope (deliberately deferred / supervised)
+
+- The migration `--apply` execution — a supervised step (Haim's hands), AFTER PR-SEC-2 deploys + getFeeAgreementUrl is live-smoked. This PR ships the SCRIPT only.
+- The `roles/iam.serviceAccountTokenCreator` signBlob grant + `iamcredentials.googleapis.com` enable — Haim's PR-SEC-1 runtime prerequisite (gates the live-smoke that in turn gates this PR's merge).
+- Restricting client-SDK writes to `feeAgreements` (firestore.rules / client-writer.js) — devils-advocate #2 follow-up. The PR-SEC-1 confused-deputy prefix-pin already neutralizes the read-oracle; this is extra defense-in-depth, tracked separately.
+- Storage-rules emulator harness — none exists (pre-existing gap).
+
+## Rollback
+
+- **Code:** `git revert <sha>` + `firebase deploy --only functions` + redeploy admin-panel (Netlify). Restores makePublic + the stored downloadUrl going forward.
+- **Migration (if `--apply` was run):** from the backup JSON (`functions/security-migration-backups/revoke-acls-plan-*.json`): re-`set` each doc's `feeAgreements` to `oldAgreements` and `file.makePublic()` each path. NOTE: this re-opens the leak — only do it under a genuine regression, and prefer fixing forward.
+
+## Notes for grader
+
+- **DEPLOY-ORDER GATE (critical):** PR-SEC-2 must NOT merge/deploy until PR-SEC-1's `getFeeAgreementUrl` is live AND live-smoked (which needs Haim's signBlob IAM grant). If PR-SEC-2 deploys before the callable can sign, the admin viewer breaks (G1). PR-SEC-1 is merged + deployed (callable live); the IAM grant + smoke are Haim's pending steps. STOP before merge regardless (Haim merges).
+- **Residual-leak window (intended):** after PR-SEC-2 deploys, NEW uploads are private + the viewer uses signed URLs, but EXISTING objects stay public until the supervised `--apply` migration revokes their ACLs. Full closure = PR-SEC-2 deploy + migration `--apply`. This is the approved sequence.
+- **G6 breaking change:** the upload callable's returned `agreement` + the stored record no longer include `downloadUrl`. Verified safe — the ONLY reader was `viewFeeAgreement` (now uses the callable); `renderFeeAgreements`/table/badges never read it. Migration plan covers existing docs.
+- **Specialists:** security-access-expert (investigation: signed-URL + revoke+null migration) + devils-advocate (MANDATORY — runs before merge; makePublic removal + PROD migration).

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ backups/
 #   - backfill-cost-per-hour.js            (H.2 — employee<->entry email mapping)
 #   - backfill-strip-legal-hourly-rate.js  (H.3 — clientId + services[] before-state)
 functions/backfill-backups/
+# One-time security migration before-state (old feeAgreements[] incl. downloadUrl
+# which embeds clientId/caseId + storagePath; the rollback key). Stay local. Used by:
+#   - revoke-fee-agreement-public-acls.js  (PR-SEC-2 — ACL revocation + downloadUrl null)
+functions/security-migration-backups/
 
 # IDE
 .vscode/

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -2072,16 +2072,43 @@ return;
          * View fee agreement
          * צפייה בהסכם שכר טרחה
          */
-        viewFeeAgreement(agreementId) {
+        async viewFeeAgreement(agreementId) {
             const agreement = this.currentClient?.feeAgreements?.find(a => a.id === agreementId);
 
-            if (!agreement || !agreement.downloadUrl) {
-                this.showNotification('לא ניתן לפתוח את ההסכם', 'error');
+            if (!agreement) {
+                this.showNotification('הסכם לא נמצא', 'error');
                 return;
             }
 
-            // Open in new tab
-            window.open(agreement.downloadUrl, '_blank');
+            // Security (PR-SEC-2): the PDF is private — fetch a short-lived signed URL
+            // on demand via getFeeAgreementUrl (no permanent public URL). Open the new
+            // tab SYNCHRONOUSLY (inside the click gesture, before the await) so the
+            // browser doesn't block it as a popup, then navigate it once the URL returns.
+            const viewTab = window.open('', '_blank');
+            try {
+                const getUrlFn = window.firebaseFunctions.httpsCallable('getFeeAgreementUrl');
+                const result = await getUrlFn({
+                    entity: 'clients',
+                    entityId: this.currentClient.id,
+                    agreementId: agreementId
+                });
+                const url = result?.data?.url;
+                if (!url) {
+                    throw new Error('missing-url');
+                }
+                if (viewTab) {
+                    viewTab.location = url;
+                } else {
+                    // popup was blocked — fall back to a same-context navigation
+                    window.open(url, '_blank');
+                }
+            } catch (error) {
+                if (viewTab) {
+                    viewTab.close();
+                }
+                console.error('❌ Error opening fee agreement:', error);
+                this.showNotification('לא ניתן לפתוח את ההסכם כעת. נסה שוב או פנה לתמיכה.', 'error');
+            }
         }
 
         /**

--- a/functions/fee-agreements/index.js
+++ b/functions/fee-agreements/index.js
@@ -115,23 +115,19 @@ const uploadFeeAgreement = functions.https.onCall(async (data, context) => {
       }
     });
 
-    // 8. Get download URL
-    await file.makePublic();
-    const downloadUrl = `https://storage.googleapis.com/${bucket.name}/${storagePath}`;
+    // 8. (Security — PR-SEC-2) Do NOT make the object public. Signed fee-agreement
+    // PDFs (client name + ת"ז + signatures + fee terms) stay PRIVATE; the admin
+    // views them on demand via the `getFeeAgreementUrl` callable, which mints a
+    // short-lived V4 signed URL from `storagePath`. The legacy `file.makePublic()`
+    // + permanent public downloadUrl was a world-readable leak that bypassed
+    // storage.rules (חוק הגנת הפרטיות / חיסיון עו"ד-לקוח). No downloadUrl is stored.
 
-    // Alternative: Use signed URL (more secure but expires)
-    // const [signedUrl] = await file.getSignedUrl({
-    //   action: 'read',
-    //   expires: Date.now() + 365 * 24 * 60 * 60 * 1000 // 1 year
-    // });
-
-    // 9. Create agreement metadata
+    // 9. Create agreement metadata (storagePath only — the URL is resolved on demand)
     const agreementData = {
       id: agreementId,
       fileName: sanitizedFileName,
       originalName: data.fileName,
       storagePath: storagePath,
-      downloadUrl: downloadUrl,
       fileType: data.fileType,
       fileSize: fileSize,
       uploadedAt: admin.firestore.Timestamp.now(),

--- a/functions/scripts/revoke-fee-agreement-public-acls.js
+++ b/functions/scripts/revoke-fee-agreement-public-acls.js
@@ -1,0 +1,215 @@
+/**
+ * revoke-fee-agreement-public-acls.js — PR-SEC-2 one-time migration
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Closes the world-readable fee-agreement leak for EXISTING objects. The upload
+ * paths used `file.makePublic()` (an object-level allUsers:READER ACL that bypasses
+ * storage.rules) + stored a permanent public `downloadUrl`. PR-SEC-2 removed the
+ * makePublic from the upload paths; this script revokes the ACL on already-uploaded
+ * objects AND nulls the stale stored `downloadUrl` (which would otherwise be a dead
+ * 403 pointer that also leaks the storage layout to every authenticated reader of
+ * the world-readable `clients` doc).
+ *
+ * Three phases (backup-FIRST — the F2 PROD-migration invariant):
+ *   SCAN (read-only): iterate `clients` + `cases`; build the doc-update plan (which
+ *     feeAgreements arrays carry a `downloadUrl` to strip) and the storage-object
+ *     plan (every object under clients|cases /agreements/). NO mutations.
+ *   BACKUP: write the durable local JSON (OLD feeAgreements arrays + object paths —
+ *     the rollback key) to disk BEFORE any mutation runs.
+ *   EXECUTE (only with `--apply`): PASS 1 rewrites each planned doc's feeAgreements
+ *     WITHOUT downloadUrl (storagePath preserved); PASS 2 `makePrivate()`s every
+ *     planned object (idempotent — already-private is a no-op; catches orphans too).
+ *
+ * Safety (mirrors functions/scripts/backfill-cost-per-hour.js; NON-interactive §8.4):
+ *   • DRY-RUN by default. `--apply` to mutate. No interactive prompt.
+ *   • Durable local JSON backup written BEFORE any mutation (read-only scan first).
+ *   • Per-record try/catch (one bad doc/object never aborts the run).
+ *   • Batched Firestore writes (≤450/commit), each commit wrapped (a failed batch
+ *     is logged + counted, never aborts the rest).
+ *   • NO PII in console output (only counts + business ids / storagePaths).
+ *
+ * Rollback: from the backup JSON, re-set each doc's feeAgreements to `oldAgreements`
+ *   and `file.makePublic()` each path (ONLY if a regression forces it — the whole
+ *   point is that these should NOT be public).
+ *
+ * Usage (from functions/, AFTER PR-SEC-2 deploys + getFeeAgreementUrl is live+smoked):
+ *   node scripts/revoke-fee-agreement-public-acls.js            # dry-run (default)
+ *   node scripts/revoke-fee-agreement-public-acls.js --apply    # mutate
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const admin = require('firebase-admin');
+
+const COLLECTIONS = ['clients', 'cases'];
+const COMMIT = 450;
+
+/** The folder shape every legitimate uploader writes. */
+function expectedPrefix(collection, entityId) {
+  return `${collection}/${entityId}/agreements/`;
+}
+
+/**
+ * PURE core (exported for unit tests): given a doc's feeAgreements array, compute
+ * the rewrite that strips `downloadUrl` and the list of objects to revoke.
+ *
+ * @returns {{ changed: boolean, newAgreements: object[], items: Array<{agreementId, storagePath, hadDownloadUrl, prefixOk}> }}
+ */
+function planDocRevocation(feeAgreements, collection, entityId) {
+  const list = Array.isArray(feeAgreements) ? feeAgreements : [];
+  const prefix = expectedPrefix(collection, entityId);
+  let changed = false;
+  const items = [];
+  const newAgreements = list.map((a) => {
+    const rec = a && typeof a === 'object' ? a : {};
+    const storagePath = typeof rec.storagePath === 'string' ? rec.storagePath : '';
+    const hadDownloadUrl = typeof rec.downloadUrl === 'string' && rec.downloadUrl.length > 0;
+    items.push({
+      agreementId: typeof rec.id === 'string' ? rec.id : null,
+      storagePath,
+      hadDownloadUrl,
+      prefixOk: storagePath.startsWith(prefix)
+    });
+    if (hadDownloadUrl) {
+      changed = true;
+      // strip the dead public URL; preserve everything else (storagePath included)
+      const rest = { ...rec };
+      delete rest.downloadUrl;
+      return rest;
+    }
+    return rec;
+  });
+  return { changed, newAgreements, items };
+}
+
+// ─── Side-effecting runner (skipped when required as a module for tests) ──────
+async function main() {
+  const APPLY = process.argv.includes('--apply');
+  if (!admin.apps.length) {
+    admin.initializeApp();
+  }
+  const db = admin.firestore();
+  const bucket = admin.storage().bucket();
+
+  console.log(`\n[revoke-acls] mode=${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+  const counts = {
+    docsScanned: 0, docsToUpdate: 0, docsUpdated: 0,
+    objectsListed: 0, objectsToRevoke: 0, objectsRevoked: 0,
+    prefixMismatches: 0, errors: 0
+  };
+  const backup = { mode: APPLY ? 'apply' : 'dry-run', docs: [], objects: [] };
+  const docPlan = [];    // { ref, newAgreements } — built read-only, executed later
+  const objectPlan = []; // File handles — built read-only, executed later
+
+  // ─── SCAN PHASE (read-only) — Firestore docs needing a downloadUrl strip ───
+  for (const collection of COLLECTIONS) {
+    let cursor = null;
+    for (;;) {
+      let q = db.collection(collection).orderBy('__name__').limit(500);
+      if (cursor) q = q.startAfter(cursor);
+      const page = await q.get();
+      if (page.empty) break;
+      cursor = page.docs[page.docs.length - 1];
+
+      for (const doc of page.docs) {
+        counts.docsScanned += 1;
+        try {
+          const data = doc.data() || {};
+          if (!Array.isArray(data.feeAgreements) || data.feeAgreements.length === 0) continue;
+          const { changed, newAgreements, items } = planDocRevocation(
+            data.feeAgreements, collection, doc.id
+          );
+          items.forEach((it) => {
+            if (it.storagePath && !it.prefixOk) counts.prefixMismatches += 1;
+          });
+          if (!changed) continue;
+          counts.docsToUpdate += 1;
+          backup.docs.push({ collection, docId: doc.id, oldAgreements: data.feeAgreements });
+          docPlan.push({ ref: doc.ref, newAgreements });
+        } catch (err) {
+          counts.errors += 1;
+          console.error(`[revoke-acls] scan doc ${collection}/${doc.id} failed: ${err && err.code ? err.code : 'error'}`);
+        }
+      }
+      console.log(`[revoke-acls] SCAN ${collection}: scanned ${counts.docsScanned}, toUpdate ${counts.docsToUpdate}`);
+    }
+  }
+
+  // ─── SCAN PHASE (read-only) — Storage objects to makePrivate (incl. orphans) ──
+  for (const collection of COLLECTIONS) {
+    let pageToken;
+    for (;;) {
+      const [files, , apiResp] = await bucket.getFiles({
+        prefix: `${collection}/`, autoPaginate: false, maxResults: 1000, pageToken
+      });
+      for (const file of files) {
+        if (!file.name.includes('/agreements/')) continue;
+        counts.objectsListed += 1;
+        counts.objectsToRevoke += 1;
+        backup.objects.push(file.name);
+        objectPlan.push(file);
+      }
+      pageToken = apiResp && apiResp.nextPageToken;
+      if (!pageToken) break;
+    }
+    console.log(`[revoke-acls] SCAN ${collection}: objectsToRevoke ${counts.objectsToRevoke}`);
+  }
+
+  // ─── BACKUP PHASE — durable JSON written BEFORE any mutation (F2 invariant) ──
+  const backupDir = path.resolve(__dirname, '../security-migration-backups');
+  if (!fs.existsSync(backupDir)) fs.mkdirSync(backupDir, { recursive: true });
+  // Unique per-run filename (timestamp) — a dry-run then --apply, or a partial-crash
+  // re-run, must NEVER overwrite an earlier run's rollback key (devils-advocate #3).
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupFile = path.join(backupDir, `revoke-acls-plan-${stamp}-${counts.docsScanned}docs.json`);
+  fs.writeFileSync(backupFile, JSON.stringify({ counts, ...backup }, null, 2));
+  console.log(`[revoke-acls] backup written to ${backupFile} (BEFORE any mutation)`);
+  if (counts.prefixMismatches > 0) {
+    console.warn(`[revoke-acls] ⚠️ ${counts.prefixMismatches} agreement(s) had a storagePath OUTSIDE the expected entity folder — review the backup before --apply.`);
+  }
+
+  // ─── EXECUTE PHASE — mutate ONLY with --apply, from the persisted plan ───────
+  if (APPLY) {
+    // PASS 1 — Firestore: strip stale downloadUrl (batched; per-commit safe).
+    let batch = db.batch();
+    let pending = 0;
+    for (const item of docPlan) {
+      batch.update(item.ref, { feeAgreements: item.newAgreements });
+      pending += 1;
+      if (pending >= COMMIT) {
+        try { await batch.commit(); counts.docsUpdated += pending; }
+        catch (err) { counts.errors += pending; console.error(`[revoke-acls] batch commit failed (${pending} docs): ${err && err.code ? err.code : 'error'}`); }
+        batch = db.batch(); pending = 0;
+      }
+    }
+    if (pending > 0) {
+      try { await batch.commit(); counts.docsUpdated += pending; }
+      catch (err) { counts.errors += pending; console.error(`[revoke-acls] final batch commit failed (${pending} docs): ${err && err.code ? err.code : 'error'}`); }
+    }
+
+    // PASS 2 — Storage: makePrivate every planned object (idempotent; per-object safe).
+    for (const file of objectPlan) {
+      try {
+        await file.makePrivate(); // idempotent: already-private = no-op
+        counts.objectsRevoked += 1;
+      } catch (err) {
+        counts.errors += 1;
+        console.error(`[revoke-acls] makePrivate ${file.name} failed: ${err && err.code ? err.code : 'error'}`);
+      }
+    }
+  }
+
+  console.log(`\n[revoke-acls] DONE — ${JSON.stringify(counts)}`);
+  console.log(`[revoke-acls] plan written to ${backupFile}`);
+  if (!APPLY) console.log('[revoke-acls] DRY-RUN — no mutations. Re-run with --apply to revoke.');
+}
+
+module.exports = { planDocRevocation, expectedPrefix };
+
+if (require.main === module) {
+  main().then(() => process.exit(0)).catch((err) => {
+    console.error('[revoke-acls] FATAL:', err && err.message ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/functions/src/whatsapp-bot/WhatsAppBot.js
+++ b/functions/src/whatsapp-bot/WhatsAppBot.js
@@ -1901,19 +1901,18 @@ ${selectedClient.idNumber ? `🆔 ת.ז. ${selectedClient.idNumber}\n` : ''}📄
                 }
             });
 
-            // הפוך לציבורי
-            await file.makePublic();
+            // אבטחה (PR-SEC-2): לא הופכים את הקובץ לציבורי. הסכמי שכ"ט חתומים
+            // (שם + ת"ז + חתימות + תנאים כספיים) נשארים פרטיים; הצפייה נעשית לפי
+            // דרישה דרך ה-callable getFeeAgreementUrl (URL חתום קצר-מועד מתוך
+            // storagePath). makePublic + downloadUrl קבוע היה דליפה גלויה-לכל
+            // שעקפה את storage.rules. לא נשמר downloadUrl.
 
-            // קבל URL להורדה
-            const downloadUrl = `https://storage.googleapis.com/${bucket.name}/${storagePath}`;
-
-            // הכן נתוני מסמך
+            // הכן נתוני מסמך (storagePath בלבד — ה-URL נפתר לפי דרישה)
             const agreementData = {
                 id: agreementId,
                 fileName: sanitizedFileName,
                 originalName: fileName,
                 storagePath: storagePath,
-                downloadUrl: downloadUrl,
                 fileType: contentType,
                 fileSize: fileSize,
                 uploadedAt: admin.firestore.Timestamp.now(),

--- a/functions/tests/revoke-fee-agreement-acls.test.js
+++ b/functions/tests/revoke-fee-agreement-acls.test.js
@@ -1,0 +1,118 @@
+/**
+ * PR-SEC-2 — cutover + migration tests
+ * ─────────────────────────────────────────────────────────────────────────────
+ * (a) planDocRevocation (pure core of revoke-fee-agreement-public-acls.js): strips
+ *     the stale downloadUrl, preserves storagePath + other fields, flags prefix
+ *     mismatches, and is a no-op when there is nothing to strip.
+ * (b) AST regression guards — the makePublic leak must NOT reappear in either
+ *     upload path, no permanent public downloadUrl is stored, and the admin viewer
+ *     goes through the getFeeAgreementUrl callable (not a stored downloadUrl).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { planDocRevocation, expectedPrefix } =
+  require('../scripts/revoke-fee-agreement-public-acls');
+
+const REPO = path.resolve(__dirname, '..', '..');
+
+// ════════════════════════════════════════════════════════════════════════════
+// (a) planDocRevocation — pure
+// ════════════════════════════════════════════════════════════════════════════
+describe('planDocRevocation', () => {
+  const good = {
+    id: 'agreement_1700000000000',
+    storagePath: 'clients/2025992/agreements/agreement_1700000000000.pdf',
+    downloadUrl: 'https://storage.googleapis.com/bucket/clients/2025992/agreements/x.pdf',
+    fileType: 'application/pdf',
+    fileSize: 12345,
+    originalName: 'hesken.pdf'
+  };
+
+  it('strips downloadUrl, preserves storagePath + every other field', () => {
+    const { changed, newAgreements, items } = planDocRevocation([good], 'clients', '2025992');
+    expect(changed).toBe(true);
+    expect(newAgreements).toHaveLength(1);
+    expect(newAgreements[0]).not.toHaveProperty('downloadUrl');
+    expect(newAgreements[0].storagePath).toBe(good.storagePath);
+    expect(newAgreements[0].id).toBe(good.id);
+    expect(newAgreements[0].fileType).toBe('application/pdf');
+    expect(newAgreements[0].originalName).toBe('hesken.pdf');
+    expect(items[0]).toMatchObject({ agreementId: good.id, hadDownloadUrl: true, prefixOk: true });
+  });
+
+  it('no-op when no item carries a downloadUrl', () => {
+    const noUrl = { id: 'a1', storagePath: 'clients/1/agreements/a1.pdf', fileType: 'application/pdf' };
+    const { changed, newAgreements } = planDocRevocation([noUrl], 'clients', '1');
+    expect(changed).toBe(false);
+    expect(newAgreements[0]).toEqual(noUrl);
+  });
+
+  it('flags a storagePath outside the entity folder (prefix mismatch)', () => {
+    const poisoned = { id: 'a2', storagePath: 'clients/9999/agreements/leak.pdf', downloadUrl: 'http://x' };
+    const { items } = planDocRevocation([poisoned], 'clients', '2025992');
+    expect(items[0].prefixOk).toBe(false);
+  });
+
+  it('handles the cases/ collection prefix', () => {
+    const c = { id: 'a3', storagePath: 'cases/CASE1/agreements/a3.pdf', downloadUrl: 'http://x' };
+    const { items } = planDocRevocation([c], 'cases', 'CASE1');
+    expect(items[0].prefixOk).toBe(true);
+    expect(expectedPrefix('cases', 'CASE1')).toBe('cases/CASE1/agreements/');
+  });
+
+  it('tolerates non-array / garbage feeAgreements', () => {
+    expect(planDocRevocation(undefined, 'clients', '1')).toMatchObject({ changed: false, newAgreements: [] });
+    expect(planDocRevocation(null, 'clients', '1').changed).toBe(false);
+    const { changed, newAgreements } = planDocRevocation([null, 42, good], 'clients', '2025992');
+    expect(changed).toBe(true);              // the one good item still strips
+    expect(newAgreements).toHaveLength(3);
+  });
+
+  it('strips downloadUrl from EACH item in a multi-agreement array', () => {
+    const a = { ...good, id: 'a1' };
+    const b = { ...good, id: 'b1', storagePath: 'clients/2025992/agreements/b1.pdf' };
+    const { newAgreements } = planDocRevocation([a, b], 'clients', '2025992');
+    expect(newAgreements.every((x) => !('downloadUrl' in x))).toBe(true);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// (b) AST regression guards — the leak must not reappear
+// ════════════════════════════════════════════════════════════════════════════
+function readSrc(rel) {
+  return fs.readFileSync(path.join(REPO, rel), 'utf8');
+}
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+describe('upload paths no longer leak (makePublic removed)', () => {
+  const uploadFiles = [
+    'functions/fee-agreements/index.js',
+    'functions/src/whatsapp-bot/WhatsAppBot.js'
+  ];
+
+  it.each(uploadFiles)('%s does NOT call makePublic()', (rel) => {
+    const code = stripComments(readSrc(rel));
+    expect(code).not.toMatch(/\.makePublic\s*\(/);
+  });
+
+  it.each(uploadFiles)('%s does NOT store a permanent public downloadUrl', (rel) => {
+    const code = stripComments(readSrc(rel));
+    // no `downloadUrl: ...` field written into the agreement record
+    expect(code).not.toMatch(/downloadUrl\s*:/);
+    // no hand-built public storage.googleapis.com URL
+    expect(code).not.toMatch(/storage\.googleapis\.com/);
+  });
+});
+
+describe('admin viewer uses the signed-URL callable', () => {
+  const rel = 'apps/admin-panel/js/ui/ClientManagementModal.js';
+  it('viewFeeAgreement calls getFeeAgreementUrl, not a stored downloadUrl', () => {
+    const code = stripComments(readSrc(rel));
+    expect(code).toContain("httpsCallable('getFeeAgreementUrl')");
+    expect(code).not.toMatch(/window\.open\(\s*agreement\.downloadUrl/);
+  });
+});


### PR DESCRIPTION
## Summary
PR-SEC-2 is the CUTOVER half of the 2-PR fee-agreement-leak remediation. PR-SEC-1 (#379, merged + deployed) added the dormant getFeeAgreementUrl callable. This PR cuts over to it and revokes the legacy public access:
- Removes file.makePublic() + the permanent public downloadUrl from BOTH upload paths (functions/fee-agreements/index.js, functions/src/whatsapp-bot/WhatsAppBot.js) — new signed-PDF uploads are PRIVATE; only storagePath is stored.
- ClientManagementModal.viewFeeAgreement now fetches a short-lived signed URL on demand via getFeeAgreementUrl (popup-safe: opens the tab inside the click, navigates after the await); Hebrew error on failure; no stored downloadUrl read.
- New one-time migration scripts/revoke-fee-agreement-public-acls.js — three phases SCAN (read-only) then BACKUP (durable JSON written BEFORE any mutation) then EXECUTE (only with --apply): PASS1 strips the stale downloadUrl across clients+cases (storagePath preserved), PASS2 makePrivate() every object under clients|cases /agreements/ (idempotent, catches orphans). dry-run default; per-record try/catch; per-run unique backup filename; exported pure planDocRevocation + require.main guard.
- 11 tests (planDocRevocation unit + AST regression guards: makePublic absent, no downloadUrl stored, viewer uses the callable). Full functions suite 989/989 green; lint 0 on changed files. security-migration-backups/ gitignored.

## Reviews
- outcomes-grader: VERDICT: PASS_WITH_WARNINGS — 7/7 MUST, all gates PASS or N/A, 989/989 tests, lint 0. Its one warning (backup-after-mutate) was FIXED in this commit via the SCAN-then-BACKUP-then-EXECUTE restructure.
- security-access-expert: investigation — signed-URL + revoke+null migration; HIGH severity (privilege + privacy law).
- devils-advocate (MANDATORY — makePublic removal + PROD migration): PROCEED WITH CAUTION. 1 red = operational deploy-order (not a code defect, see the gate below); 2 yellow folded — backup filename collision FIXED (per-run timestamp), and the cases-entity check added as a pre-apply step; 2 green (broad-revoke is intentional/idempotent; G6 has no live consumer). Confirmed: the migration does NOT need signBlob (makePrivate is an ACL op, not URL signing).

## DEPLOY-ORDER GATE (the critical item — Haim, before merge)
The cutover deletes the old public-URL viewer; the new viewer needs the callable to SIGN, which needs the runtime SA to hold roles/iam.serviceAccountTokenCreator (itself) + iamcredentials.googleapis.com enabled. Required order, non-negotiable:
1. Grant the signBlob IAM + enable the API.
2. Live-smoke getFeeAgreementUrl (admin invokes it, confirm it returns a working signed URL) — deploy-green is NOT enough.
3. THEN merge/deploy this PR (frontend cuts over).
4. THEN run the migration --apply (supervised) — LAST, least-reversible. Before --apply, confirm whether any cases doc holds a fee agreement (the admin viewer is clients-only; cases-stored agreements have no viewer and would become un-viewable — latent, not a new regression).
If IAM+smoke are not confirmed YES, do NOT deploy the frontend (it would make the view button a 100%-failure path with no fallback).

## PRODUCT-GRADE GATES
- G1 errors professional: PASS — viewer failure shows a Hebrew message with a next-action; no stack/undefined/raw-FirebaseError to the client.
- G2 rollback: PASS — see Rollback below (git revert + redeploy; migration rollback from the durable per-run backup JSON).
- G3 monitoring: PASS — migration logs counts per phase + writes the plan file; upload paths keep their audit/log; viewer logs console.error on failure.
- G4 test proves scenario: PASS — 11 tests (planDocRevocation strip/preserve/prefix/garbage/multi + AST guards locking the leak out). End-to-end view = the supervised live-smoke (documented).
- G5 Hebrew text: PASS — new customer-facing strings are Hebrew; English confined to logs/identifiers/comments.
- G6 breaking change: DECLARED — the uploadFeeAgreement callable return + stored record no longer carry downloadUrl. Verified the ONLY reader was viewFeeAgreement (now uses the callable); renderFeeAgreements/table/badges never read it; user-app + WhatsApp never read it. No live consumer breaks. Migration covers existing docs.
- G7 security reviewed: PASS — security-access-expert + devils-advocate consulted (verdicts above). This is the security remediation itself.

## Rollback
- Code: git revert <sha> + firebase deploy --only functions + redeploy admin-panel (Netlify). Restores makePublic + stored downloadUrl going forward.
- Migration (only if --apply ran): from the per-run backup JSON (functions/security-migration-backups/revoke-acls-plan-*.json) re-set each doc feeAgreements to oldAgreements and makePublic() each path. NOTE: that re-opens the leak — only under a genuine regression; prefer fixing forward.

## Out of scope (supervised / follow-up)
- The migration --apply execution (Haim, after deploy + IAM + smoke). This PR ships the SCRIPT only.
- The signBlob IAM grant + live-smoke (PR-SEC-1 runtime prerequisite, Haim).
- Restricting client-SDK writes to feeAgreements (firestore.rules) — extra defense-in-depth; the PR-SEC-1 confused-deputy prefix-pin already neutralizes the read-oracle. Tracked.

## STOP before merge
Per the working agreement, Haim merges — and only after the DEPLOY-ORDER GATE above is satisfied (IAM + live-smoke confirmed).