### PR TITLE
refactor(security): escapeHtml SSOT PR1 — shared window.escapeHtml + route the string-replace escaper family

### DIFF
--- a/.claude/rubrics/pr-escapehtml-ssot-pr1.md
+++ b/.claude/rubrics/pr-escapehtml-ssot-pr1.md
@@ -1,0 +1,35 @@
+# Rubric — PR-ESCAPEHTML-SSOT-PR1
+
+**Title:** escapeHtml SSOT consolidation — PR1: the shared `window.escapeHtml` util + the string-replace → innerHTML family
+**App:** Admin Panel · **Env:** DEV · **Frontend-only, refactor (SSOT-preserving), admin-critical**
+
+**Scope:** PR1 of the Haim-approved 3-PR escapeHtml-dedup (checkpoint 2026-06-17). Create ONE canonical escaper `apps/admin-panel/js/core/escape-html.js` → `window.escapeHtml` (5-entity `& < > " '` → `&amp; &lt; &gt; &quot; &#039;`, `null`/`undefined`→`''`, classic IIFE + `module.exports` guard, alongside `js/core/csv-safe.js`), and ROUTE the **string-replace → innerHTML** escaper family to delegate to it: `client-case-selector.js`, `EmployeeCostsPage.js`, `ProfitabilityPage.js`, `AuditTrailPage.js`, `SystemSettingsPage.js`, `client-type-display.js`. Add the `<script>` on the 6 host pages + cache-bust. **NOT** the textContent family (PR2) or `WorkloadCard.sanitize` (PR3).
+
+## MUST (block on FAIL)
+- **M1** — SSOT created: `js/core/escape-html.js` defines the canonical 5-entity escaper (`&#039;` 3-digit, matching `ReportGenerator`/`WhatsApp` pinned by `report-generator-escaping.test.ts`), `null`/`undefined`→`''` guard, `window.escapeHtml` + `module.exports`. No new inline escape logic added anywhere.
+- **M2** — the 6 escapers DELEGATE to `window.escapeHtml` (`return window.escapeHtml(...)`); the duplicated `.replace(...)` regex/map logic is REMOVED from each. "Route, never copy."
+- **M3** — scope discipline / MUST-EXCLUDE: `ClientsTable.js` `data-tooltip-html` (2-entity `&`+`"`, packs already-rendered HTML) is NOT touched; the ~16 textContent copies (PR2) + `WorkloadCard.sanitize` (PR3) are NOT touched.
+- **M4** — behavior changes DECLARED (G6): AuditTrailPage + SystemSettingsPage now also escape `'`→`&#039;` (4-entity → 5-entity, a security improvement); EmployeeCostsPage + ProfitabilityPage shift `&#39;`→`&#039;` (entity-equivalent, same render); the null-guard tightens from `!str` to `null`/`undefined`-only (a literal `0`/`false` stringifies instead of blanking). Benign string output otherwise unchanged.
+- **M5** — tests: `escape-html.test.ts` pins the 5-entity shape + each char + the `null`/`undefined` guard + the `0`/`false` stringify; `client-type-display.test.ts` imports `escape-html.js` so `renderTypeTooltip`'s delegated escaper resolves; full admin-panel suite green.
+- **M6** — cache-bust: the new `escape-html.js` `<script>` loads BEFORE consumers (after `constants.js`) on all 6 pages, and the 6 changed consumer files get a bumped `?v=` so browsers reload them.
+
+## SHOULD
+- **S1** — the routed wrappers carry a one-line comment pointing to the SSOT + (where applicable) the byte-change note.
+- **S2** — `client-type-display.js` (#6, coupled to the excluded ClientsTable tooltip) escapes leaf text only — documented in the wrapper comment; its existing test stays green.
+
+## Test plan
+`tests/unit/admin-panel/escape-html.test.ts` (8 tests: load contract, 5-entity canonical shape, per-char, script payload, null/undefined guard, 0/false stringify, benign Hebrew unchanged, global/repeat). Affected suites green: `client-type-display.test.ts` (renderTypeTooltip output unchanged — byte-identical escaper), `employee-costs-pii-guard.test.ts` + `profitability-pii-guard.test.ts` (static source guards, unaffected). Full admin-panel suite **151/151** (143 prior + 8). (The 1 failing file in the full root run — `user-app/israeli-id-drift-guard.test.ts`, `Failed to resolve "zod"` — is a worktree partial-node_modules artifact unrelated to this admin-panel-only PR; passes in CI with full deps.)
+
+## Rollback
+`git revert <merge-commit>` + redeploy (frontend; Netlify). No data migration, no schema/rule change. Reverting restores the 6 local escapers + removes `escape-html.js` + the 6 `<script>` tags.
+
+## PRODUCT-GRADE GATES
+- **G1 PASS** — the SSOT guard returns `''` for null/undefined; no `undefined`/`null`/`[object Object]` reaches output.
+- **G2 PASS** — `git revert` rollback (code-only).
+- **G3 N/A** — no data mutation (pure display-string escaping refactor).
+- **G4 PASS** — `escape-html.test.ts` proves the escaper output + the integration via `client-type-display.test.ts` (renderTypeTooltip).
+- **G5 PASS** — escaper maps only `& < > " '`; Hebrew + all other text passes through unchanged.
+- **G6 PASS (declared)** — behavior change: AuditTrail/SystemSettings now escape `'` (security improvement, not a break); apostrophe-entity + null-guard shifts are entity-equivalent/safer. No customer-visible regression for benign input.
+- **G7 PASS** — XSS hardening (consolidates escapers, upgrades 2 to full 5-entity), security-access-expert lens; the URL/CSS-unsafe caveat is documented in the util header; ClientsTable pre-built-HTML tooltip correctly excluded.
+
+VERDICT: PASS

--- a/apps/admin-panel/audit-trail.html
+++ b/apps/admin-panel/audit-trail.html
@@ -61,10 +61,12 @@
     <script src="js/core/config-loader.js"></script>
     <script src="js/core/auth.js"></script>
     <script src="js/core/constants.js"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <script src="js/core/auth-guard.js?v=20250103"></script>
     <script src="js/ui/Navigation.js"></script>
-    <script src="js/ui/AuditTrailPage.js?v=20260417a"></script>
+    <script src="js/ui/AuditTrailPage.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <script>

--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -429,6 +429,8 @@
     <script src="js/core/config-loader.js?v=20251125"></script>
     <script src="js/core/auth.js?v=20251125"></script>
     <script src="js/core/constants.js?v=20251125"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- Navigation Component -->
     <script src="js/ui/Navigation.js?v=20251125"></script>
@@ -437,7 +439,7 @@
     <!-- PR-2.1.1: business-rules-adapter loads window.BUSINESS_RULES — must come before any consumer -->
     <script src="js/shared/business-rules-adapter.js?v=20260526-pr-2-1-1"></script>
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager -->
-    <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
+    <script src="js/core/client-type-display.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
     <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -561,6 +561,8 @@
     <script src="js/core/config-loader.js?v=20251123v1"></script>
     <script src="js/core/auth.js?v=20251123v1"></script>
     <script src="js/core/constants.js?v=20251123v1"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- ===== Auth Guard (Unified Authentication) ===== -->
     <script src="js/core/auth-guard.js?v=20250103"></script>
@@ -577,7 +579,7 @@
     <!-- PR-2.1.1: business-rules-adapter loads window.BUSINESS_RULES — must come before any consumer -->
     <script src="js/shared/business-rules-adapter.js?v=20260526-pr-2-1-1"></script>
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager (used by .loadClients) -->
-    <script src="js/core/client-type-display.js?v=20260514-mixed"></script>
+    <script src="js/core/client-type-display.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
     <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
@@ -611,7 +613,7 @@
     <!-- ===== Legacy Dependencies (still needed by other modules) ===== -->
     <script src="js/modules/logger.js?v=20251201-FIX2"></script>
     <script src="js/modules/event-bus.js?v=20251201-FIX2"></script>
-    <script src="js/modules/client-case-selector.js?v=20251201-FIX2"></script>
+    <script src="js/modules/client-case-selector.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/modules/service-card-renderer.js?v=20251201-FIX2"></script>
 
     <!-- ===== Floating Action Button ===== -->

--- a/apps/admin-panel/employee-costs.html
+++ b/apps/admin-panel/employee-costs.html
@@ -66,6 +66,8 @@
     <script src="js/core/config-loader.js"></script>
     <script src="js/core/auth.js"></script>
     <script src="js/core/constants.js"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- ===== Auth Guard ===== -->
     <script src="js/core/auth-guard.js?v=20250103"></script>
@@ -76,7 +78,7 @@
     <!-- ===== Data + Modals + Page + Notifications ===== -->
     <script src="js/managers/DataManager.js"></script>
     <script src="js/ui/Modals.js"></script>
-    <script src="js/ui/EmployeeCostsPage.js"></script>
+    <script src="js/ui/EmployeeCostsPage.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <!-- ===== Page Initialization ===== -->

--- a/apps/admin-panel/js/core/client-type-display.js
+++ b/apps/admin-panel/js/core/client-type-display.js
@@ -125,12 +125,10 @@
             return '<div class="type-tooltip"><em>אין שירותים</em></div>';
         }
 
