### PR TITLE
fix(security): SMS CSV/formula-injection neutralization + shared CsvSafe encoder

### DIFF
--- a/.claude/rubrics/pr-sms-csv-injection.md
+++ b/.claude/rubrics/pr-sms-csv-injection.md
@@ -1,0 +1,62 @@
+# Rubric — PR-SMS-CSV-INJECTION
+
+**Title:** Neutralize CSV / Formula Injection in the SMS phone-list export (OWASP) + introduce the shared `CsvSafe` encoder (SSOT)
+**Branch:** security/sms-csv-injection
+**Base:** main
+**Scope:** Add `apps/admin-panel/js/core/csv-safe.js` exposing `window.CsvSafe.cell(value)` — the shared single-source-of-truth CSV/Excel cell encoder (OWASP formula-injection guard + RFC-4180 quote-doubling). Route the value cells of `convertToCSV(data)` in `apps/admin-panel/js/ui/SMSManagement.js` (~line 504) through it, with a fail-closed guard. Add a vitest unit + integration suite. Frontend-only, additive, no behavior change for benign data, no HTML/CSS/rules/claims/auth touched.
+
+**Reachability (honest — security-access-expert verdict):** `SMSManagement.js` is **ORPHANED** — `SYSTEM_MAP.md §D "JS Files Not Loaded by Any HTML"` lists it (#5); no HTML `<script>` loads it and no other JS references it. The `exportPhoneList → convertToCSV` sink is therefore **not reachable in the running app today**. Severity is **LOW / latent (defense-in-depth)** — a real CSV formula-injection weakness in dead-but-shipped code that would carry employee name/email/phone into a downloaded CSV **if** a future PR wires the component live. We fix it now because (a) it is the safe, additive testbed that establishes the canonical `CsvSafe` encoder, and (b) that encoder turns the genuinely-LIVE sibling sinks (ClientsTable, DataManager) into a one-line fix in their follow-up PRs. "Live data-exfiltration" is NOT claimed for this PR.
+
+## MUST criteria (block on FAIL)
+
+### M1 — `CsvSafe.cell` is the OWASP-correct neutralizer
+**Rule:** for a value starting with `= + - @ TAB(0x09) CR(0x0D) LF(0x0A)`, prefix a single `'` **before** RFC-4180 quote-doubling; return the INNER cell content (caller wraps in `"..."`). Trigger regex `/^[=+\-@\t\r\n]/` (a strict superset of PR-SEC-3's inline copy — adds LF). null/undefined → `''`.
+**Evidence required:** `apps/admin-panel/js/core/csv-safe.js` `cell()`; unit tests for each trigger char + classic payloads (`=HYPERLINK`, `=cmd|' /C calc'!A1`) + combined `="evil"` (prefix-then-double).
+
+### M2 — SMS value cells route through `CsvSafe.cell`, fail-closed
+**Rule:** `SMSManagement.convertToCSV` value cells return `` `"${window.CsvSafe.cell(value)}"` `` (transport quotes preserved); if `window.CsvSafe.cell` is unavailable the function throws (fail-closed) rather than emitting raw cells. The hardcoded Hebrew header literals are NOT user data and are left as-is.
+**Evidence required:** `SMSManagement.js` convertToCSV diff (guard + the routed return line); integration test asserts no quoted cell opens onto a formula trigger + the fail-closed throw.
+
+### M3 — single canonical encoder, no new surface
+**Rule:** one shared util in `js/core/` (peer of `budget-status.js` / `profitability-format.js`), one canonical name `window.CsvSafe.cell`, no new dependency, no new collection/rule/claim. No inline copy of the regex added to SMSManagement.
+**Evidence required:** diff shows the util + a call site; no duplicated regex in `SMSManagement.js`.
+
+### M4 — correct context: CSV encoding only, no HTML-escape
+**Rule:** the fix uses CSV/Excel encoding (formula guard + quote-doubling). It does NOT HTML-escape (would be inert against the formula engine and would corrupt legitimate names like `O'Brien` / `Smith & Co`). No other file's CSV/HTML context is touched.
+**Evidence required:** diff limited to `csv-safe.js`, `SMSManagement.js` convertToCSV, the test, and this rubric.
+
+### M5 — test proves the neutralization (G4, to the reachable ceiling)
+**Rule:** vitest suite covers (a) `CsvSafe.cell` directly — every trigger char, mid-string non-trigger, quote-doubling, prefix-before-double order, null/undefined; and (b) `convertToCSV` integration — poisoned name/email/phone come out inert, benign values unchanged, empty-data `''`, and fail-closed throw. PR body documents that a pure/integration unit test is the achievable ceiling because the calling page is orphaned (no live UI to E2E).
+**Evidence required:** `tests/unit/admin-panel/sms-csv-injection.test.ts` green; full root vitest suite still green.
+
+### M6 — no new lint errors / no benign-data behavior change
+**Rule:** 0 new ESLint errors on touched lines; a benign export (Hebrew names, normal emails/phones) renders byte-identically to before except for the (now-correct) formula guard on values that legitimately start with a trigger (e.g. a `+972…` phone → text, which is desirable).
+**Evidence required:** ESLint on the two JS files = 0 new errors; integration "no false positives" test.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — SSOT convergence noted
+**Rule:** `CsvSafe.cell` is documented as the canonical home the in-flight PR-SEC-3 `ReportGenerator.csvCell` and the live `ClientsTable` / `DataManager` exporters converge onto (tracked as follow-ups), so the project does not keep ≥3 divergent inline copies.
+**Evidence required:** docblock in `csv-safe.js` + this rubric's Out-of-scope.
+
+### S2 — no "undefined"/"null" leak (G1 alignment)
+**Rule:** `CsvSafe.cell(null|undefined)` → `''` (no literal `undefined`/`null` in the CSV).
+**Evidence required:** unit test assertion.
+
+## Out of scope (tracked separately)
+
+- **`ClientsTable.js:~738` `exportToExcel`** — LIVE (clients.html / clients-fluent.html), `"${cell}"` with **no quote-doubling at all** and no formula guard; leaks the world-readable `שם הלקוח`. Highest real-risk CSV sink → its own PR (live admin page → full ADMIN SAFETY validation). Chip filed.
+- **`DataManager.js:~707` `exportToCsv`** — LIVE (index/workload/employee-costs), same weakness; own PR. Chip filed.
+- **`ReportGenerator.csvCell`** (PR-SEC-3, in flight, inline) — refactor to delegate to `CsvSafe.cell` after both land (merge-second rebases to the util).
+- **`SMSManagement.js` retirement** — it is orphaned with `// TODO: Implement` stubs; whether to retire vs. keep is a separate Product-Owner call. SYSTEM_MAP §D entry is NOT edited (the file stays orphaned).
+- **`SMSManagement.js:~318` `innerHTML` interpolation** — a distinct XSS class (also orphaned), not part of this CSV PR.
+
+## Rollback
+
+`git revert <commit>` + redeploy (code-only, frontend; Netlify auto-redeploys from main). No data migration, no schema change, no Firestore rule/claim change. Reverting removes `csv-safe.js` and restores the prior `convertToCSV` line; because SMS is orphaned there is no live consumer to regress either way.
+
+## Notes for grader
+
+- **security-access-expert verdict: GO-WITH-CHANGES** — neutralizer logic OWASP-correct and complete (prefix-`'`-first → quote-double → wrap; transport quotes do not defeat the guard; order is load-bearing). Change folded: added `\n` to the trigger class. Reachability framed honestly (LOW/latent — SMS orphaned).
+- **completeness-checker:** 9 findings; the load-bearing one (PR-SEC-3 committed inline → util-vs-one-inline convergence) is addressed by adopting a superset regex + tracking the merge-second delegation. Live sinks (ClientsTable, DataManager) deferred to their own PRs with chips.
+- **G7:** output-encoding only; no firestore.rules / claims / auth / PII-handling change → the security review is the consultation; no live PII surface added (orphaned path).

--- a/apps/admin-panel/js/core/csv-safe.js
+++ b/apps/admin-panel/js/core/csv-safe.js
@@ -1,0 +1,61 @@
+/**
+ * csv-safe.js — shared SSOT encoder for CSV/Excel cell values (OWASP CSV /
+ * Formula Injection defense). Admin-panel exports build CSVs that an admin opens
+ * in Excel / Google Sheets; a cell whose value STARTS with a formula trigger
+ * (= + - @) or a control char (TAB 0x09 / CR 0x0D / LF 0x0A) is EVALUATED as a
+ * formula by the spreadsheet → data exfiltration / command execution.
+ * `cell(value)` neutralizes it by prefixing a single quote — the spreadsheet
+ * "force text" marker — so the value renders as inert text, never a live formula.
+ *
+ * Two independent layers — the CALLER still wraps the returned string in "...":
+ *   1. OWASP formula-injection — leading-trigger → prefix `'`. The outer RFC-4180
+ *      transport quotes do NOT defeat this: the spreadsheet's CSV parser strips
+ *      the transport "..." BEFORE the cell reaches the formula engine, and the
+ *      leading `'` then marks the field as text. Order is load-bearing: prefix
+ *      FIRST, then quote-double (the `'` is part of the logical value at pos 0).
+ *   2. RFC-4180 — double any embedded double-quote.
+ *
+ * Returns the INNER cell content (NOT wrapped in "..."), matching the contract the
+ * existing inline encoders use (the caller adds the transport quotes), so the
+ * sibling ReportGenerator.csvCell (PR-SEC-3) can later delegate here unchanged.
+ *
+ * Trigger set /^[=+\-@\t\r\n]/ is a strict SUPERSET of PR-SEC-3's inline copy
+ * (adds LF 0x0A for parity with CR). The future CSV-dedup follow-up routes the
+ * LIVE sinks — ReportGenerator, ClientsTable, DataManager — through THIS one
+ * canonical home (tracked separately; out of scope for this PR).
+ *
+ * Pattern mirrors js/core/budget-status.js (classic <script> load + dual-export).
+ * Created: 2026-06-17 — security/sms-csv-injection (PR-SMS-CSV-INJECTION).
+ */
+(function () {
+  'use strict';
+
+  // OWASP formula-injection triggers: = + - @ , plus TAB / CR / LF control chars.
+  // Anchored to the FIRST char — only the leading char drives the formula engine.
+  // (`\-` is an escaped literal hyphen inside the class, not a range.)
+  const FORMULA_TRIGGER = /^[=+\-@\t\r\n]/;
+
+  /**
+   * Neutralize one value for safe inclusion inside a CSV cell. The caller is
+   * responsible for the outer "..." transport quoting.
+   * @param {*} value raw cell value (any type; null/undefined → '')
+   * @returns {string} inner cell content (formula-guarded + quote-doubled, NOT wrapped)
+   */
+  function cell(value) {
+    const s = String(value === undefined || value === null ? '' : value);
+    const neutralized = FORMULA_TRIGGER.test(s) ? "'" + s : s;
+    return neutralized.replace(/"/g, '""');
+  }
+
+  const api = { cell: cell };
+
+  // Expose to window — admin-panel pattern (classic <script> load).
+  if (typeof window !== 'undefined') {
+    window.CsvSafe = api;
+  }
+
+  // CommonJS export — for vitest tests under Node.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/apps/admin-panel/js/ui/SMSManagement.js
+++ b/apps/admin-panel/js/ui/SMSManagement.js
@@ -495,13 +495,24 @@ return;
 return '';
 }
 
+            // OWASP CSV/Formula-Injection — every VALUE cell is neutralized via the
+            // shared SSOT encoder window.CsvSafe.cell (prefixes a leading formula
+            // trigger [= + - @ TAB CR LF] with ' then RFC-4180 quote-doubles; the
+            // caller still wraps in "..."). The headers below are hardcoded Hebrew
+            // literals from exportPhoneList (not user data) so they are left as-is.
+            // Fail-closed: if js/core/csv-safe.js did not load, abort the export
+            // rather than emit un-neutralized cells.
+            if (!window.CsvSafe || typeof window.CsvSafe.cell !== 'function') {
+                throw new Error('CsvSafe encoder not loaded — CSV export aborted (js/core/csv-safe.js must load first)');
+            }
+
             const headers = Object.keys(data[0]);
             const csvHeaders = headers.join(',');
 
             const csvRows = data.map(row => {
                 return headers.map(header => {
                     const value = row[header] || '';
-                    return `"${value.toString().replace(/"/g, '""')}"`;
+                    return `"${window.CsvSafe.cell(value)}"`;
                 }).join(',');
             });
 

--- a/tests/unit/admin-panel/sms-csv-injection.test.ts
+++ b/tests/unit/admin-panel/sms-csv-injection.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit + integration tests — SMS CSV / Formula-Injection neutralization
+ * (PR-SMS-CSV-INJECTION)
+ *
+ * Background: admin CSV exports are opened in Excel / Google Sheets. A cell whose
+ * value STARTS with `= + - @` (or TAB / CR / LF) is evaluated as a formula by the
+ * spreadsheet → data exfiltration / command execution (OWASP "CSV Injection").
+ *
+ * `window.CsvSafe.cell` is the shared SSOT neutralizer (js/core/csv-safe.js): it
+ * prefixes a single quote when the value starts with a trigger char, then preserves
+ * RFC-4180 quote-doubling, returning the INNER cell content (the caller wraps "...").
+ *
+ * `SMSManagement.convertToCSV` routes every value cell through it and fails closed
+ * if the encoder script did not load. NOTE: SMSManagement.js is currently ORPHANED
+ * (SYSTEM_MAP §D — loaded by no HTML), so this fix is defense-in-depth and
+ * establishes the canonical encoder; the integration block proves convertToCSV
+ * emits inert cells to the extent the path is reachable (G4 — see rubric).
+ *
+ * Created: 2026-06-17 — security/sms-csv-injection
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// csv-safe.js MUST load before SMSManagement.js (sets window.CsvSafe, used by
+// convertToCSV). Both are classic IIFEs that assign to window (happy-dom provides it).
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/csv-safe.js';
+// @ts-ignore
+import '../../../apps/admin-panel/js/ui/SMSManagement.js';
+
+const CsvSafe: any = (window as any).CsvSafe;
+const SMSManagement: any = (window as any).SMSManagement;
+
+// A quoted CSV field must NEVER open directly onto a formula trigger. After
+// neutralization every triggered cell opens with a single quote (`"'=...`). This
+// catches a live formula cell at the start of the file OR after any comma / newline.
+const OPENS_ONTO_TRIGGER = /(?:^|[,\n])"[=+\-@\t\r\n]/;
+
+describe('CsvSafe.cell — wiring', () => {
+  it('is exposed as window.CsvSafe.cell', () => {
+    expect(CsvSafe).toBeTruthy();
+    expect(typeof CsvSafe.cell).toBe('function');
+  });
+});
+
+describe('CsvSafe.cell — neutralizes leading formula triggers (OWASP)', () => {
+  it('prefixes a single quote for each trigger char: = + - @ TAB CR LF', () => {
+    expect(CsvSafe.cell('=1+1')).toBe("'=1+1");
+    expect(CsvSafe.cell('+1+1')).toBe("'+1+1");
+    expect(CsvSafe.cell('-2+3')).toBe("'-2+3");
+    expect(CsvSafe.cell('@SUM(1)')).toBe("'@SUM(1)");
+    expect(CsvSafe.cell('\t=1')).toBe("'\t=1");
+    expect(CsvSafe.cell('\r=1')).toBe("'\r=1");
+    expect(CsvSafe.cell('\n=1')).toBe("'\n=1");
+  });
+
+  it('neutralizes the classic payloads', () => {
+    // =HYPERLINK("http://evil","x") → leading quote, inner double-quotes doubled
+    const hyperlink = CsvSafe.cell('=HYPERLINK("http://evil","x")');
+    expect(hyperlink.startsWith("'=HYPERLINK(")).toBe(true);
+    expect(hyperlink).toContain('""http://evil""');
+    // =cmd|' /C calc'!A1 (DDE command-exec payload)
+    expect(CsvSafe.cell("=cmd|' /C calc'!A1")).toBe("'=cmd|' /C calc'!A1");
+  });
+});
+
+describe('CsvSafe.cell — leaves safe values untouched (no false positives)', () => {
+  it('does NOT prefix Hebrew text, normal names, or digit-leading values', () => {
+    expect(CsvSafe.cell('דוד כהן')).toBe('דוד כהן');
+    expect(CsvSafe.cell('Acme Ltd')).toBe('Acme Ltd');
+    expect(CsvSafe.cell('050-1234567')).toBe('050-1234567');
+    expect(CsvSafe.cell('2026-06-17')).toBe('2026-06-17');
+  });
+
+  it('does NOT prefix when a trigger char appears MID-string (only leading matters)', () => {
+    expect(CsvSafe.cell('a=b')).toBe('a=b');
+    expect(CsvSafe.cell('david@example.com')).toBe('david@example.com');
+    expect(CsvSafe.cell('total: 5-2')).toBe('total: 5-2');
+  });
+});
+
+describe('CsvSafe.cell — RFC-4180 quote-doubling preserved', () => {
+  it('doubles embedded double-quotes', () => {
+    expect(CsvSafe.cell('say "hi"')).toBe('say ""hi""');
+  });
+
+  it('applies the trigger-prefix BEFORE doubling (combined case)', () => {
+    // value starts with `=` AND contains quotes → prefix ' then double the inner quotes
+    const r = CsvSafe.cell('="evil"');
+    expect(r.startsWith("'=")).toBe(true);
+    expect(r).toContain('""evil""');
+  });
+
+  it('coerces empty / null / undefined to an empty string', () => {
+    expect(CsvSafe.cell('')).toBe('');
+    expect(CsvSafe.cell(null)).toBe('');
+    expect(CsvSafe.cell(undefined)).toBe('');
+  });
+});
+
+// --- integration: prove SMSManagement.convertToCSV emits inert cells (G4) -----
+
+describe('SMSManagement.convertToCSV — the export scenario', () => {
+  it('neutralizes poisoned employee name / email / phone cells', () => {
+    const csv = SMSManagement.convertToCSV([
+      { 'שם': "=cmd|' /C calc'!A1", 'אימייל': '+evil@x.com', 'טלפון': '@SUM(1)', 'מאומת': 'כן' }
+    ]);
+    expect(csv).toContain("\"'=cmd|' /C calc'!A1\""); // name → leading quote inside transport quotes
+    expect(csv).toContain("\"'+evil@x.com\"");         // email
+    expect(csv).toContain("\"'@SUM(1)\"");             // phone
+    // No quoted cell anywhere opens directly onto a live formula trigger.
+    expect(csv).not.toMatch(OPENS_ONTO_TRIGGER);
+  });
+
+  it('leaves legitimate values unchanged (no false positives in the file)', () => {
+    const csv = SMSManagement.convertToCSV([
+      { 'שם': 'דוד כהן', 'אימייל': 'david@example.com', 'טלפון': '050-1234567', 'מאומת': 'לא' }
+    ]);
+    expect(csv).toContain('"דוד כהן"');
+    expect(csv).toContain('"david@example.com"');
+    expect(csv).toContain('"050-1234567"');
+    // no stray single-quote was injected in front of a clean Hebrew cell
+    expect(csv).not.toContain("'דוד");
+  });
+
+  it('returns an empty string for empty data', () => {
+    expect(SMSManagement.convertToCSV([])).toBe('');
+  });
+
+  it('fails closed (throws) when the CsvSafe encoder is not loaded', () => {
+    const saved = (window as any).CsvSafe;
+    try {
+      delete (window as any).CsvSafe;
+      expect(() => SMSManagement.convertToCSV([{ 'שם': '=x' }])).toThrow();
+    } finally {
+      (window as any).CsvSafe = saved;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

OWASP **CSV / Formula Injection** fix, frontend-only (Admin Panel). `SMSManagement.convertToCSV` did RFC-4180 quote-doubling but **no** formula-trigger neutralization — a value starting with `= + - @` / TAB / CR / LF is evaluated as a formula when the CSV is opened in Excel / Google Sheets (data exfiltration / command execution).

Introduces the shared SSOT encoder **`window.CsvSafe.cell`** (`apps/admin-panel/js/core/csv-safe.js`) — prefix a leading trigger with `'` (force-text) **before** quote-doubling, caller keeps the `"..."` wrapper — and routes the SMS value cells through it with a **fail-closed** guard.

### Reachability (honest)
`SMSManagement.js` is **orphaned** — `SYSTEM_MAP.md` section D "JS Files Not Loaded by Any HTML" lists it (#5); no page loads it. So this sink is **not reachable today** -> severity **LOW / latent (defense-in-depth)**. The value is (a) establishing the canonical encoder, and (b) the genuinely-LIVE sibling sinks (`ClientsTable.exportToExcel`, `DataManager.exportToCsv`) become a one-line `CsvSafe.cell` fix in their own follow-up PRs. No live-exfiltration is claimed here.

## What changed
- **add** `apps/admin-panel/js/core/csv-safe.js` — `window.CsvSafe.cell(value)`, trigger `/^[=+\-@\t\r\n]/` (superset of PR-SEC-3 inline copy — adds LF), dual-export (window + CommonJS), mirrors `budget-status.js`.
- **route** `SMSManagement.convertToCSV` value cells through `window.CsvSafe.cell` + fail-closed throw if the encoder is not loaded. Hardcoded Hebrew header literals left as-is (not user data).
- **test** `tests/unit/admin-panel/sms-csv-injection.test.ts` — 12 tests (CsvSafe.cell unit matrix + convertToCSV integration + fail-closed).
- **rubric** `.claude/rubrics/pr-sms-csv-injection.md`.

## Test plan
- `tests/unit/admin-panel/sms-csv-injection.test.ts` -> **12/12 pass**. Covers each trigger char, classic payloads (`=HYPERLINK`, `=cmd| /C calc!A1`), mid-string non-trigger, quote-doubling, prefix-before-double order, null/undefined to empty, and the `convertToCSV` integration (poisoned name/email/phone come out inert; benign unchanged; empty data; fail-closed throw).
- Full root vitest suite -> **615 pass / 2 skipped** (1 pre-existing unrelated post-teardown timer flake in `tests/unit/user-app/holidays-cache-merge.test.ts`).
- ESLint on both JS files -> **0 errors** (5 pre-existing warnings in SMSManagement.js, none on touched lines; csv-safe.js clean).

Customer scenario (G4): no live UI to E2E because the component is orphaned — the integration test drives the real `SMSManagement.convertToCSV` and asserts no quoted cell opens onto a formula trigger. This is the achievable ceiling and is documented as such.

## PRODUCT-GRADE GATES
- **G1 — errors professional:** PASS. Only new error is a developer fail-closed `throw` on an orphaned, non-customer-facing path; no stack-trace / object / raw-Firebase leak.
- **G2 — rollback:** PASS. See Rollback below (code-only `git revert`).
- **G3 — monitoring if data-mutating:** N/A. Read-only export, no write/update/delete.
- **G4 — test proves scenario:** PASS. Integration test on the real convertToCSV; ceiling documented (orphaned page).
- **G5 — Hebrew customer text:** PASS. No UI strings added; the one English string is a developer-only `throw`.
- **G6 — breaking change:** PASS. Additive; benign data byte-identical (a +972 phone now exports as text, which is desirable); orphaned path has no live consumer.
- **G7 — security reviewed:** PASS. Output-encoding only; no rules/claims/auth/PII-handling change. **security-access-expert: GO-WITH-CHANGES** (added LF to the trigger class; honest LOW/latent severity).

## Rollback
`git revert 8a116ea` + redeploy (code-only, frontend; Netlify auto-redeploys from `main`). No data migration, no schema/rule/claim change. Because SMS is orphaned there is no live consumer to regress either way.

## Out of scope (tracked follow-ups)
- `ClientsTable.js` `exportToExcel` — LIVE (clients.html), no quote-doubling + no formula guard, leaks world-readable client name -> own PR (highest real risk).
- `DataManager.js` `exportToCsv` — LIVE (index/workload/employee-costs) -> own PR.
- `ReportGenerator.csvCell` (PR-SEC-3, inline) -> refactor to delegate to `CsvSafe.cell` after both land.
- `SMSManagement.js` retirement (orphaned, TODO stubs) — separate Product-Owner call.

## Reviews
- **outcomes-grader: VERDICT: PASS** — 6/6 MUST, 2/2 SHOULD, 7/7 gates PASS/N-A, 0 blockers.
- **security-access-expert: GO-WITH-CHANGES** (folded).
- **completeness-checker:** 9 findings; live sinks deferred to follow-ups with chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)