### PR TITLE
fix(security): neutralize CSV/formula-injection in DataManager users-export via shared CsvSafe encoder

### DIFF
--- a/.claude/rubrics/pr-datamanager-csv-injection.md
+++ b/.claude/rubrics/pr-datamanager-csv-injection.md
@@ -1,0 +1,40 @@
+# Rubric — PR-DATAMANAGER-CSV-INJECTION
+
+**Title:** Neutralize CSV / Formula Injection in the DataManager users-CSV export (OWASP) — route through the shared `CsvSafe` SSOT encoder
+**Base:** main (includes #384 CsvSafe + #385 ReportGenerator routing + #386 ClientsTable routing)
+**App:** Admin Panel · **Env:** DEV · **Frontend-only, additive, admin-critical**
+
+**Scope:** Route every value cell of `DataManager.exportToCSV()` (`apps/admin-panel/js/managers/DataManager.js` ~line 707) through `window.CsvSafe.cell` — the shared SSOT encoder `apps/admin-panel/js/core/csv-safe.js` (introduced by #384, wired live by #385) — plus a fail-secure `ensureCsvSafe()` guard. Add a vitest integration suite. **NOT a new inline neutralizer.** This is the LAST live admin-panel CSV sink (the CSV-injection sub-track closes here).
+
+**Reachability (LIVE — security-access-expert lens):** `exportToCSV` builds the users-list CSV the admin downloads. It is wired LIVE from the "ייצוא" button in `FilterBar.js` (`attachExportButton` → `window.DataManager.exportToCSV()`), and FilterBar is loaded ONLY on `index.html` — where `csv-safe.js` is already present (line 238). Before this fix the cell-build wrapped each value in `"..."` with **NO quote-doubling AND NO formula guard** (identical class to #386). A live user `username`/`name`/`email`/`role` containing `= + - @` (or `"`) → live formula execution / broken CSV when the admin opens the download. Severity **HIGH / LIVE** (the user-list export of a live admin grid).
+
+**Out of scope:** the other two pages that load `DataManager.js` (`workload.html`, `employee-costs.html`) do NOT load FilterBar → the export button is not reachable there, so NO `<script>` change is needed (the `ensureCsvSafe` guard is the fail-secure backstop regardless). The Hebrew headers (`headers.join(',')`) are hardcoded with no formula trigger → left as-is.
+
+## MUST (block on FAIL)
+- **M1** — every value cell routes through `window.CsvSafe.cell`: `rows.map(r => r.map(cell => \`"${window.CsvSafe.cell(cell)}"\`)...)`. No inline neutralizer/regex added. Hardcoded Hebrew headers left as-is (no formula trigger).
+- **M2** — fail-secure: `ensureCsvSafe()` runs at the top of `exportToCSV` (before any cell is built); if `window.CsvSafe.cell` is unavailable the export ABORTS (`return`) with a Hebrew `window.notify.error`, never emits un-neutralized CSV.
+- **M3** — SSOT preserved: uses the existing `js/core/csv-safe.js` (no new file, no regex copy) — the "encoders are SSOT — route, never copy" rule.
+- **M4** — scope discipline: diff limited to `exportToCSV` + the new `ensureCsvSafe` method + the test + this rubric; no other DataManager method touched.
+- **M5** — test proves the customer scenario (G4): a poisoned name/email/role comes out inert (formula-prefixed + quote-doubled), benign Hebrew unchanged, fail-secure abort emits no CSV.
+- **M6** — G1: null/undefined cells → `''` (csv-safe handles), no literal `undefined`/`null` in the CSV.
+
+## SHOULD
+- **S1** — each trigger char (`= + - @`) covered in tests.
+- **S2** — load-order documented: `csv-safe.js` is present on `index.html` (from #385) — the only page exposing the export; the fail-secure guard is the backstop regardless of order (export is user-triggered, post-load).
+
+## Test plan
+`tests/unit/admin-panel/datamanager-csv-injection.test.ts` (vitest + happy-dom): Blob-capture integration — poisoned `=HYPERLINK("..")` / `+`/`-`/`@` cells neutralized + quote-doubled; benign Hebrew unchanged (no false-positive `'`); fail-secure abort (`captured===''` + Hebrew notice). 6/6 pass; full admin-panel suite 143/143. (Loads `constants.js` first — the DataManager singleton is built at module load and its constructor reads `window.ADMIN_PANEL_CONSTANTS`.)
+
+## Rollback
+`git revert <merge-commit>` + redeploy (frontend; Netlify auto-redeploys from main). No data migration, no schema/rule/claim change. Reverting restores the prior `exportToCSV` cell line + removes `ensureCsvSafe`; `csv-safe.js` (from #384) untouched.
+
+## PRODUCT-GRADE GATES
+- **G1 PASS** — fail-secure Hebrew notice; null/undefined → `''`; no stack-trace/undefined in output.
+- **G2 PASS** — `git revert` rollback (code-only).
+- **G3 N/A** — no data mutation (export reads `filteredUsers`, writes nothing to Firestore).
+- **G4 PASS** — integration test proves poisoned cells inert + fail-secure abort.
+- **G5 PASS** — Hebrew error notice ("שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב").
+- **G6 N/A** — no contract/schema/route change; CSV columns/format byte-identical for benign data (only newly-neutralized for malicious/quote-containing values — a fix, not a break).
+- **G7 PASS** — security fix (OWASP CSV/formula injection), security-access-expert lens; SSOT-routed.
+
+VERDICT: PASS

--- a/apps/admin-panel/js/managers/DataManager.js
+++ b/apps/admin-panel/js/managers/DataManager.js
@@ -668,6 +668,14 @@ return null;
             try {
                 console.log('📥 Exporting users to CSV...');
 
+                // SECURITY (CSV / formula injection): every value cell must be
+                // neutralized through the shared SSOT encoder (window.CsvSafe.cell,
+                // js/core/csv-safe.js) before it reaches the file. If that encoder is
+                // not loaded, fail secure — abort rather than emit un-neutralized CSV.
+                if (!this.ensureCsvSafe()) {
+                    return;
+                }
+
                 const users = this.filteredUsers;
 
                 if (users.length === 0) {
@@ -704,7 +712,7 @@ return null;
                 // Build CSV content
                 const csvContent = [
                     headers.join(','),
-                    ...rows.map(r => r.map(cell => `"${cell}"`).join(','))
+                    ...rows.map(r => r.map(cell => `"${window.CsvSafe.cell(cell)}"`).join(','))
                 ].join('\n');
 
                 // Create Blob with UTF-8 BOM for Excel compatibility
@@ -740,6 +748,26 @@ return null;
                 console.error('❌ Error exporting to CSV:', error);
                 window.notify.error('שגיאה בייצוא לExcel. נסה שוב', 'שגיאה');
             }
+        }
+
+        /**
+         * Fail-secure guard for the CSV export.
+         * Verifies the shared SSOT CSV/formula-injection encoder
+         * (window.CsvSafe.cell, js/core/csv-safe.js) is loaded before any cell is
+         * written. If it is missing, abort the export with a Hebrew notice rather
+         * than emit un-neutralized CSV.
+         *
+         * @returns {boolean} true if the encoder is available, false otherwise
+         */
+        ensureCsvSafe() {
+            if (window.CsvSafe && typeof window.CsvSafe.cell === 'function') {
+                return true;
+            }
+            console.error('DataManager: CsvSafe encoder not loaded (js/core/csv-safe.js must be present on this page)');
+            if (window.notify) {
+                window.notify.error('שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב', 'ייצוא נכשל');
+            }
+            return false;
         }
 
         /**

--- a/tests/unit/admin-panel/datamanager-csv-injection.test.ts
+++ b/tests/unit/admin-panel/datamanager-csv-injection.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Integration tests — DataManager users-CSV export routes through the shared SSOT
+ * CSV/formula-injection encoder (security/datamanager-csv-injection).
+ *
+ * `exportToCSV()` builds the users-list CSV the admin downloads from the index page
+ * (wired from the "ייצוא" button in FilterBar → window.DataManager.exportToCSV).
+ * BEFORE this fix it wrapped each cell in "..." with NO quote-doubling AND NO
+ * formula-injection guard — the LAST live CSV sink of the same class as #386
+ * (ClientsTable). A user display name like `=cmd|' /C calc'!A1` executed as a
+ * formula when the admin opened the download.
+ *
+ * The fix routes EVERY cell through `window.CsvSafe.cell` (the SSOT encoder
+ * apps/admin-panel/js/core/csv-safe.js, introduced by #384, already wired live on
+ * index.html by #385) — NOT a new inline copy — and fails secure if the encoder
+ * is missing. The neutralization logic itself is unit-tested by csv-safe's own
+ * suite; THESE tests prove the customer scenario end-to-end (G4):
+ *   - a poisoned user name / email / role cell comes out of the downloaded CSV as
+ *     inert text, never a live formula, and
+ *   - if the encoder is not loaded, the export FAILS SECURE (aborts, Hebrew notice).
+ *
+ * Created: 2026-06-21 — security/datamanager-csv-injection
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// constants.js MUST load first — the DataManager singleton is built at module load
+// (`new DataManager()`) and its constructor reads window.ADMIN_PANEL_CONSTANTS.CACHE.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/constants.js';
+// The SSOT encoder MUST be present before DataManager's export runs (mirrors the
+// <script> tag on index.html). Import it so window.CsvSafe is defined.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/csv-safe.js';
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/managers/DataManager.js';
+
+// window.DataManager is the singleton instance (new DataManager()).
+const dataManager: any = (window as any).DataManager;
+const savedCsvSafe: any = (window as any).CsvSafe;
+
+// A quoted CSV field must NEVER open directly onto a formula trigger. After
+// neutralization every triggered cell opens with a single quote (`"'=...`).
+const OPENS_ONTO_TRIGGER = /(?:^|[,\n])"[=+\-@\t\r]/;
+
+// Feed exportToCSV its data source (the filtered users list).
+function setUsers(rows: any[]) {
+  dataManager.filteredUsers = rows;
+}
+
+describe('DataManager CSV wiring', () => {
+  it('the shared CsvSafe encoder is loaded (load contract)', () => {
+    expect(savedCsvSafe).toBeTruthy();
+    expect(typeof savedCsvSafe.cell).toBe('function');
+  });
+
+  it('exportToCSV has a fail-secure ensureCsvSafe guard (no inline copy)', () => {
+    expect(typeof dataManager.ensureCsvSafe).toBe('function');
+  });
+});
+
+// --- integration: prove the downloaded CSV is inert (G4) ---------------------
+// Capture the CSV string by stubbing the Blob constructor + URL.createObjectURL.
+
+describe('DataManager.exportToCSV — the customer scenario (G4)', () => {
+  let captured = '';
+  const RealBlob = globalThis.Blob;
+  const realCreateObjectURL = URL.createObjectURL;
+
+  beforeEach(() => {
+    captured = '';
+    (window as any).CsvSafe = savedCsvSafe; // present for the happy-path tests
+    // @ts-ignore — capture the CSV parts without relying on Blob.text()
+    globalThis.Blob = function (parts: unknown[]) {
+      captured = (parts || []).join('');
+    } as any;
+    // @ts-ignore
+    URL.createObjectURL = () => 'blob:mock';
+  });
+
+  afterEach(() => {
+    globalThis.Blob = RealBlob;
+    URL.createObjectURL = realCreateObjectURL;
+    (window as any).CsvSafe = savedCsvSafe;
+    (window as any).notify = undefined;
+  });
+
+  it('poisoned user name / email / role cells are neutralized', () => {
+    setUsers([{
+      username: '=HYPERLINK("http://evil","x")',
+      email: '+evil@example.com',
+      role: '@admin',
+      isActive: true,
+      clientsCount: 3,
+      tasksCount: 7,
+      hoursThisWeek: 5,
+      hoursThisMonth: 20
+    }]);
+
+    dataManager.exportToCSV();
+
+    expect(captured).toContain("'=HYPERLINK(");   // user name — formula-prefixed
+    expect(captured).toContain('""http://evil""'); // ...with RFC-4180 quote-doubling intact
+    expect(captured).toContain("'+evil@example.com"); // email
+    expect(captured).toContain("'@admin");         // role string (via getRoleText)
+    // No quoted cell anywhere opens directly onto a live formula trigger.
+    expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+  });
+
+  it('each leading formula trigger (= + - @) is neutralized in the user-name cell', () => {
+    for (const payload of ['=cmd', '+1', '-1', '@x']) {
+      captured = '';
+      setUsers([{
+        username: payload,
+        email: 'user@example.com',
+        role: 'employee',
+        isActive: true,
+        clientsCount: 0,
+        tasksCount: 0,
+        hoursThisWeek: 0,
+        hoursThisMonth: 0
+      }]);
+      dataManager.exportToCSV();
+      expect(captured).toContain(`'${payload}`);
+      expect(captured).not.toMatch(OPENS_ONTO_TRIGGER);
+    }
+  });
+
+  it('legitimate values are unchanged (no false-positive single quote)', () => {
+    setUsers([{
+      username: 'משה לוי',
+      email: 'moshe@example.com',
+      role: 'admin',
+      isActive: true,
+      clientsCount: 5,
+      tasksCount: 2,
+      hoursThisWeek: 3,
+      hoursThisMonth: 12
+    }]);
+
+    dataManager.exportToCSV();
+
+    expect(captured).toContain('"משה לוי"');
+    expect(captured).toContain('"moshe@example.com"');
+    expect(captured).not.toContain("'משה"); // no stray text-marker on a clean cell
+  });
+
+  it('FAIL-SECURE: if CsvSafe is not loaded, the export ABORTS (no CSV) + Hebrew notice', () => {
+    const notifyCalls: Array<{ msg: string; title: string }> = [];
+    (window as any).notify = { error: (msg: string, title: string) => notifyCalls.push({ msg, title }) };
+    delete (window as any).CsvSafe; // simulate js/core/csv-safe.js not loaded
+
+    setUsers([{
+      username: '=cmd',
+      email: 'x@example.com',
+      role: 'employee',
+      isActive: true,
+      clientsCount: 0,
+      tasksCount: 0,
+      hoursThisWeek: 0,
+      hoursThisMonth: 0
+    }]);
+
+    dataManager.exportToCSV();
+
+    expect(captured).toBe(''); // aborted before building/emitting any CSV
+    expect(notifyCalls.length).toBe(1);
+    expect(notifyCalls[0].msg).toMatch(/[֐-׿]/); // Hebrew error text
+  });
+});


### PR DESCRIPTION
## What

Routes every value cell of `DataManager.exportToCSV()` through the shared SSOT encoder `window.CsvSafe.cell` (`apps/admin-panel/js/core/csv-safe.js`, introduced by #384) instead of the raw `"${cell}"` wrap that had **NO quote-doubling and NO formula guard** — the **LAST live admin-panel CSV sink** (same class as the merged #386 ClientsTable). A user `username`/`name`/`email`/`role` beginning with `= + - @` executed as a formula when the admin opened the download; a stray `"` broke the CSV.

Adds a fail-secure `ensureCsvSafe()` guard: if the encoder is not loaded, the export aborts with a Hebrew notice rather than emit un-neutralized CSV. Faithful mirror of merged precedent #386 — **route, never copy (encoders are SSOT)**.

This closes the CSV-injection sub-track (#384 SMS, #385 ReportGenerator, #386 ClientsTable, this = DataManager).

## Scope / Reachability (security-access-expert lens)

- `exportToCSV` is wired LIVE from the "ייצוא" button in `FilterBar.js` (`attachExportButton` -> `window.DataManager.exportToCSV()`), and FilterBar is loaded **only on `index.html`** — where `csv-safe.js` is already present (line 238).
- The other two pages loading `DataManager.js` (`workload.html`, `employee-costs.html`) do **not** load FilterBar -> the export button is unreachable there, so **no `<script>` change is needed**; `ensureCsvSafe` is the fail-secure backstop regardless.
- Hardcoded Hebrew headers (`headers.join(',')`) have no formula trigger -> left as-is.
- Diff limited to `exportToCSV` + the new `ensureCsvSafe` method + the test + the rubric (+30/-1 in DataManager.js).

## Test plan (G4)

`tests/unit/admin-panel/datamanager-csv-injection.test.ts` (vitest + happy-dom, Blob-capture integration):
- poisoned `=HYPERLINK("..")` / `+` / `-` / `@` name/email/role cells -> inert (formula-prefixed + RFC-4180 quote-doubled), no quoted cell opens onto a live trigger;
- benign Hebrew (`משה לוי`) unchanged — no false-positive `'`;
- fail-secure: encoder missing -> export aborts (`captured===''`) + Hebrew notice.

6/6 new pass; full admin-panel suite **143/143** (137 prior + 6).

## Reviews

- **outcomes-grader = PASS** (6/6 MUST, 2/2 SHOULD, 7/7 gates; independent read of the files; confirmed faithful mirror of #386, scope-disciplined, fail-secure, G4-proven).
- security-access-expert lens (OWASP CSV/formula injection): SSOT-routed, fail-secure.
- Rubric: `.claude/rubrics/pr-datamanager-csv-injection.md`.

## Rollback

`git revert <merge-commit>` + redeploy (frontend; Netlify auto-redeploys from main). No data migration, no schema/rule/claim change. Reverting restores the prior `exportToCSV` cell line + removes `ensureCsvSafe`; `csv-safe.js` (#384) untouched. Executable in under 5 minutes.

## PRODUCT-GRADE GATES

- **G1 PASS** — fail-secure Hebrew notice ("שגיאה בייצוא הקובץ — רכיב אבטחה חסר. רענן את הדף ונסה שוב"); null/undefined cells -> `''` via csv-safe; no stack-trace/undefined/[object Object] in output.
- **G2 PASS** — `git revert` rollback (code-only).
- **G3 N/A** — no data mutation (export reads `filteredUsers`, writes nothing to Firestore).
- **G4 PASS** — Blob-capture integration test proves poisoned cells inert + fail-secure abort.
- **G5 PASS** — Hebrew customer-facing error notice; `console.*` lines are dev-only (acceptable).
- **G6 N/A** — no contract/schema/route change; CSV byte-identical for benign data (only malicious/quote-containing values newly neutralized — a fix, not a break).
- **G7 PASS** — security fix (OWASP CSV/formula injection), security-access-expert lens; SSOT-routed; no auth/permission/PII surface changed.

VERDICT: PASS