-        const escapeHtml = (str) => String(str || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#039;');
+        // Routed to the shared SSOT escaper (js/core/escape-html.js) — escapes leaf
+        // text only (the assembled tooltip HTML is handled by ClientsTable, excluded).
+        // Byte-identical for string input (same 5 entities incl. &#039;).
+        const escapeHtml = (str) => window.escapeHtml(str);
 
         const activeRows = breakdown.filter(b => b.isActive).map(b => {
             const typeLabel = b.isFixed ? 'פיקס' : 'שעות';

--- a/apps/admin-panel/js/core/escape-html.js
+++ b/apps/admin-panel/js/core/escape-html.js
@@ -1,0 +1,47 @@
+/**
+ * Shared HTML-escape SSOT — apps/admin-panel/js/core/escape-html.js
+ *
+ * The ONE canonical HTML-entity escaper for the Admin Panel. Consolidates the
+ * duplicated escapeHtml / escapeHTML / _escapeHtml copies (escapeHtml SSOT dedup,
+ * 3-PR plan — this is PR1, the string-replace → innerHTML family) into a single
+ * 5-entity escaper exposed as `window.escapeHtml`.
+ *
+ * Escapes & < > " ' → &amp; &lt; &gt; &quot; &#039; — safe for HTML TEXT and for
+ * quoted ATTRIBUTE values. NOT URL/CSS-safe (no `javascript:` protection) — never
+ * use it for href / src / style / inline-event sinks.
+ *
+ * Guard: null / undefined → '' (only). A literal 0 / false is escaped to its
+ * string form, NOT blanked — the stricter, safer guard (vs the `if (!text)` form
+ * some copies used, which silently dropped a legitimate 0).
+ *
+ * Mirrors the js/core/ encoder pattern (csv-safe.js / budget-status.js):
+ * classic IIFE + window global + a module.exports guard so vitest can import it.
+ */
+(function () {
+  'use strict';
+
+  const MAP = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#039;'
+  };
+
+  function escapeHtml(text) {
+    if (text === null || text === undefined) {
+      return '';
+    }
+    return String(text).replace(/[&<>"']/g, function (ch) {
+      return MAP[ch];
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    window.escapeHtml = escapeHtml;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { escapeHtml: escapeHtml };
+  }
+})();

--- a/apps/admin-panel/js/modules/client-case-selector.js
+++ b/apps/admin-panel/js/modules/client-case-selector.js
@@ -1668,19 +1668,9 @@ input.value = '';
      * Escape HTML
      */
     escapeHtml(text) {
-      if (text === null || text === undefined) {
-        return '';
-      }
-      // המרה למחרזת אם זה לא מחרזת
-      text = String(text);
-      const map = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        "'": '&#039;'
-      };
-      return text.replace(/[&<>"']/g, m => map[m]);
+      // Routed to the shared SSOT escaper (apps/admin-panel/js/core/escape-html.js).
+      // Byte-identical to the prior local copy (same 5 entities, same null/undefined guard).
+      return window.escapeHtml(text);
     }
 
     /**

--- a/apps/admin-panel/js/ui/AuditTrailPage.js
+++ b/apps/admin-panel/js/ui/AuditTrailPage.js
@@ -998,10 +998,10 @@
   }
 
   function _escapeHtml(str) {
-    if (!str) {
- return '';
-}
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    // Routed to the shared SSOT escaper (js/core/escape-html.js).
+    // Behavior change (security improvement): now also escapes ' → &#039; (was 4-entity);
+    // and 0/false stringify instead of blanking (the stricter null/undefined guard).
+    return window.escapeHtml(str);
   }
 
   window.AuditTrailPage = AuditTrailPage;

--- a/apps/admin-panel/js/ui/EmployeeCostsPage.js
+++ b/apps/admin-panel/js/ui/EmployeeCostsPage.js
@@ -595,15 +595,9 @@
     },
 
     _escapeHtml: function(str) {
-      if (str === null || str === undefined) {
-        return '';
-      }
-      return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+      // Routed to the shared SSOT escaper (js/core/escape-html.js).
+      // Behavior change: the apostrophe now encodes as &#039; (was &#39;) — same render.
+      return window.escapeHtml(str);
     }
   };
 

--- a/apps/admin-panel/js/ui/ProfitabilityPage.js
+++ b/apps/admin-panel/js/ui/ProfitabilityPage.js
@@ -734,15 +734,9 @@
     },
 
     _escapeHtml: function (str) {
-      if (str === null || str === undefined) {
-        return '';
-      }
-      return String(str)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+      // Routed to the shared SSOT escaper (js/core/escape-html.js).
+      // Behavior change: the apostrophe now encodes as &#039; (was &#39;) — same render.
+      return window.escapeHtml(str);
     }
   };
 

--- a/apps/admin-panel/js/ui/SystemSettingsPage.js
+++ b/apps/admin-panel/js/ui/SystemSettingsPage.js
@@ -521,10 +521,10 @@
   };
 
   function _escapeHtml(str) {
-    if (!str) {
- return '';
-}
-    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    // Routed to the shared SSOT escaper (js/core/escape-html.js).
+    // Behavior change (security improvement): now also escapes ' → &#039; (was 4-entity);
+    // and 0/false stringify instead of blanking (the stricter null/undefined guard).
+    return window.escapeHtml(str);
   }
 
   window.SystemSettingsPage = SystemSettingsPage;

--- a/apps/admin-panel/profitability.html
+++ b/apps/admin-panel/profitability.html
@@ -66,6 +66,8 @@
     <script src="js/core/config-loader.js"></script>
     <script src="js/core/auth.js"></script>
     <script src="js/core/constants.js"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- ===== Auth Guard ===== -->
     <script src="js/core/auth-guard.js?v=20250103"></script>
@@ -76,7 +78,7 @@
     <!-- ===== Modals + Pure Formatters + Page + Notifications ===== -->
     <script src="js/ui/Modals.js"></script>
     <script src="js/core/profitability-format.js"></script>
-    <script src="js/ui/ProfitabilityPage.js"></script>
+    <script src="js/ui/ProfitabilityPage.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/ui/Notifications.js"></script>
 
     <!-- ===== Page Initialization ===== -->

--- a/apps/admin-panel/settings.html
+++ b/apps/admin-panel/settings.html
@@ -66,6 +66,8 @@
     <script src="js/core/config-loader.js"></script>
     <script src="js/core/auth.js"></script>
     <script src="js/core/constants.js"></script>
+    <!-- Shared HTML-escape SSOT (window.escapeHtml) — load before any escaper consumer -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- ===== Auth Guard ===== -->
     <script src="js/core/auth-guard.js?v=20250103"></script>
@@ -74,7 +76,7 @@
     <script src="js/ui/Navigation.js"></script>
 
     <!-- ===== Settings Page Component ===== -->
-    <script src="js/ui/SystemSettingsPage.js"></script>
+    <script src="js/ui/SystemSettingsPage.js?v=20260621-escapehtml-pr1"></script>
 
     <!-- ===== Notifications ===== -->
     <script src="js/ui/Notifications.js"></script>

--- a/tests/unit/admin-panel/client-type-display.test.ts
+++ b/tests/unit/admin-panel/client-type-display.test.ts
@@ -10,6 +10,12 @@
 
 import { describe, it, expect } from 'vitest';
 
+// renderTypeTooltip's leaf-text escaper now delegates to the shared SSOT
+// window.escapeHtml (escapeHtml-dedup PR1) — import it first so the global is
+// defined when the tooltip renders.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/escape-html.js';
+
 // @ts-ignore — CommonJS require from TypeScript ESM test
 import {
   computeClientTypeDisplay,

--- a/tests/unit/admin-panel/escape-html.test.ts
+++ b/tests/unit/admin-panel/escape-html.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests — the shared HTML-escape SSOT (apps/admin-panel/js/core/escape-html.js).
+ *
+ * `window.escapeHtml` is the ONE canonical 5-entity escaper that PR1 of the
+ * escapeHtml-dedup routes the string-replace → innerHTML family through. These
+ * tests pin its exact output shape (`& < > " '` → `&amp; &lt; &gt; &quot; &#039;`),
+ * which MUST match the canonical ReportGenerator/WhatsApp escaper already pinned by
+ * report-generator-escaping.test.ts / whatsapp-message-dialog-escaping.test.ts, plus
+ * the stricter null/undefined-only guard.
+ *
+ * Created: 2026-06-21 — refactor/escapehtml-ssot-pr1
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/escape-html.js';
+
+const escapeHtml: (t: unknown) => string = (window as any).escapeHtml;
+
+describe('window.escapeHtml — the SSOT 5-entity escaper', () => {
+  it('is loaded as a global function', () => {
+    expect(typeof escapeHtml).toBe('function');
+  });
+
+  it('escapes all five entities in the canonical shape (matches ReportGenerator/WhatsApp)', () => {
+    expect(escapeHtml('<>&"\'')).toBe('&lt;&gt;&amp;&quot;&#039;');
+  });
+
+  it('escapes each trigger character individually', () => {
+    expect(escapeHtml('&')).toBe('&amp;');
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('>')).toBe('&gt;');
+    expect(escapeHtml('"')).toBe('&quot;');
+    expect(escapeHtml("'")).toBe('&#039;');
+  });
+
+  it('neutralizes a script-injection payload', () => {
+    expect(escapeHtml('<img src=x onerror=alert(1)>'))
+      .toBe('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('null / undefined → empty string', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+
+  it('a literal 0 / false is stringified, NOT blanked (stricter guard than !text)', () => {
+    expect(escapeHtml(0)).toBe('0');
+    expect(escapeHtml(false)).toBe('false');
+  });
+
+  it('leaves benign Hebrew + plain text unchanged', () => {
+    expect(escapeHtml('משה לוי')).toBe('משה לוי');
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+  });
+
+  it('escapes every occurrence (global), including repeated + already-encoded entities', () => {
+    expect(escapeHtml('a & b & c')).toBe('a &amp; b &amp; c');
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+});


### PR DESCRIPTION
## What

PR1 of the Haim-approved 3-PR **escapeHtml SSOT consolidation** (checkpoint 2026-06-17). Consolidates the duplicated HTML-escape helpers into ONE canonical escaper and routes the **string-replace → innerHTML** family to it.

- **NEW `apps/admin-panel/js/core/escape-html.js` → `window.escapeHtml`**: 5-entity `& < > " '` → `&amp; &lt; &gt; &quot; &#039;` (matches the `ReportGenerator`/`WhatsApp` shape pinned by `report-generator-escaping.test.ts`), `null`/`undefined`→`''`, classic IIFE + `module.exports` guard (mirrors `js/core/csv-safe.js`). NOT URL/CSS-safe — documented in the header.
- **Route 6 escapers to delegate** (`return window.escapeHtml(...)` — logic deduped, call-sites unchanged): `client-case-selector.js`, `EmployeeCostsPage.js`, `ProfitabilityPage.js`, `AuditTrailPage.js`, `SystemSettingsPage.js`, `client-type-display.js`.
- **Wire + cache-bust**: add `<script src="js/core/escape-html.js?v=…">` on 6 host pages (after `constants.js`, before consumers) + bump the 6 changed consumers' `?v=`.

## Behavior changes (declared — G6)

- **AuditTrailPage + SystemSettingsPage** now ALSO escape `'`→`&#039;` (were 4-entity → 5-entity) — a **security improvement**, pinned by a test.
- **EmployeeCostsPage + ProfitabilityPage**: `&#39;` → `&#039;` (entity-equivalent, same browser render).
- null-guard tightens from `!str` to `null`/`undefined`-only — a literal `0`/`false` now stringifies instead of blanking (no active call-site passes `0`/`false`; devils-advocate confirmed empty blast radius).
- Benign string output otherwise unchanged.

## Excluded (scope discipline)

`ClientsTable` `data-tooltip-html` (2-entity, packs already-rendered HTML — a `<>`-escaper would break it); the ~16 `textContent` copies (**PR2**); `WorkloadCard.sanitize` (**PR3**).

## Reviews

- **devils-advocate = GO** — the critical "a page loads a routed file but not `escape-html.js`" attack does **NOT** fire: verified all 6 admin pages load `escape-html.js`, and user-app's `client-case-selector.js` is a **separate untouched copy** (different hash, own local escaper). Load-order, the ClientsTable exclusion, global collision, and cache-bust all clean.
- **outcomes-grader = PASS_WITH_WARNINGS** — 6/6 MUST, 2/2 SHOULD, 7/7 gates PASS/N/A. The grader empirically executed the real modules (15/15 assertion pairs) since the worktree's partial `node_modules` blocks the vitest runner — that warning is environment-only; CI runs with full deps.
- Rubric: `.claude/rubrics/pr-escapehtml-ssot-pr1.md`.

## Test plan (G4)

`tests/unit/admin-panel/escape-html.test.ts` (8 tests: load contract, 5-entity canonical shape, per-char, script payload, null/undefined guard, `0`/`false` stringify, benign Hebrew unchanged, global/repeat). `client-type-display.test.ts` imports `escape-html.js` so `renderTypeTooltip`'s delegated escaper resolves. Full **admin-panel suite 151/151** (143 prior + 8) via the documented NODE_PATH technique. (The 1 failing file in the full root run — `user-app/israeli-id-drift-guard.test.ts`, `Failed to resolve "zod"` — is a worktree partial-`node_modules` artifact in a file this admin-panel-only PR does not touch; it passes in CI with full deps.)

## Rollback

`git revert <merge-commit>` + redeploy (frontend; Netlify). No data migration, no schema/rule change. Reverting restores the 6 local escapers + removes `escape-html.js` + the 6 `<script>` tags. Executable in under 5 minutes.

## PRODUCT-GRADE GATES

- **G1 PASS** — the SSOT guard returns `''` for null/undefined; no `undefined`/`null`/`[object Object]` in output.
- **G2 PASS** — `git revert` rollback (code-only).
- **G3 N/A** — no data mutation (pure display-string escaping refactor).
- **G4 PASS** — `escape-html.test.ts` proves the output + `client-type-display.test.ts` proves the integration (renderTypeTooltip).
- **G5 PASS** — escaper maps only `& < > " '`; Hebrew + all other text passes through unchanged.
- **G6 PASS (declared)** — behavior change: AuditTrail/SystemSettings now escape `'` (security improvement, not a break); apostrophe-entity + null-guard shifts are entity-equivalent/safer; no customer-visible regression for benign input.
- **G7 PASS** — XSS hardening (consolidates escapers + upgrades 2 to full 5-entity), security-access-expert lens; URL/CSS-unsafe caveat documented; ClientsTable pre-built-HTML tooltip correctly excluded.

VERDICT: PASS_WITH_WARNINGS