### PR TITLE
feat(security): route ReportGenerator CSV exports through the CsvSafe SSOT encoder (PR-SEC-3)

### DIFF
--- a/.claude/rubrics/pr-sec-3.md
+++ b/.claude/rubrics/pr-sec-3.md
@@ -1,0 +1,134 @@
+# Rubric — PR-SEC-3 (route ReportGenerator CSV exports through the shared CsvSafe SSOT encoder)
+
+**Title:** feat(security): neutralize CSV/formula-injection in ReportGenerator exports via window.CsvSafe (OWASP)
+**Branch:** security/csv-injection-report-generator-pr-sec-3
+**Base:** main
+**Scope:** Frontend-only, additive hardening of the two CSV exporters in
+`apps/admin-panel/js/managers/ReportGenerator.js` — `generateExcel` (~L902-947) and
+`generateEmployeeCSV` (~L1591-1661). User-controllable values (client/employee/task names,
+service names, timesheet action/description) were written into CSV cells with only
+quote-doubling (`generateEmployeeCSV`) or NO escaping at all (`generateExcel`). A cell whose
+value starts with `= + - @` (or TAB 0x09 / CR 0x0D / LF 0x0A) is evaluated as a formula when
+the CSV is opened in Excel / Google Sheets (OWASP "CSV Injection" / "Formula Injection").
+
+**Approach — route, don't copy (encoders are SSOT).** PR #384 (PR-SMS-CSV-INJECTION) merged the
+canonical encoder `apps/admin-panel/js/core/csv-safe.js → window.CsvSafe.cell` (single-quote
+prefix on a leading trigger + RFC-4180 quote-doubling). Its own header names ReportGenerator as
+a LIVE sink to route here. This PR **delegates** both ReportGenerator exporters to
+`window.CsvSafe.cell` (no second inline copy), wires `csv-safe.js` to load **before**
+`ReportGenerator.js` on the 3 pages that load it, and adds a fail-secure guard. This realizes
+the "route the LIVE ReportGenerator sink" follow-up #384's csv-safe.js header anticipated.
+
+**Deliberately distinct from PR #382 (XSS):** that PR HTML-escaped the same module's *HTML*
+report sinks. HTML-escaping a CSV cell corrupts it — CSV/formula injection is a separate
+context, which is why it was left out of #382 and addressed here.
+
+## MUST criteria (block on FAIL)
+
+### M1 — Both exporters route every user-controllable string cell through window.CsvSafe.cell (SSOT)
+**Rule:** `generateEmployeeCSV` routes employee.name / client name / description / clientName
+(via the delegated `csvEscape = (val) => window.CsvSafe.cell(val)`); `generateExcel` routes
+employee name / service name / action-description / task name / status / deadline-placeholder
+through `window.CsvSafe.cell(...)`. **No inline neutralizer remains** — ReportGenerator declares
+no `csvCell` of its own (zero duplicated neutralization logic).
+**Evidence:** `git diff` shows `window.CsvSafe.cell(...)` at every routed site; the prior inline
+`csvCell` method is removed; test "ReportGenerator does NOT keep a second inline neutralizer".
+
+### M2 — Neutralization is correct (delegated to the audited SSOT) — leading triggers + RFC-4180
+**Rule:** A cell value starting with `= + - @` / TAB / CR / LF is prefixed `'` (prefix BEFORE
+quote-doubling); embedded `"` is doubled. `generateExcel` (previously NO escaping) now also gets
+the RFC-4180 quote-doubling. The logic itself is `window.CsvSafe.cell` (unit-tested by csv-safe's
+own suite under #384); this PR proves it end-to-end through the exporters.
+**Evidence:** `js/core/csv-safe.js` `cell()` (`/^[=+\-@\t\r\n]/` → `'` + `.replace(/"/g,'""')`);
+integration tests assert `'=HYPERLINK(` + `""http://evil""` etc. and `not.toMatch /(?:^|[,\n])"[=+\-@\t\r]/`.
+
+### M3 — Load-order wired: csv-safe.js loads BEFORE ReportGenerator on every page that loads it
+**Rule:** The 3 HTML pages that `<script>` `ReportGenerator.js` (`clients.html`,
+`clients-fluent.html`, `index.html`) load `js/core/csv-safe.js` immediately before it. (Runtime
+only needs it present by export time, but loading it first is explicit + matches the wiring note.)
+**Evidence:** `git diff` of the 3 HTML files — one added `<script src="js/core/csv-safe.js?v=20260617-pr-sec-3">`
+line directly above each `ReportGenerator.js` line, with an explanatory comment.
+
+### M4 — Fail-secure if the encoder is missing (no un-neutralized CSV ever emitted)
+**Rule:** If `window.CsvSafe.cell` is not loaded, each exporter ABORTS before building any CSV
+(returns early) and shows a Hebrew error notice — it never falls back to emitting an
+un-neutralized CSV.
+**Evidence:** `ensureCsvSafe()` guard at the top of both exporters; test "FAIL-SECURE: if the
+CsvSafe encoder is not loaded, the export ABORTS (no CSV emitted) + Hebrew notice".
+
+### M5 — No false positives on legitimate data
+**Rule:** Hebrew text, normal names, digit-leading values, and dates are unchanged. Numeric cells
+(minutes/hours/counts) are NOT routed — a legitimate negative number must not become text `'-5`.
+**Evidence:** test "generateExcel: legitimate values are unchanged"; the diff leaves
+`${entry.minutes}`, `${task.estimatedHours||0}`, `${task.actualMinutes||0}`, the date cells,
+summary numerics, and `period.label` raw.
+
+### M6 — Customer-scenario integration coverage (G4)
+**Rule:** A test drives the actual `generateExcel` / `generateEmployeeCSV` download path with a
+poisoned input and asserts the produced CSV contains the neutralized (`'`-prefixed) cell and NO
+quoted cell opening directly onto a raw trigger.
+**Evidence:** the two "the customer scenario (G4)" integration tests + the fail-secure test;
+Blob constructor + URL stubbed to capture the CSV string; csv-safe.js imported first so
+`window.CsvSafe` exists (mirrors the page <script> order). 6/6 in this suite green.
+
+### M7 — Additive / non-breaking, output-encoding only
+**Rule:** No data, schema, route, CF, rule, claim, or auth change. The only behavior changes are
+(a) inert-text rendering of cells that would otherwise be formulas (the fix) and (b) a new
+load-order dependency on `csv-safe.js` (additive `<script>`; pure global, no display change).
+Existing ReportGenerator tests stay green.
+**Evidence:** `git diff` = ReportGenerator.js + 3 HTML `<script>` adds + the test + this rubric
+only; `report-generator-service-hours.test.ts` 12/12 + all admin-panel unit tests 131/131 green.
+
+## SHOULD criteria (warning on FAIL)
+
+### S1 — Guard documented + fail-secure with Hebrew text
+**Rule:** `ensureCsvSafe()` carries a JSDoc explaining the fail-secure rationale; the user-facing
+abort message is Hebrew (G5); the dev diagnostic is `console.error` (allowed).
+**Evidence:** JSDoc above `ensureCsvSafe`; Hebrew `window.notify.error(...)`.
+
+### S2 — Header label-lines correctly left untouched
+**Rule:** `generateExcel` L911-913 (`דוח פעילות ללקוח - ${client.fullName}`, `מספר תיק: ...`) are
+NOT changed — the user value follows a Hebrew literal so the cell never STARTS with a trigger,
+and the lines are unquoted (quote-doubling without quoting would itself corrupt them).
+**Evidence:** diff does not touch L911-913; security review confirmed not an injection vector.
+
+### S3 — ESLint 0 errors
+**Rule:** Changed files lint with 0 errors (pre-existing `no-console`/`any` warnings allowed).
+**Evidence:** `npx eslint <changed files>` → 0 errors (47 pre-existing warnings, none added).
+
+## Out of scope (tracked separately — Haim-approved Option 1 at the 2026-06-17 checkpoint)
+
+- `apps/admin-panel/js/ui/ClientsTable.js` `exportToExcel()` (L738: `row.map(cell => \`"${cell}"\`)`
+  — **NO escaping at all**, the worst LIVE sibling) — route to `window.CsvSafe.cell` in a separate
+  PR/chip (🔴 HIGH). Named in csv-safe.js's header as a remaining LIVE sink.
+- `apps/admin-panel/js/ui/SMSManagement.js` `convertToCSV()` — already routed to `window.CsvSafe.cell`
+  by #384, but **orphaned** (loaded by no HTML page; SYSTEM_MAP §D) → defense-in-depth only.
+- `DataManager.exportToCsv` (the 3rd LIVE sink named in csv-safe.js's header) — separate chip.
+
+## Rollback
+
+Additive and trivial to undo (frontend-only, no data migration):
+- `git revert <sha>` → redeploy the admin panel (Netlify). The 3 `<script>` adds + the routing
+  revert together; cells return to the prior (unescaped / quote-doubling-only) behavior. No
+  inverse migration; nothing persisted; `csv-safe.js` itself (from #384) is untouched by the revert.
+
+## Notes for grader
+
+- **Why delegate instead of the originally-committed inline `csvCell`:** PR #384 merged the
+  canonical `window.CsvSafe.cell` to main AFTER this branch's first commit. Per the SSOT rule
+  (encoders are routed, not copied — MASTER_PLAN §2.0.2 Architecture) and #384's own header naming
+  ReportGenerator as a LIVE sink, the branch was rebased onto #384 and the inline copy replaced by
+  delegation. Net: one neutralizer system-wide.
+- **Behavioral nuances (declared, benign):** (a) a routed cell whose value legitimately starts
+  with a trigger renders with a leading apostrophe Excel/Sheets treat as the text marker (not shown
+  as data); (b) `generateExcel` cells now also get RFC-4180 quote-doubling they previously lacked
+  (a fix); (c) the trigger set is now CsvSafe's superset (adds LF 0x0A) — strictly safer.
+- **Specialists consulted (G7):** security-access-expert — VERDICT **PASS_WITH_CONDITIONS**:
+  single-quote prefix is the correct OWASP technique, `"..."` transport-quoting does NOT defeat it,
+  trigger set complete, no bypass (`="evil"`, `=cmd|...`, `+1+1`, `-2+3`), numerics correctly left
+  raw, header lines correctly untouched, and **strongly preferred extracting/using a shared CsvSafe
+  SSOT** — which is exactly this PR's approach. All conditions satisfied.
+- **devils-advocate:** NOT mandatory — output-encoding change only; no firestore.rules / claims /
+  auth / field-exposure / schema / migration trigger (per §3.8.4). The 3 HTML `<script>` adds are
+  additive (define a pure global; no display/state change).
+- **G3 framing:** N/A — read-only export, no data mutation, no logging added.

--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -441,6 +441,8 @@
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
+    <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
+    <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
 
     <!-- Fluent Design Components -->

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -579,6 +579,8 @@
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager (used by .loadClients) -->
     <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
+    <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
+    <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
     <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>

--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -234,6 +234,8 @@
     <script src="js/ui/Notifications.js?v=e02c45c"></script>
     <script src="js/ui/UserForm.js?v=e02c45c"></script>
     <script src="js/ui/UserDetailsModal.js?v=e02c45c"></script>
+    <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
+    <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
     <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
     <script src="js/ui/DeleteDataSidePanel.js?v=e02c45c"></script>
     <script src="js/managers/UsersActions.js?v=e02c45c"></script>

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -904,6 +904,10 @@ return true;
 
             const { client, timesheetEntries, budgetTasks, stats } = reportData;
 
+            if (!this.ensureCsvSafe()) {
+                return;
+            }
+
             // Build CSV content
             let csv = '\uFEFF'; // BOM for Hebrew support
 
@@ -923,7 +927,7 @@ return true;
             csv += 'פירוט שעות:\n';
             csv += 'תאריך,חבר צוות,שירות,זמן (דקות),תיאור\n';
             timesheetEntries.forEach(entry => {
-                csv += `"${this.formatDate(entry.date)}","${this.dataManager.getEmployeeName(entry.employee)}","${entry.serviceName || entry.service || '-'}","${entry.minutes}","${entry.action || entry.taskDescription || entry.description || ''}"\n`;
+                csv += `"${this.formatDate(entry.date)}","${window.CsvSafe.cell(this.dataManager.getEmployeeName(entry.employee))}","${window.CsvSafe.cell(entry.serviceName || entry.service || '-')}","${entry.minutes}","${window.CsvSafe.cell(entry.action || entry.taskDescription || entry.description || '')}"\n`;
             });
             csv += '\n';
 
@@ -931,7 +935,7 @@ return true;
             csv += 'משימות:\n';
             csv += 'שם המשימה,סטטוס,זמן מתוכנן (שעות),זמן בפועל (דקות),תאריך יעד\n';
             budgetTasks.forEach(task => {
-                csv += `"${task.taskName || task.title}","${this.getTaskStatusText(task.status)}","${task.estimatedHours || 0}","${task.actualMinutes || 0}","${task.deadline ? this.formatDate(task.deadline) : '-'}"\n`;
+                csv += `"${window.CsvSafe.cell(task.taskName || task.title)}","${window.CsvSafe.cell(this.getTaskStatusText(task.status))}","${task.estimatedHours || 0}","${task.actualMinutes || 0}","${window.CsvSafe.cell(task.deadline ? this.formatDate(task.deadline) : '-')}"\n`;
             });
 
             // Download
@@ -1593,8 +1597,13 @@ return '0.00';
 
             const { employee, period, summary, clientBreakdown, entries } = reportData;
 
-            // RFC 4180: escape double quotes by doubling them
-            const csvEscape = (val) => String(val || '').replace(/"/g, '""');
+            if (!this.ensureCsvSafe()) {
+                return;
+            }
+
+            // RFC 4180 quote-doubling + OWASP CSV/formula-injection neutralization,
+            // via the shared SSOT encoder window.CsvSafe.cell (js/core/csv-safe.js).
+            const csvEscape = (val) => window.CsvSafe.cell(val);
 
             let csv = '\uFEFF'; // BOM for Hebrew/Excel support
 
@@ -1658,6 +1667,26 @@ return '0.00';
             if (window.notify) {
                 window.notify.success('הקובץ הורד בהצלחה', 'ייצוא הצליח');
             }
+        }
+
+        /**
+         * Fail-secure precondition for CSV exports: the shared SSOT encoder
+         * (js/core/csv-safe.js → window.CsvSafe.cell) MUST be loaded before any CSV
+         * is built. It neutralizes OWASP CSV / formula injection (prefixes a leading
+         * `= + - @` / TAB / CR / LF with a single quote) + preserves RFC-4180
+         * quote-doubling. If it is missing (the script did not load), ABORT the
+         * export rather than emit an un-neutralized CSV — and tell the user in Hebrew.
+         * @returns {boolean} true if the encoder is available
+         */
+        ensureCsvSafe() {
+            if (window.CsvSafe && typeof window.CsvSafe.cell === 'function') {
+                return true;
+            }
+            console.error('ReportGenerator: CsvSafe encoder not loaded (js/core/csv-safe.js must load before ReportGenerator.js)');
+            if (window.notify) {
+                window.notify.error('שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב', 'ייצוא נכשל');
+            }
+            return false;
         }
 
         /**

--- a/tests/unit/admin-panel/report-generator-csv-injection.test.ts
+++ b/tests/unit/admin-panel/report-generator-csv-injection.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests — ReportGenerator CSV exports route through the shared SSOT
+ * CSV/formula-injection encoder (PR-SEC-3).
+ *
+ * The admin downloads these CSVs and opens them in Excel / Google Sheets. A cell whose
+ * value STARTS with `= + - @` (or TAB / CR / LF) is evaluated as a formula by the
+ * spreadsheet → data exfiltration / command execution (OWASP "CSV Injection").
+ *
+ * PR-SEC-3 routes every user-controllable string cell in `generateExcel` +
+ * `generateEmployeeCSV` through the SSOT encoder `window.CsvSafe.cell`
+ * (apps/admin-panel/js/core/csv-safe.js, introduced by PR-SMS-CSV-INJECTION #384) —
+ * NOT a second inline copy. The neutralization logic itself is unit-tested by
+ * csv-safe's own suite; THESE tests prove the customer scenario end-to-end:
+ *   - a poisoned client/employee/description/task value comes out of the downloaded
+ *     CSV as inert text, never as a live formula (G4), and
+ *   - if the encoder is not loaded, the export FAILS SECURE (aborts, Hebrew notice)
+ *     rather than emitting an un-neutralized CSV.
+ *
+ * Created: 2026-06-17 — security/csv-injection-report-generator-pr-sec-3
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// The SSOT encoder MUST be loaded before ReportGenerator (mirrors the <script> order
+// wired into clients.html / clients-fluent.html / index.html). Import it first so
+// window.CsvSafe is defined when ReportGenerator's exports run.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/csv-safe.js';
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/managers/ReportGenerator.js';
+
+const reportGenerator: any = (window as any).ReportGenerator;
+const savedCsvSafe: any = (window as any).CsvSafe;
+
+// A quoted CSV field must NEVER open directly onto a formula trigger. After neutralization
+// every triggered cell opens with a single quote (`"'=...`). This catches a live formula
+// cell at the start of the file OR after any comma / newline (covers first-and-later cells).
+const OPENS_ONTO_TRIGGER = /(?:^|[,\n])"[=+\-@\t\r]/;
+
+describe('PR-SEC-3 wiring', () => {
+  it('the shared CsvSafe encoder is loaded (load-order contract)', () => {
+    expect(savedCsvSafe).toBeTruthy();
+    expect(typeof savedCsvSafe.cell).toBe('function');
+  });
+
+  it('ReportGenerator does NOT keep a second inline neutralizer (csvCell removed — SSOT)', () => {
+    // The neutralization lives ONLY in window.CsvSafe.cell; ReportGenerator must not
+    // re-declare its own csvCell copy.
+    expect(reportGenerator.csvCell).toBeUndefined();
+    expect(typeof reportGenerator.ensureCsvSafe).toBe('function');
+  });
+});
+
+// --- integration: prove the downloaded CSV is inert (G4) ---------------------
+// Capture the CSV string by stubbing the Blob constructor (no dependency on Blob.text())
+// and stubbing URL.createObjectURL so the download path doesn't throw on the fake blob.
+
+describe('generateExcel / generateEmployeeCSV — the customer scenario (G4)', () => {
+  let captured = '';
+  const RealBlob = globalThis.Blob;
+  const realCreateObjectURL = URL.createObjectURL;
+
+  beforeEach(() => {
+    captured = '';
+    (window as any).CsvSafe = savedCsvSafe; // ensure present for the happy-path tests
+    // @ts-ignore — capture the CSV parts without relying on Blob.text()
+    globalThis.Blob = function (parts: unknown[]) {
+      captured = (parts || []).join('');
+    } as any;
+    // @ts-ignore
+    URL.createObjectURL = () => 'blob:mock';
+  });
+
+  afterEach(() => {
+    globalThis.Blob = RealBlob;
+    URL.createObjectURL = realCreateObjectURL;
+    (window as any).CsvSafe = savedCsvSafe;
+    (window as any).notify = undefined;
+  });
+
+  it('generateExcel: poisoned employee / service / description / task cells are neutralized', () => {
+    reportGenerator.dataManager = { getEmployeeName: (e: unknown) => e };
+    reportGenerator.generateExcel({
+      client: { fullName: 'לקוח רגיל', caseNumber: '2025001' },
+      timesheetEntries: [{
+        date: '2026-06-17',
+        employee: "=cmd|' /C calc'!A1",
+        serviceName: '+SERVICE',
+        minutes: 60,
+        action: '=HYPERLINK("http://evil","x")'
+      }],
+      budgetTasks: [{
+        taskName: '@taskname', status: 'active', estimatedHours: 1, actualMinutes: 30, deadline: null
+      }],
+      stats: { totalHours: 1, entriesCount: 1 },
+      formData: { startDate: '2026-06-01', endDate: '2026-06-30' }
+    });
+
+    expect(captured).toContain("'=cmd|' /C calc'!A1"); // employee name
+    expect(captured).toContain("'+SERVICE");            // service name
+    expect(captured).toContain("'=HYPERLINK(");         // description neutralized
+    expect(captured).toContain('""http://evil""');      // ...with quote-doubling intact
+    expect(captured).toContain("'@taskname");           // task name
+    // No quoted cell anywhere opens directly onto a live formula trigger.
+    expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+  });
+
+  it('generateEmployeeCSV: poisoned employee name / client name / description cells are neutralized', () => {
+    reportGenerator.generateEmployeeCSV({
+      employee: { name: '=cmd', dailyTarget: 8 },
+      period: { label: 'יוני 2026', year: 2026, month: 6 },
+      summary: {
+        totalHours: 10, clientHours: 8, internalHours: 2,
+        workingDays: 5, dailyAverage: 2, quotaPercent: 80
+      },
+      clientBreakdown: [{ name: '@evilclient', hours: 3, count: 2, percent: 30 }],
+      entries: {
+        internal: [{ date: '2026-06-01', action: '+internal note', minutes: 30 }],
+        client: [{ date: '2026-06-02', clientName: '-client', action: '=desc', minutes: 60 }]
+      }
+    });
+
+    expect(captured).toContain("'=cmd");          // employee name
+    expect(captured).toContain("'@evilclient");   // client breakdown name
+    expect(captured).toContain("'+internal note"); // internal description
+    expect(captured).toContain("'-client");        // client entry name
+    expect(captured).toContain("'=desc");          // client entry description
+    expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+  });
+
+  it('generateExcel: legitimate values are unchanged (no false positives in the file)', () => {
+    reportGenerator.dataManager = { getEmployeeName: (e: unknown) => e };
+    reportGenerator.generateExcel({
+      client: { fullName: 'משה לוי', caseNumber: '2025002' },
+      timesheetEntries: [{
+        date: '2026-06-17', employee: 'דוד כהן', serviceName: 'ייעוץ', minutes: 45, action: 'פגישה עם הלקוח'
+      }],
+      budgetTasks: [],
+      stats: { totalHours: 0.75, entriesCount: 1 },
+      formData: { startDate: '2026-06-01', endDate: '2026-06-30' }
+    });
+
+    expect(captured).toContain('"דוד כהן"');
+    expect(captured).toContain('"ייעוץ"');
+    expect(captured).toContain('"פגישה עם הלקוח"');
+    // no stray single-quote was injected in front of a clean Hebrew cell
+    expect(captured).not.toContain("'דוד");
+  });
+
+  it('FAIL-SECURE: if the CsvSafe encoder is not loaded, the export ABORTS (no CSV emitted) + Hebrew notice', () => {
+    const notifyCalls: Array<{ msg: string; title: string }> = [];
+    (window as any).notify = { error: (msg: string, title: string) => notifyCalls.push({ msg, title }) };
+    delete (window as any).CsvSafe; // simulate the script not loaded
+
+    reportGenerator.dataManager = { getEmployeeName: (e: unknown) => e };
+    reportGenerator.generateExcel({
+      client: { fullName: 'לקוח', caseNumber: '1' },
+      timesheetEntries: [{ date: '2026-06-17', employee: '=cmd', serviceName: 'x', minutes: 1, action: 'y' }],
+      budgetTasks: [],
+      stats: { totalHours: 0, entriesCount: 1 },
+      formData: { startDate: '2026-06-01', endDate: '2026-06-30' }
+    });
+
+    expect(captured).toBe(''); // aborted before building/emitting any CSV
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0].msg).toMatch(/[֐-׿]/); // Hebrew error text
+  });
+});


### PR DESCRIPTION
## Summary
`generateExcel` + `generateEmployeeCSV` (apps/admin-panel/js/managers/ReportGenerator.js) wrote user-controllable values (client/employee/task names, service names, timesheet action/description) into CSV cells with only quote-doubling — or no escaping at all — so a value starting with `= + - @` (or TAB/CR/LF) executed as a formula when the CSV is opened in Excel/Sheets (OWASP CSV / formula injection). Deliberately distinct from the XSS PR #382 (HTML-escaping a CSV cell would corrupt it — different context).

## What changed (route, do not copy — encoders are SSOT)
PR #384 merged the canonical encoder `apps/admin-panel/js/core/csv-safe.js` → `window.CsvSafe.cell` (single-quote prefix on a leading trigger + RFC-4180 quote-doubling); its header names ReportGenerator as a LIVE sink to route here. This PR delegates BOTH exporters to it instead of an inline copy:
- `generateExcel`: employee name, service name, action/description, task name, status, deadline-placeholder routed through `window.CsvSafe.cell(...)`; numeric cells (minutes/hours/counts) and dates left raw.
- `generateEmployeeCSV`: the local `csvEscape` now delegates to `window.CsvSafe.cell`.
- The prior inline `csvCell` neutralizer was REMOVED (one neutralizer system-wide, no duplicate).
- `csv-safe.js` is wired to load BEFORE `ReportGenerator.js` on the 3 pages that load it (clients.html, clients-fluent.html, index.html).
- New fail-secure `ensureCsvSafe()` guard: if the encoder is missing, the export aborts with a Hebrew notice rather than emit an un-neutralized CSV.
- The Hebrew-prefixed header label-lines are untouched (they never START with a trigger).

Frontend-only, additive, output-encoding only. No data / schema / route / CF / rule / claim / auth change.

## PRODUCT-GRADE GATES
- **G1** professional errors: **PASS** — only new customer path is the fail-secure notice (Hebrew + next-action). No stack trace / undefined / English / raw FirebaseError. console.error is dev-only.
- **G2** rollback: **PASS** — see Rollback below (git revert + Netlify redeploy, under 5 min, no data migration).
- **G3** monitoring if data-mutating: **N/A** — read-only export, no Firestore write.
- **G4** test proves customer scenario: **PASS** — 2 integration tests drive the real download path with poisoned input + a fail-secure abort test; 6/6 green.
- **G5** Hebrew customer text: **PASS** — the sole customer-facing string is Hebrew.
- **G6** no breaking change: **PASS** — additive script load + output-encoding only; declared nuances are strictly-safer, non-breaking.
- **G7** security agent reviewed: **PASS** — security-access-expert PASS_WITH_CONDITIONS, explicitly preferred this shared-SSOT routing; devils-advocate N/A (no rules/claims/auth/schema/migration trigger).

## VERDICT: PASS
outcomes-grader **PASS** (97/100 — 7/7 MUST, 3/3 SHOULD, all 7 gates PASS/N-A). Rubric: `.claude/rubrics/pr-sec-3.md`. Grader ran independently: 18/18 targeted tests + 131/131 admin-panel folder green; ESLint 0 errors.

## Test plan
- `npx vitest run tests/unit/admin-panel/report-generator-csv-injection.test.ts` — 6/6 (2 integration neutralization scenarios + fail-secure abort + no-false-positives + 2 wiring/SSOT).
- `npx vitest run tests/unit/admin-panel/report-generator-service-hours.test.ts` — 12/12 (regression, untouched).
- Whole `tests/unit/admin-panel/` folder — 131/131. ESLint on changed files — 0 errors.

## Rollback
`git revert <merge sha>` then redeploy the admin panel (Netlify). The 3 script-tag adds + the routing revert together; cells return to the prior behavior. No inverse migration; nothing persisted; `csv-safe.js` (from #384) is untouched by the revert.

## Out of scope (Haim-approved Option 1, tracked separately)
- `ClientsTable.exportToExcel` (no escaping at all — worst LIVE sibling) → route to window.CsvSafe.cell in a follow-up (HIGH).
- `DataManager.exportToCsv` (3rd LIVE sink named in csv-safe.js header) → follow-up.
- `SMSManagement.convertToCSV` already routed by #384 but orphaned (defense-in-depth only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)