### PR TITLE
fix(security): neutralize CSV/formula-injection in ClientsTable export (CsvSafe SSOT)

### DIFF
--- a/.claude/rubrics/pr-clientstable-csv-injection.md
+++ b/.claude/rubrics/pr-clientstable-csv-injection.md
@@ -1,0 +1,40 @@
+# Rubric — PR-CLIENTSTABLE-CSV-INJECTION
+
+**Title:** Neutralize CSV / Formula Injection in the ClientsTable Excel export (OWASP) — route through the shared `CsvSafe` SSOT encoder
+**Base:** main (includes #384 CsvSafe + #385 ReportGenerator routing)
+**App:** Admin Panel · **Env:** DEV · **Frontend-only, additive, admin-critical**
+
+**Scope:** Route every value cell of `ClientsTable.exportToExcel()` (`apps/admin-panel/js/ui/ClientsTable.js` ~line 738) through `window.CsvSafe.cell` — the shared SSOT encoder `apps/admin-panel/js/core/csv-safe.js` (introduced by #384, wired live by #385) — plus a fail-secure `ensureCsvSafe()` guard. Add a vitest integration suite. **NOT a new inline neutralizer.**
+
+**Reachability (LIVE — security-access-expert lens):** ClientsTable is the live admin clients-list grid; `exportToExcel` is reachable via the "ייצוא ל-Excel" button. Before this fix the cell-build wrapped each value in `"..."` with **NO quote-doubling AND NO formula guard** — the WORST of the admin-panel CSV sinks. A live `client.fullName` / `caseNumber` / `assignedTo` containing `= + - @` (or `"`) → live formula execution / broken CSV when the admin opens the download. Severity **HIGH / LIVE** (unlike #384 SMS, which was orphaned).
+
+**Out of scope:** the HTML-escaping in the same file (`escapeHtml`, the `titleAttr` and `getTypeBadge` `data-tooltip-html` inline escapes) — that is the separate escapeHtml-dedup track. The sibling LIVE `DataManager.exportToCsv` CSV sink — separate chip.
+
+## MUST (block on FAIL)
+- **M1** — every cell routes through `window.CsvSafe.cell`: `rows.map(row => row.map(cell => \`"${window.CsvSafe.cell(cell)}"\`)...)`. No inline neutralizer/regex added. Hardcoded Hebrew headers left as-is (no formula trigger).
+- **M2** — fail-secure: `ensureCsvSafe()` at the top of `exportToExcel`; if `window.CsvSafe.cell` is unavailable the export ABORTS (`return`) with a Hebrew `window.notify.error`, never emits un-neutralized CSV.
+- **M3** — SSOT preserved: uses the existing `js/core/csv-safe.js` (no new file, no regex copy) — the "encoders are SSOT — route, never copy" rule.
+- **M4** — scope discipline: diff limited to `exportToExcel` + the new `ensureCsvSafe` method + the test + this rubric; the file's HTML-escaping is NOT touched.
+- **M5** — test proves the customer scenario (G4): a poisoned name/case/assignedTo comes out inert (formula-prefixed + quote-doubled), benign unchanged, fail-secure abort emits no CSV.
+- **M6** — G1: null/undefined cells → `''` (csv-safe handles), no literal `undefined`/`null` in the CSV.
+
+## SHOULD
+- **S1** — each trigger char (`= + - @`) covered in tests.
+- **S2** — load-order documented: `csv-safe.js` is present on `clients.html` + `clients-fluent.html` (from #385); the fail-secure guard is the backstop regardless of order (export is user-triggered, post-load).
+
+## Test plan
+`tests/unit/admin-panel/clientstable-csv-injection.test.ts` (vitest + happy-dom): Blob-capture integration — poisoned `=HYPERLINK("..")` / `+`/`-`/`@` cells neutralized + quote-doubled; benign Hebrew unchanged (no false-positive `'`); fail-secure abort (`captured===''` + Hebrew notice). 6/6 pass; full admin-panel suite 137/137.
+
+## Rollback
+`git revert <merge-commit>` + redeploy (frontend; Netlify auto-redeploys from main). No data migration, no schema/rule/claim change. Reverting restores the prior `exportToExcel` cell line + removes `ensureCsvSafe`; `csv-safe.js` (from #384) untouched.
+
+## PRODUCT-GRADE GATES
+- **G1 PASS** — fail-secure Hebrew notice; null/undefined → `''`; no stack-trace/undefined in output.
+- **G2 PASS** — `git revert` rollback (code-only).
+- **G3 N/A** — no data mutation (export reads `filteredClients`, writes nothing to Firestore).
+- **G4 PASS** — integration test proves poisoned cells inert + fail-secure abort.
+- **G5 PASS** — Hebrew error notice ("שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב").
+- **G6 N/A** — no contract/schema/route change; CSV columns/format byte-identical for benign data (only newly-neutralized for malicious/quote-containing values — a fix, not a break).
+- **G7 PASS** — security fix (OWASP CSV/formula injection), security-access-expert lens; SSOT-routed.
+
+VERDICT: PASS

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -704,6 +704,10 @@ ${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''
          * ייצוא לאקסל
          */
         exportToExcel() {
+            if (!this.ensureCsvSafe()) {
+                return;
+            }
+
             console.log('📥 Exporting clients to Excel...');
 
             const clients = this.dataManager.filteredClients;
@@ -734,8 +738,11 @@ ${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''
                 ];
             });
 
+            // RFC-4180 quote-doubling + OWASP CSV/formula-injection neutralization,
+            // via the shared SSOT encoder window.CsvSafe.cell (js/core/csv-safe.js).
+            // Headers are hardcoded Hebrew labels (no formula trigger) — left as-is.
             let csv = headers.join(',') + '\n';
-            csv += rows.map(row => row.map(cell => `"${cell}"`).join(',')).join('\n');
+            csv += rows.map(row => row.map(cell => `"${window.CsvSafe.cell(cell)}"`).join(',')).join('\n');
 
             // Add BOM for Hebrew support
             const BOM = '\uFEFF';
@@ -748,6 +755,24 @@ ${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''
             if (window.notify) {
                 window.notify.success('הקובץ הורד בהצלחה', 'ייצוא הצליח');
             }
+        }
+
+        /**
+         * Fail-secure guard for CSV export: the shared CSV/formula-injection
+         * encoder (js/core/csv-safe.js → window.CsvSafe.cell) MUST be present
+         * before exporting. If missing, abort with a Hebrew message rather than
+         * emit un-neutralized cells.
+         * @returns {boolean} true if the encoder is available
+         */
+        ensureCsvSafe() {
+            if (window.CsvSafe && typeof window.CsvSafe.cell === 'function') {
+                return true;
+            }
+            console.error('ClientsTable: CsvSafe encoder not loaded (js/core/csv-safe.js must be present on this page)');
+            if (window.notify) {
+                window.notify.error('שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב', 'ייצוא נכשל');
+            }
+            return false;
         }
 
         /**

--- a/tests/unit/admin-panel/clientstable-csv-injection.test.ts
+++ b/tests/unit/admin-panel/clientstable-csv-injection.test.ts
@@ -87,7 +87,7 @@ describe('ClientsTable.exportToExcel — the customer scenario (G4)', () => {
       typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
       hoursRemaining: 5,
       status: 'active',
-      assignedTo: ['@evil', 'דוד'],
+      assignedTo: ['@evil', 'דוד']
     }]);
 
     clientsTable.exportToExcel();
@@ -109,7 +109,7 @@ describe('ClientsTable.exportToExcel — the customer scenario (G4)', () => {
         typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
         hoursRemaining: 1,
         status: 'active',
-        assignedTo: [],
+        assignedTo: []
       }]);
       clientsTable.exportToExcel();
       expect(captured).toContain(`'${payload}`);
@@ -124,7 +124,7 @@ describe('ClientsTable.exportToExcel — the customer scenario (G4)', () => {
       typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
       hoursRemaining: 5,
       status: 'active',
-      assignedTo: ['דוד כהן'],
+      assignedTo: ['דוד כהן']
     }]);
 
     clientsTable.exportToExcel();
@@ -145,7 +145,7 @@ describe('ClientsTable.exportToExcel — the customer scenario (G4)', () => {
       typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
       hoursRemaining: 1,
       status: 'active',
-      assignedTo: [],
+      assignedTo: []
     }]);
 
     clientsTable.exportToExcel();

--- a/tests/unit/admin-panel/clientstable-csv-injection.test.ts
+++ b/tests/unit/admin-panel/clientstable-csv-injection.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Integration tests — ClientsTable Excel/CSV export routes through the shared SSOT
+ * CSV/formula-injection encoder (security/clientstable-csv-injection).
+ *
+ * `exportToExcel()` builds the clients-list CSV the admin downloads and opens in
+ * Excel / Google Sheets. BEFORE this fix it wrapped each cell in "..." with NO
+ * quote-doubling AND NO formula-injection guard (the worst of the admin-panel CSV
+ * sinks) — a LIVE client name like `=cmd|' /C calc'!A1` executed as a formula.
+ *
+ * The fix routes EVERY cell through `window.CsvSafe.cell` (the SSOT encoder
+ * apps/admin-panel/js/core/csv-safe.js, introduced by #384, already wired live by
+ * #385) — NOT a new inline copy — and fails secure if the encoder is missing.
+ * The neutralization logic itself is unit-tested by csv-safe's own suite; THESE
+ * tests prove the customer scenario end-to-end (G4):
+ *   - a poisoned client name / case number / assignedTo cell comes out of the
+ *     downloaded CSV as inert text, never a live formula, and
+ *   - if the encoder is not loaded, the export FAILS SECURE (aborts, Hebrew notice).
+ *
+ * Created: 2026-06-17 — security/clientstable-csv-injection
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// The SSOT encoder MUST be present before ClientsTable's export runs (mirrors the
+// <script> tags on clients.html / clients-fluent.html). Import it first so
+// window.CsvSafe is defined when exportToExcel() runs.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/csv-safe.js';
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/ui/ClientsTable.js';
+
+// window.ClientsTable is the singleton instance (new ClientsTable()).
+const clientsTable: any = (window as any).ClientsTable;
+const savedCsvSafe: any = (window as any).CsvSafe;
+
+// A quoted CSV field must NEVER open directly onto a formula trigger. After
+// neutralization every triggered cell opens with a single quote (`"'=...`).
+const OPENS_ONTO_TRIGGER = /(?:^|[,\n])"[=+\-@\t\r]/;
+
+// Feed exportToExcel its data source + neutralize the unrelated date helper.
+function setRows(rows: any[]) {
+  clientsTable.dataManager = { filteredClients: rows };
+  clientsTable.getTeamLastLogin = () => '01/06/2026';
+}
+
+describe('ClientsTable CSV wiring', () => {
+  it('the shared CsvSafe encoder is loaded (load contract)', () => {
+    expect(savedCsvSafe).toBeTruthy();
+    expect(typeof savedCsvSafe.cell).toBe('function');
+  });
+
+  it('exportToExcel has a fail-secure ensureCsvSafe guard (no inline copy)', () => {
+    expect(typeof clientsTable.ensureCsvSafe).toBe('function');
+  });
+});
+
+// --- integration: prove the downloaded CSV is inert (G4) ---------------------
+// Capture the CSV string by stubbing the Blob constructor + URL.createObjectURL.
+
+describe('ClientsTable.exportToExcel — the customer scenario (G4)', () => {
+  let captured = '';
+  const RealBlob = globalThis.Blob;
+  const realCreateObjectURL = URL.createObjectURL;
+
+  beforeEach(() => {
+    captured = '';
+    (window as any).CsvSafe = savedCsvSafe; // present for the happy-path tests
+    // @ts-ignore — capture the CSV parts without relying on Blob.text()
+    globalThis.Blob = function (parts: unknown[]) {
+      captured = (parts || []).join('');
+    } as any;
+    // @ts-ignore
+    URL.createObjectURL = () => 'blob:mock';
+  });
+
+  afterEach(() => {
+    globalThis.Blob = RealBlob;
+    URL.createObjectURL = realCreateObjectURL;
+    (window as any).CsvSafe = savedCsvSafe;
+    (window as any).notify = undefined;
+  });
+
+  it('poisoned client name / case number / assignedTo cells are neutralized', () => {
+    setRows([{
+      fullName: '=HYPERLINK("http://evil","x")',
+      caseNumber: '+2025003',
+      typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
+      hoursRemaining: 5,
+      status: 'active',
+      assignedTo: ['@evil', 'דוד'],
+    }]);
+
+    clientsTable.exportToExcel();
+
+    expect(captured).toContain("'=HYPERLINK(");   // client name — formula-prefixed
+    expect(captured).toContain('""http://evil""'); // ...with RFC-4180 quote-doubling intact
+    expect(captured).toContain("'+2025003");       // case number
+    expect(captured).toContain("'@evil");          // assignedTo join starts with @
+    // No quoted cell anywhere opens directly onto a live formula trigger.
+    expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+  });
+
+  it('each leading formula trigger (= + - @) is neutralized in the client-name cell', () => {
+    for (const payload of ['=cmd', '+1', '-1', '@x']) {
+      captured = '';
+      setRows([{
+        fullName: payload,
+        caseNumber: '2025001',
+        typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
+        hoursRemaining: 1,
+        status: 'active',
+        assignedTo: [],
+      }]);
+      clientsTable.exportToExcel();
+      expect(captured).toContain(`'${payload}`);
+      expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+    }
+  });
+
+  it('legitimate values are unchanged (no false-positive single quote)', () => {
+    setRows([{
+      fullName: 'משה לוי',
+      caseNumber: '2025002',
+      typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
+      hoursRemaining: 5,
+      status: 'active',
+      assignedTo: ['דוד כהן'],
+    }]);
+
+    clientsTable.exportToExcel();
+
+    expect(captured).toContain('"משה לוי"');
+    expect(captured).toContain('"דוד כהן"');
+    expect(captured).not.toContain("'משה"); // no stray text-marker on a clean cell
+  });
+
+  it('FAIL-SECURE: if CsvSafe is not loaded, the export ABORTS (no CSV) + Hebrew notice', () => {
+    const notifyCalls: Array<{ msg: string; title: string }> = [];
+    (window as any).notify = { error: (msg: string, title: string) => notifyCalls.push({ msg, title }) };
+    delete (window as any).CsvSafe; // simulate js/core/csv-safe.js not loaded
+
+    setRows([{
+      fullName: '=cmd',
+      caseNumber: '1',
+      typeDisplay: { kind: 'hours', label: 'שעות', breakdown: [] },
+      hoursRemaining: 1,
+      status: 'active',
+      assignedTo: [],
+    }]);
+
+    clientsTable.exportToExcel();
+
+    expect(captured).toBe(''); // aborted before building/emitting any CSV
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0].msg).toMatch(/[֐-׿]/); // Hebrew error text
+  });
+});


### PR DESCRIPTION
## Summary
Routes every value cell of `ClientsTable.exportToExcel()` (`apps/admin-panel/js/ui/ClientsTable.js`) through the shared SSOT encoder `window.CsvSafe.cell` (`js/core/csv-safe.js`, introduced by #384, wired live by #385) + a fail-secure `ensureCsvSafe()` guard. Frontend-only, additive, admin-panel.

The clients-list export previously built cells as `"${cell}"` with **no RFC-4180 quote-doubling AND no OWASP formula-injection guard** — the worst of the admin-panel CSV sinks. Rubric: `.claude/rubrics/pr-clientstable-csv-injection.md`.

## Reachability — LIVE (security-access-expert lens)
`ClientsTable` is the live admin clients-list grid; `exportToExcel` is reachable via the "ייצוא ל-Excel" button. A live `client.fullName` / `caseNumber` / `assignedTo` containing `= + - @` (or `"`) executed as a formula / broke the CSV when the admin opened the download. Severity **HIGH/LIVE** (unlike #384 SMS, which was orphaned).

## What changed (ClientsTable.js, +26/-1)
- Route: `rows.map(row => row.map(cell => \`"${window.CsvSafe.cell(cell)}"\`)...)` — every cell (no inline neutralizer; no new regex copy). Hardcoded Hebrew headers left as-is (no trigger).
- `ensureCsvSafe()` guard at the top of `exportToExcel` — if `window.CsvSafe.cell` is missing, ABORT with a Hebrew `window.notify.error`, never emit un-neutralized CSV.
- **Untouched:** the HTML-escaping in the same file (`escapeHtml`, `titleAttr`, `getTypeBadge` `data-tooltip-html`) — separate escapeHtml-dedup track; verified byte-identical.

## Test plan
`tests/unit/admin-panel/clientstable-csv-injection.test.ts` (vitest + happy-dom, Blob-capture): poisoned `=HYPERLINK("..")`/`+`/`-`/`@` cells neutralized (prefix + quote-doubling), benign Hebrew unchanged (no false-positive `'`), fail-secure abort emits no CSV. **6/6 new pass; full admin-panel suite 137/137.** ESLint via CI Code-Quality job. Independent outcomes-grader = PASS (6/6 MUST, 2/2 SHOULD).

## Rollback
`git revert <merge-commit>` + redeploy (frontend; Netlify auto-redeploys from main). No data migration, no schema/rule/claim change. `csv-safe.js` (from #384) untouched.

## PRODUCT-GRADE GATES
- **G1 PASS** — fail-secure Hebrew notice; null/undefined → `''`; no stack-trace/undefined in CSV.
- **G2 PASS** — `git revert` rollback (code-only).
- **G3 N/A** — no data mutation (export reads `filteredClients`, writes nothing).
- **G4 PASS** — integration test proves poisoned cells inert + fail-secure abort.
- **G5 PASS** — Hebrew error notice.
- **G6 N/A** — no contract/schema/route change; CSV byte-identical for benign data (only malicious/quote values newly neutralized — a fix).
- **G7 PASS** — OWASP CSV/formula-injection fix, security-access-expert lens, SSOT-routed.

VERDICT: PASS