### PR TITLE
fix(security): escape user-controllable fields in client activity report (stored-XSS)

### DIFF
--- a/.claude/rubrics/pr-report-generator-xss-escape.md
+++ b/.claude/rubrics/pr-report-generator-xss-escape.md
@@ -1,0 +1,61 @@
+# Rubric — PR-SEC-XSS-REPORTGEN
+
+**Title:** Escape user-controllable fields in the client activity report (stored-XSS fix)
+**Branch:** security/pr-report-generator-xss-escape
+**Base:** main
+**Scope:** Output-encode every user-controllable string interpolated into the CLIENT activity report HTML (rendered via `document.write` in `generateHTML`) inside `apps/admin-panel/js/managers/ReportGenerator.js`, using the file's existing `escapeHtml` helper — bringing the client path to parity with the already-hardened employee-report path. Adds a vitest unit suite proving the escaping. Frontend-only, additive, no behavior change for benign data.
+
+**Reachability:** the H.6 cutover CF `createClientFromSalesRecord` stores `sale.clientName` RAW into the world-readable `clients.fullName`; a client name containing markup executes when a partner generates that client's report.
+
+## MUST criteria (block on FAIL)
+
+### M1 — both named fullName sinks escaped
+**Rule:** `client.fullName` is wrapped in `this.escapeHtml(...)` at the `<title>` (line ~226) and the info-value `<span>` (line ~482).
+**Evidence required:** ReportGenerator.js:226, :482.
+
+### M2 — all other user-controllable HTML sinks in the client path escaped
+**Rule:** every remaining raw user-controllable interpolation reaching the client-report `document.write` is escaped: caseNumber (~486), formData.service section title (~502), emp.employeeName (~527), service.service (~576), entry.action/description (~832), getEmployeeName (~833), packages serviceName (~1165), pkgDescription (~1194).
+**Evidence required:** the 8 file:line sites above, each via `this.escapeHtml(...)`.
+
+### M3 — uses the existing helper, no new surface
+**Rule:** escaping uses the in-file `this.escapeHtml` (line ~1666). No new escaper, no new dependency, no new collection/rule/claim.
+**Evidence required:** diff shows only `escapeHtml(...)` wrapping; no new function/import.
+
+### M4 — CSV/Excel context left untouched
+**Rule:** the CSV/Excel sinks (generateExcel ~911/926/934/941, generateEmployeeCSV) are NOT HTML-escaped (different context; CSV-injection is a separate tracked item).
+**Evidence required:** diff does not touch those lines.
+
+### M5 — test proves the customer scenario
+**Rule:** a vitest suite renders a report whose fullName/caseNumber/service/employee/description carry an `onerror` payload and asserts the raw live tag NEVER appears, only the escaped form; existing ReportGenerator tests still pass.
+**Evidence required:** `tests/unit/admin-panel/report-generator-escaping.test.ts` green; `report-generator-service-hours.test.ts` still green.
+
+### M6 — no new lint errors / no benign-data behavior change
+**Rule:** no new ESLint errors on touched lines; numeric/date/constant interpolations untouched so benign reports render identically.
+**Evidence required:** `eslint` on the two files = 0 errors on changed lines; diff limited to wrapping calls.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — multi-sink regression signal
+**Rule:** the test asserts an escaped-occurrence count (>= 8 in buildHTMLContent) so a regression on a single sink is caught.
+**Evidence required:** test assertion.
+
+### S2 — no "undefined" leak
+**Rule:** `escapeHtml(null/undefined)` returns `''` (G1 alignment — no "undefined" rendered).
+**Evidence required:** test assertion.
+
+## Out of scope
+
+- `WhatsAppMessageDialog.js:72` `userName` → innerHTML XSS (same class, different sink — tracked separately).
+- CSV formula-injection in `generateExcel` / `generateEmployeeCSV` (csvEscape doubles quotes only — tracked separately).
+- Consolidating the ~9 duplicate `escapeHtml` copies into a shared util (tracked separately).
+- Re-sanitizing the 3 intake routes — the correct fix is output-encoding at the sink (existing stored data is only protected by it; intake sanitization would corrupt the billing-verified `fullName` join key).
+
+## Rollback
+
+`git revert <commit>` + redeploy (code-only, frontend; Netlify auto-redeploys from main). No data migration, no schema change.
+
+## Notes for grader
+
+- security-access-expert verdict: **GO-WITH-CHANGES → comprehensive (10 sinks)**. `escapeHtml` (& < > " ') is sufficient for the only two contexts used — element text content and the `<title>` element (RCDATA). All attribute-context interpolations (`class="${...}"`, logo `src`/`onerror`) are controlled constants — no breakout.
+- Security gate relevant: `clients.fullName` is world-readable and written raw by the H.6 CF — escape-at-the-sink is the correct and complete fix.
+- The H.6.a rubric (`pr-h-6-a-create-client-from-sales-record.md` M6 delta #2) names this as the tracked sink-escaping follow-up but cited only 226/482; the real sink set is 10 (this PR).

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -223,7 +223,7 @@ return true;
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>דוח פעילות ללקוח - ${client.fullName}</title>
+    <title>דוח פעילות ללקוח - ${this.escapeHtml(client.fullName)}</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         * {
@@ -479,11 +479,11 @@ return true;
             <div class="info-grid">
                 <div class="info-item">
                     <span class="info-label">שם הלקוח</span>
-                    <span class="info-value">${client.fullName}</span>
+                    <span class="info-value">${this.escapeHtml(client.fullName)}</span>
                 </div>
                 <div class="info-item">
                     <span class="info-label">מספר תיק</span>
-                    <span class="info-value">${client.caseNumber || '-'}</span>
+                    <span class="info-value">${this.escapeHtml(client.caseNumber || '-')}</span>
                 </div>
                 <div class="info-item">
                     <span class="info-label">תקופת הדוח</span>
@@ -499,7 +499,7 @@ return true;
         <!-- Hours Info (if applicable) -->
         ${client.type === 'hours' || client.type === 'legal_procedure' || client.procedureType === 'legal_procedure' || formData.service ? `
         <div class="section">
-            <h3 class="section-title"><i class="fas fa-clock"></i> מידע על ${formData.service === 'all' ? 'כל השירותים' : formData.service}</h3>
+            <h3 class="section-title"><i class="fas fa-clock"></i> מידע על ${formData.service === 'all' ? 'כל השירותים' : this.escapeHtml(formData.service)}</h3>
             <div class="info-grid">
                 ${this.renderServiceInfo(client, formData)}
             </div>
@@ -524,7 +524,7 @@ return true;
                 <tbody>
                     ${stats.byEmployee.map(emp => `
                         <tr>
-                            <td>${emp.employeeName}</td>
+                            <td>${this.escapeHtml(emp.employeeName)}</td>
                             <td class="highlight">${emp.hours.toFixed(2)} שעות</td>
                             <td>${emp.entries}</td>
                         </tr>
@@ -573,7 +573,7 @@ return true;
                 <tbody>
                     ${stats.byService.map(service => `
                         <tr>
-                            <td>${service.service}</td>
+                            <td>${this.escapeHtml(service.service)}</td>
                             <td class="highlight">${service.hours.toFixed(2)} שעות</td>
                             <td>${service.entries}</td>
                         </tr>
@@ -829,8 +829,8 @@ return true;
                 return `
                     <tr>
                         <td>${this.formatDate(entry.date)}</td>
-                        <td>${entry.action || entry.taskDescription || entry.description || '-'}</td>
-                        <td>${this.dataManager.getEmployeeName(entry.employee)}</td>
+                        <td>${this.escapeHtml(entry.action || entry.taskDescription || entry.description || '-')}</td>
+                        <td>${this.escapeHtml(this.dataManager.getEmployeeName(entry.employee))}</td>
                         <td class="highlight">${minutes}</td>
                         ${client.type === 'hours' || client.type === 'legal_procedure' || client.procedureType === 'legal_procedure' ? `<td>${accumulatedMinutes}</td>` : ''}
                         ${client.type === 'hours' || client.type === 'legal_procedure' || client.procedureType === 'legal_procedure' ? `<td class="${balanceClass}">${remainingMinutes}</td>` : ''}
@@ -1162,7 +1162,7 @@ return '0:00';
         <div class="section" style="margin-top: 2rem;">
             <h3 class="section-title">
                 <i class="fas fa-boxes"></i>
-                פירוט חבילות שעות - ${serviceName}${dateRangeText}
+                פירוט חבילות שעות - ${this.escapeHtml(serviceName)}${dateRangeText}
             </h3>
             <table>
                 <thead>
@@ -1191,7 +1191,7 @@ return '0:00';
                             <td class="highlight">${pkgHours.toFixed(1)}</td>
                             <td>${pkgUsed.toFixed(1)}</td>
                             <td>${pkgRemaining.toFixed(1)}</td>
-                            <td style="max-width: 200px; word-wrap: break-word;">${pkgDescription}</td>
+                            <td style="max-width: 200px; word-wrap: break-word;">${this.escapeHtml(pkgDescription)}</td>
                         </tr>
                         `;
                     }).join('')}

--- a/tests/unit/admin-panel/report-generator-escaping.test.ts
+++ b/tests/unit/admin-panel/report-generator-escaping.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests — ReportGenerator client-report HTML escaping (stored-XSS gap)
+ *
+ * The CLIENT report path (buildHTMLContent + renderPackagesTable) interpolates
+ * user-controllable strings RAW into an HTML document that is rendered via
+ * `document.write` (generateHTML). A client whose name / a timesheet description /
+ * a package note contains markup (e.g. a name written RAW into the world-readable
+ * `clients.fullName` by the H.6 cutover CF `createClientFromSalesRecord`) would
+ * execute when a partner generates that client's activity report.
+ *
+ * Fix = escape at the sink via the existing `escapeHtml` helper (the EMPLOYEE
+ * report path already does this). These tests prove every user-controllable sink
+ * in the client path is now escaped — the raw payload must NEVER appear as a live
+ * tag in the rendered HTML, only its escaped form.
+ *
+ * Created: 2026-06-17 — security/report-generator-xss-escape
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// ReportGenerator.js is an IIFE that assigns the singleton to window (happy-dom
+// provides window). Import for side-effect, then read the instance off window.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/managers/ReportGenerator.js';
+
+const reportGenerator: any = (window as any).ReportGenerator;
+
+// A canonical stored-XSS payload. Escaped form: `<` -> &lt;, `>` -> &gt;.
+const XSS = '<img src=x onerror=alert(1)>';
+const XSS_LIVE = '<img src=x onerror=alert(1)>';
+const XSS_ESCAPED = '&lt;img src=x onerror=alert(1)&gt;';
+
+// helper: count non-overlapping occurrences of a substring
+function count(haystack: string, needle: string): number {
+  let n = 0;
+  let i = haystack.indexOf(needle);
+  while (i !== -1) {
+    n++;
+    i = haystack.indexOf(needle, i + needle.length);
+  }
+  return n;
+}
+
+// --- the escapeHtml helper itself -------------------------------------------
+
+describe('escapeHtml — helper', () => {
+  it('is exposed on the ReportGenerator singleton', () => {
+    expect(reportGenerator).toBeTruthy();
+    expect(typeof reportGenerator.escapeHtml).toBe('function');
+  });
+
+  it('escapes all five HTML-significant characters', () => {
+    expect(reportGenerator.escapeHtml('<>&"\'')).toBe('&lt;&gt;&amp;&quot;&#039;');
+  });
+
+  it('neutralizes an onerror <img> payload (no live tag survives)', () => {
+    const out = reportGenerator.escapeHtml(XSS);
+    expect(out).toBe(XSS_ESCAPED);
+    expect(out).not.toContain('<img');
+  });
+
+  it('returns empty string for null/undefined (no "undefined" leak — G1)', () => {
+    expect(reportGenerator.escapeHtml(null)).toBe('');
+    expect(reportGenerator.escapeHtml(undefined)).toBe('');
+  });
+});
+
+// --- the client report (buildHTMLContent) -----------------------------------
+
+describe('buildHTMLContent — escapes every user-controllable sink in the client path', () => {
+  beforeEach(() => {
+    // renderTimesheetRows + renderServiceInfo reach for the data manager; stub it.
+    // getEmployeeName echoes its arg so we can feed it a payload as the "employee".
+    reportGenerator.dataManager = {
+      getEmployeeName: (id: string) => id,
+      getClientTimesheetEntries: () => []
+    };
+  });
+
+  function reportDataWithPayloadEverywhere() {
+    return {
+      client: {
+        fullName: XSS, // -> <title> (226) + info-value (482)
+        caseNumber: XSS, // -> info-value (486)
+        type: 'hours', // renders the hours/timesheet/summary sections
+        services: []
+      },
+      formData: {
+        service: XSS, // -> section title (502)
+        reportType: 'full', // renders the timesheet table
+        startDate: '2026-01-01',
+        endDate: '2026-01-31'
+      },
+      timesheetEntries: [
+        { date: '2026-01-10', action: XSS, employee: XSS, minutes: 60 } // -> 832 + 833
+      ],
+      budgetTasks: [],
+      stats: {
+        totalMinutes: 60,
+        totalHours: 1,
+        entriesCount: 1,
+        byEmployee: [{ employee: XSS, employeeName: XSS, hours: 1, entries: 1, minutes: 60 }], // -> 527
+        byService: [{ service: XSS, hours: 1, entries: 1, minutes: 60 }], // -> 576
+        tasksStats: { total: 0, completed: 0, inProgress: 0, pending: 0 }
+      },
+      generatedAt: new Date('2026-02-01')
+    };
+  }
+
+  it('NEVER emits the raw payload as a live tag anywhere in the document', () => {
+    const html = reportGenerator.buildHTMLContent(reportDataWithPayloadEverywhere());
+    // If any single sink rendered raw, the live tag would appear here and fail.
+    expect(html).not.toContain(XSS_LIVE);
+  });
+
+  it('emits the escaped form for every active sink (>= 8 occurrences)', () => {
+    const html = reportGenerator.buildHTMLContent(reportDataWithPayloadEverywhere());
+    expect(html).toContain(XSS_ESCAPED);
+    // title(226) + fullName(482) + caseNumber(486) + service(502) +
+    // employeeName(527) + service.service(576) + entry.action(832) + employee(833)
+    expect(count(html, XSS_ESCAPED)).toBeGreaterThanOrEqual(8);
+  });
+
+  it('escapes the two NAMED fullName sinks specifically (title + info-value)', () => {
+    const html = reportGenerator.buildHTMLContent(reportDataWithPayloadEverywhere());
+    expect(html).toContain(`<title>דוח פעילות ללקוח - ${XSS_ESCAPED}</title>`);
+    expect(html).toContain(`<span class="info-value">${XSS_ESCAPED}</span>`);
+  });
+});
+
+// --- the packages table (renderPackagesTable) -------------------------------
+
+describe('renderPackagesTable — escapes service name and package description/reason', () => {
+  it('escapes the service-name title (1165) and the package note (1194)', () => {
+    const packages = [
+      { type: 'נוספת', hours: 5, hoursUsed: 1, hoursRemaining: 4, purchaseDate: '2026-01-01', description: XSS },
+      { type: 'נוספת', hours: 5, hoursUsed: 1, hoursRemaining: 4, purchaseDate: '2026-01-02', reason: XSS }
+    ];
+    const html = reportGenerator.renderPackagesTable(packages, XSS, null, null);
+    expect(html).not.toContain(XSS_LIVE);
+    expect(html).toContain(XSS_ESCAPED);
+    // serviceName title + 2 package notes
+    expect(count(html, XSS_ESCAPED)).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// --- date sinks are laundered through formatDate (not raw markup) ------------
+// The report's date interpolations (formData.startDate/endDate at ~490, the
+// service purchaseDate at ~768) are NOT escaped — they are passed through
+// formatDate(), which runs the value through `new Date(...)` and emits only
+// `toLocaleDateString('he-IL')`. A markup-bearing value therefore becomes an
+// "Invalid Date" token, never a live tag. This proves that laundering holds so
+// the "no live tag anywhere in the document" guarantee is real, not assumed.
+
+describe('buildHTMLContent — date sinks cannot smuggle markup (formatDate laundering)', () => {
+  beforeEach(() => {
+    reportGenerator.dataManager = {
+      getEmployeeName: (id: string) => id,
+      getClientTimesheetEntries: () => []
+    };
+  });
+
+  it('markup in form dates AND in a service purchasedAt never renders as a live tag', () => {
+    const reportData = {
+      client: {
+        fullName: 'לקוח תקין',
+        caseNumber: '1234567',
+        type: 'hours',
+        // purchaseDate path: dateService.purchasedAt.toDate() -> formatDate (line ~768)
+        services: [{ name: 'svc', purchasedAt: { toDate: () => XSS } }]
+      },
+      formData: {
+        service: 'svc',
+        reportType: 'full',
+        // attacker-controlled form fields laundered through formatDate (line ~490)
+        startDate: '2026-01-01' + XSS,
+        endDate: XSS
+      },
+      timesheetEntries: [],
+      budgetTasks: [],
+      stats: {
+        totalMinutes: 0, totalHours: 0, entriesCount: 0,
+        byEmployee: [], byService: [],
+        tasksStats: { total: 0, completed: 0, inProgress: 0, pending: 0 }
+      },
+      generatedAt: new Date('2026-02-01')
+    };
+    const html = reportGenerator.buildHTMLContent(reportData);
+    expect(html).not.toContain(XSS_LIVE);
+  });
+});


### PR DESCRIPTION
## Summary

The client activity report (`apps/admin-panel/js/managers/ReportGenerator.js`, rendered via `document.write`) interpolated user-controllable strings RAW into HTML. A client name / timesheet description / package note containing markup would execute when a partner generates that client's report. This wraps all 10 user-controllable sinks in the file's existing `escapeHtml` helper, bringing the client report to parity with the already-hardened employee report.

Reachability: the H.6 cutover CF `createClientFromSalesRecord` writes `sale.clientName` RAW into the world-readable `clients.fullName`. Output-encoding at the sink (not input-sanitization) is the correct fix — existing stored data is only protected by it, and the billing-verified `fullName` join key must stay pristine.

## Changes

- `apps/admin-panel/js/managers/ReportGenerator.js` — 10 sinks wrapped in `this.escapeHtml(...)`: fullName (title + info-value), caseNumber, service-section title, by-employee name, by-service name, timesheet description, employee name, packages title, package note. +10/-10, pure wrapping (no logic change).
- `tests/unit/admin-panel/report-generator-escaping.test.ts` — NEW (9 tests): escapeHtml helper unit + full-report integration (payload in every sink renders escaped, never a live tag, escaped form >= 8x) + packages table + a formatDate date-laundering proof.
- `.claude/rubrics/pr-report-generator-xss-escape.md` — NEW rubric.

## Test plan

- vitest tests/unit/admin-panel/ -> 8 files, 106 tests pass (9 new escaping + 12 existing report-generator regression).
- Customer scenario: a report whose client.fullName is an onerror img payload renders the escaped entity, never the live tag.
- eslint on the two changed files -> 0 errors.

## Reviews

- security-access-expert: GO-WITH-CHANGES -> comprehensive (10 sinks). escapeHtml (& < > " ') is sufficient for the two contexts used (element text + title RCDATA); all attribute contexts are controlled constants. The world-readable fullName written raw by the H.6 CF makes this security-gate relevant; escape-at-sink is correct and complete.
- devils-advocate: GO-WITH-CHANGES, 0 critical. Two test-coverage notes on formatDate-laundered date sinks were folded in (added the laundering proof test).
- outcomes-grader: VERDICT: PASS (6/6 MUST, 2/2 SHOULD, all 7 gates PASS or N/A).

## Out of scope (tracked separately)

- WhatsAppMessageDialog.js:72 userName -> innerHTML (same class, different sink).
- CSV formula-injection in generateExcel / generateEmployeeCSV (different vuln class; HTML-escaping there would corrupt the CSV).
- Consolidating the ~9 duplicate escapeHtml copies into a shared util.

## Breaking change

None. Additive output-encoding; benign data (numbers, dates, Hebrew text) renders identically.

## Rollback

git revert <commit> + redeploy (code-only, frontend; Netlify auto-redeploys from main). No data migration, no schema change.

## PRODUCT-GRADE GATES

- **G1** customer-visible errors professional: PASS (escapeHtml of null/undefined returns empty string, removing any undefined leak; no new error path)
- **G2** rollback documented: PASS (single git revert + Netlify redeploy)
- **G3** monitoring if data-mutating: N/A (read-only frontend render, no writes)
- **G4** test proves customer scenario: PASS (integration test renders the full report with a payload and asserts no live tag)
- **G5** Hebrew customer-facing text: N/A (no UI strings added or changed)
- **G6** breaking change with migration: N/A (additive, benign output byte-identical)
- **G7** security agent reviewed: PASS (security-access-expert GO-WITH-CHANGES; devils-advocate GO-WITH-CHANGES, 0 critical)

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)