### PR TITLE
refactor(admin-panel): escapeHtml SSOT consolidation — PR2 (route 16 escapers)

### DIFF
--- a/.claude/rubrics/pr-escapehtml-ssot-pr2.md
+++ b/.claude/rubrics/pr-escapehtml-ssot-pr2.md
@@ -1,0 +1,38 @@
+# Rubric — PR-ESCAPEHTML-SSOT-PR2
+
+**Title:** escapeHtml SSOT consolidation — PR2: the temp-div textContent family + the 2 inline-map copies → `window.escapeHtml`
+**App:** Admin Panel · **Env:** DEV · **Frontend-only, refactor (SSOT-preserving), admin-critical**
+
+**Scope:** PR2 of the Haim-approved 3-PR escapeHtml-dedup (checkpoint 2026-06-17; PR2 scope re-confirmed 2026-06-21 → "PR אחד, 16 routes"). Route the remaining LIVE duplicated escapers to the SSOT `apps/admin-panel/js/core/escape-html.js` → `window.escapeHtml` (shipped PR1 #390). **16 escapers** — 14 "temp-div" copies (`div.textContent = x; return div.innerHTML;`, 3-entity `& < >` only) + 2 inline-map 5-entity copies (`ReportGenerator`, `WhatsAppMessageDialog`) — each body replaced with `return window.escapeHtml(<param>);` (call-sites unchanged). Add `<script src="js/core/escape-html.js">` to the 2 host pages that lack it (**index.html**, **system-announcements.html**) + a full per-occurrence `?v=` bump across the 4 host pages (index, system-announcements, clients, clients-fluent). Fix the 2 existing behavioral tests that would otherwise red-CI. **NOT** `notification-bell.safeText` (onclick JS-string hazard — excluded), `case-form-validator` (dead admin copy — PR3 delete), `WorkloadCard.sanitize`/`service-card-renderer` (PR3), or the ClientsTable `data-tooltip-html` / ClientManagementModal `data-name` inline partials (permanent excludes).
+
+### The 16 routed escapers
+MessagesFullscreenModal `escapeHTML` · FluentDataGrid `escapeHtml` · DeleteDataSidePanel `escapeHtml` · ServiceOverdraftResolution `escapeHtml` · AnnouncementCard `static escapeHtml` · AdminThreadView `_escapeHTML` · ClientReportModal `escapeHtml` · ClientManagementModal `escapeHtml` · ReadStatusModal `escapeHtml` · TaskApprovalSidePanel `_escapeHtml` · UserAlertsPanel `escapeHTML` · UserDetailsModal `escapeHtml` · UsersTable `escapeHtml` · ClientsTable `escapeHtml` (the METHOD only) · WhatsAppMessageDialog `escapeHtml` · ReportGenerator `escapeHtml`.
+
+## MUST (block on FAIL)
+- **M1** — all 16 escapers DELEGATE to `window.escapeHtml` (`return window.escapeHtml(...)`); the temp-div (`document.createElement('div')…innerHTML`) / inline-map (`.replace(/[&<>"']/g…)`) bodies are REMOVED from each. "Route, never copy." No new inline escape logic added anywhere.
+- **M2** — every page that loads a routed file ALSO loads `escape-html.js`, BEFORE that consumer. `escape-html.js` added to **index.html** + **system-announcements.html** (the only 2 host pages lacking it; clients + clients-fluent already have it from PR1). This is the PR1 devils-advocate's load-order invariant — pinned by the routing-guard test.
+- **M3** — scope discipline / MUST-EXCLUDE preserved: `ClientsTable.js` `getTypeBadge` `data-tooltip-html` (2-entity `&`+`"`, packs already-rendered HTML) NOT touched; `ClientManagementModal` `data-name` inline `.replace(/"/g,…)` partials NOT touched; `notification-bell.safeText` (onclick JS-string-in-attr — `'`→`&#039;` would defeat its `\'` escaping) NOT routed; `case-form-validator` (dead admin copy) NOT routed; `WorkloadCard.sanitize` + `service-card-renderer` (PR3) NOT touched.
+- **M4** — behavior change DECLARED (G6): the 14 temp-div escapers go 3-entity → 5-entity (now also escape `"`→`&quot;` and `'`→`&#039;` — inert in HTML TEXT positions, a security IMPROVEMENT in the HTML-ATTRIBUTE sinks); the `if(!text)`/`text||''` falsy guards narrow to null/undefined-only (a literal `0`/`false` now stringifies instead of blanking — unobservable: every call-site passes strings or `||`-guards a string fallback); WhatsApp + ReportGenerator keep 5-entity output, only the null-guard narrows. No non-HTML / `.value` / string-compare sink consumes a routed escaper (verified — ClientReportModal's `<input value>` sinks are `disabled` static-HTML, parser-decoded, no read-back).
+- **M5** — the 2 existing behavioral tests that exercise a routed manager (`report-generator-escaping.test.ts`, `whatsapp-message-dialog-escaping.test.ts`) import `escape-html.js` so `window.escapeHtml` resolves at call-time (else `TypeError` → red CI). New `escapehtml-ssot-pr2-routing.test.ts` proves all 16 delegate (old body removed) + the 4-page load-order invariant + the ClientsTable-tooltip exclusion + the SSOT 5-entity contract. Full admin-panel suite green.
+- **M6** — cache-bust: `escape-html.js` `<script>` added with a manual `?v=20260621-escapehtml-pr2` tag (the `csv-safe.js` precedent on index.html — manual tag, not the global git-hash; no `update-cache-busting.js` run → no user-app churn), and EVERY routed consumer × EVERY host page it loads on gets a bumped `?v=` (incl. the divergent TaskApprovalSidePanel on index+clients and the previously-untagged AnnouncementCard/ReadStatusModal/TaskApprovalSidePanel).
+
+## SHOULD
+- **S1** — each routed body carries a PR1-style comment pointing to the SSOT + the entity/null-guard behavior note.
+- **S2** — ClientsTable's routed `escapeHtml` method carries a comment that the separate `data-tooltip-html` escape in `getTypeBadge()` is intentionally NOT routed.
+
+## Test plan
+`tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts` (23 tests: 16 per-file delegation guards [body delegates + temp-div/inline-map body removed], 1 count guard, 1 ClientsTable-tooltip exclusion guard, 4 per-page load-order guards, 1 SSOT 5-entity behavioral contract). The 2 fixed behavioral tests now exercise the routed `ReportGenerator` + `WhatsAppMessageDialog` end-to-end (instantiate manager → build HTML → assert XSS payload rendered inert). Full admin-panel suite **174/174** (151 prior + 23). Full root run: only `user-app/israeli-id-drift-guard.test.ts` fails (`Failed to resolve "zod"` — worktree partial-node_modules artifact, unrelated to this admin-panel-only PR; passes in CI with full deps; this PR touches ZERO user-app/zod/schema files). Local ESLint not runnable in the worktree (flat config's `@typescript-eslint` plugin absent from the partial tracked `node_modules`) — CI lint is the gate; changes are mechanically lint-safe (body→single `return`, `div`/`map` locals removed, `window` pre-existing global).
+
+## Rollback
+`git revert <merge-commit>` + redeploy (frontend; Netlify). No data migration, no schema/rule change. Reverting restores the 16 local escapers + removes the 2 new `<script>` tags + the `?v=` bumps.
+
+## PRODUCT-GRADE GATES
+- **G1 PASS** — the SSOT guard returns `''` for null/undefined; the temp-div copies' old `undefined`→`'undefined'` quirk is REMOVED (now `''`) — strictly fewer `undefined` leaks reach output.
+- **G2 PASS** — `git revert` rollback (code-only, no data/schema/rule).
+- **G3 N/A** — no data mutation (pure display-string escaping refactor).
+- **G4 PASS** — routing-guard test (all 16 delegate + load-order) + the 2 fixed behavioral tests exercising the routed managers end-to-end + the PR1 SSOT contract test.
+- **G5 PASS** — escaper maps only `& < > " '`; Hebrew + all other text passes through unchanged (the 2 fixed tests assert a benign Hebrew name renders unchanged).
+- **G6 PASS (declared)** — behavior change: temp-div copies 3→5-entity (inert in text, safer in attributes); null-guard narrows (unobservable for the string call-sites). No customer-visible regression for benign input; no non-HTML sink affected.
+- **G7 PASS** — XSS hardening (consolidates 16 escapers onto the audited SSOT; upgrades 14 from 3-entity to full 5-entity, closing latent attribute-breakout gaps e.g. ClientManagementModal `title=`/FluentDataGrid `data-type`/`title=`). security lens applied; the onclick JS-string hazard (notification-bell) correctly EXCLUDED rather than naively routed; URL/CSS-unsafe caveat already documented in the SSOT header.
+
+VERDICT: PASS

--- a/apps/admin-panel/clients-fluent.html
+++ b/apps/admin-panel/clients-fluent.html
@@ -441,14 +441,14 @@
     <!-- ClientTypeDisplay MUST load BEFORE ClientsDataManager -->
     <script src="js/core/client-type-display.js?v=20260621-escapehtml-pr1"></script>
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
-    <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
+    <script src="js/ui/ClientsTable.js?v=20260621-escapehtml-pr2"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260621-escapehtml-pr2"></script>
     <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
     <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- Fluent Design Components -->
-    <script src="js/fluent/FluentDataGrid.js?v=20251125"></script>
+    <script src="js/fluent/FluentDataGrid.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/fluent/FluentClientsManager.js?v=20251125"></script>
 
     <!-- Shared Components -->

--- a/apps/admin-panel/clients.html
+++ b/apps/admin-panel/clients.html
@@ -583,17 +583,17 @@
     <script src="js/managers/ClientsDataManager.js?v=20260516-isOnHold"></script>
     <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
     <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/ui/Pagination.js?v=20251215"></script>
-    <script src="js/ui/ClientReportModal.js?v=20260516-fixed-tag"></script>
-    <script src="js/ui/ClientManagementModal.js?v=20260517-zindex"></script>
-    <script src="js/ui/ClientsTable.js?v=20260516-isOnHold"></script>
+    <script src="js/ui/ClientReportModal.js?v=20260621-escapehtml-pr2"></script>
+    <script src="js/ui/ClientManagementModal.js?v=20260621-escapehtml-pr2"></script>
+    <script src="js/ui/ClientsTable.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Shared Components ===== -->
     <script src="js/ui/Notifications.js?v=20251123v1"></script>
 
     <!-- ===== Service Overdraft Resolution Feature ===== -->
-    <script src="js/features/ServiceOverdraftResolution.js?v=1.0.1"></script>
+    <script src="js/features/ServiceOverdraftResolution.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Task Approval System (for Side Panel) ===== -->
     <script type="module">
@@ -608,7 +608,7 @@
     </script>
     <!-- H.4 PR-a: canonical budget-meter helper (must load before the overrun side panel) -->
     <script src="js/core/budget-status.js"></script>
-    <script src="js/ui/TaskApprovalSidePanel.js"></script>
+    <script src="js/ui/TaskApprovalSidePanel.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Legacy Dependencies (still needed by other modules) ===== -->
     <script src="js/modules/logger.js?v=20251201-FIX2"></script>

--- a/apps/admin-panel/index.html
+++ b/apps/admin-panel/index.html
@@ -206,6 +206,8 @@
     <script src="js/modules/idle-timeout-manager.js?v=e02c45c"></script>
     <script src="js/core/auth.js?v=e02c45c"></script>
     <script src="js/core/constants.js?v=e02c45c"></script>
+    <!-- Shared HTML-escape SSOT (escapeHtml dedup PR2) — must load before any consumer below -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Navigation Component ===== -->
     <script src="js/ui/Navigation.js?v=e02c45c"></script>
@@ -218,7 +220,7 @@
     <!-- ===== Phase 2: Data & UI Components ===== -->
     <script src="js/managers/DataManager.js?v=e02c45c"></script>
     <script src="js/ui/StatsCards.js?v=e02c45c"></script>
-    <script src="js/ui/UsersTable.js?v=e02c45c"></script>
+    <script src="js/ui/UsersTable.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/ui/FilterBar.js?v=e02c45c"></script>
     <script src="js/ui/Pagination.js?v=e02c45c"></script>
     <script src="js/ui/DashboardUI.js?v=e02c45c"></script>
@@ -233,11 +235,11 @@
     <script src="js/ui/Modals.js?v=e02c45c"></script>
     <script src="js/ui/Notifications.js?v=e02c45c"></script>
     <script src="js/ui/UserForm.js?v=e02c45c"></script>
-    <script src="js/ui/UserDetailsModal.js?v=e02c45c"></script>
+    <script src="js/ui/UserDetailsModal.js?v=20260621-escapehtml-pr2"></script>
     <!-- CsvSafe (OWASP CSV/formula-injection encoder) MUST load BEFORE ReportGenerator (used by its CSV exports) -->
     <script src="js/core/csv-safe.js?v=20260617-pr-sec-3"></script>
-    <script src="js/managers/ReportGenerator.js?v=20260507-stage-2"></script>
-    <script src="js/ui/DeleteDataSidePanel.js?v=e02c45c"></script>
+    <script src="js/managers/ReportGenerator.js?v=20260621-escapehtml-pr2"></script>
+    <script src="js/ui/DeleteDataSidePanel.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/managers/UsersActions.js?v=e02c45c"></script>
 
     <!-- ===== Alert Communication System ===== -->
@@ -245,14 +247,14 @@
     <script src="js/managers/AlertsAnalyticsService.js?v=e02c45c"></script>
 
     <!-- ===== WhatsApp Messaging System ===== -->
-    <script src="js/managers/WhatsAppMessageDialog.js?v=e02c45c"></script>
+    <script src="js/managers/WhatsAppMessageDialog.js?v=20260621-escapehtml-pr2"></script>
 
     <script src="js/config/message-categories.js?v=e02c45c"></script>
     <script src="js/managers/AlertCommunicationManager.js?v=e02c45c"></script>
-    <script src="js/ui/UserAlertsPanel.js?v=e02c45c"></script>
+    <script src="js/ui/UserAlertsPanel.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/ui/QuickMessageDialog.js?v=e02c45c"></script>
-    <script src="js/ui/MessagesFullscreenModal.js?v=e02c45c"></script>
-    <script src="js/ui/AdminThreadView.js?v=e02c45c"></script>
+    <script src="js/ui/MessagesFullscreenModal.js?v=20260621-escapehtml-pr2"></script>
+    <script src="js/ui/AdminThreadView.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Task Approval System (for Side Panel) ===== -->
     <script type="module">
@@ -267,7 +269,7 @@
     </script>
     <!-- H.4 PR-a: canonical budget-meter helper (must load before the overrun side panel) -->
     <script src="js/core/budget-status.js?v=e02c45c"></script>
-    <script src="js/ui/TaskApprovalSidePanel.js?v=e02c45c"></script>
+    <script src="js/ui/TaskApprovalSidePanel.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ✅ NotificationBell - For admins who are also users -->
     <script src="js/modules/notification-bell.js?v=e02c45c"></script>

--- a/apps/admin-panel/js/features/ServiceOverdraftResolution.js
+++ b/apps/admin-panel/js/features/ServiceOverdraftResolution.js
@@ -901,12 +901,10 @@ closeModal();
          * Escape HTML לביטחון
          */
         escapeHtml(text) {
-            if (!text) {
-return '';
-}
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/fluent/FluentDataGrid.js
+++ b/apps/admin-panel/js/fluent/FluentDataGrid.js
@@ -904,9 +904,10 @@ return;
      * Utility: Escape HTML
      */
     escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
+        // Routed to the shared SSOT escaper (js/core/escape-html.js).
+        // Behavior change: now also escapes " and ' (the temp-div escaped only & < >) —
+        // safe in HTML text/attribute contexts (data-type / title attrs included).
+        return window.escapeHtml(text);
     },
 
     /**

--- a/apps/admin-panel/js/managers/ReportGenerator.js
+++ b/apps/admin-panel/js/managers/ReportGenerator.js
@@ -1693,11 +1693,10 @@ return '0.00';
          * Helper: Escape HTML characters for employee reports
          */
         escapeHtml(text) {
-            if (!text) {
-return '';
-}
-            const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
-            return String(text).replace(/[&<>"']/g, c => map[c]);
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Entity output unchanged (already 5-entity); null-guard narrows to null/undefined
+            // (0/false now stringify rather than blank).
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/managers/WhatsAppMessageDialog.js
+++ b/apps/admin-panel/js/managers/WhatsAppMessageDialog.js
@@ -53,16 +53,15 @@ window.WhatsAppMessageDialog = (function() {
 
     /**
      * Output-encode a string for safe interpolation into an HTML text/element
-     * context. Mirrors ReportGenerator.escapeHtml (& < > " ' → entities) so the
-     * user-controllable display name cannot break out of the modal markup that
-     * is injected via insertAdjacentHTML below (stored-XSS defense).
+     * context. Delegates to the shared SSOT escaper window.escapeHtml (& < > " ' →
+     * entities) so the user-controllable display name cannot break out of the modal
+     * markup that is injected via insertAdjacentHTML below (stored-XSS defense).
      */
     function escapeHtml(text) {
-        if (!text) {
-            return '';
-        }
-        const map = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
-        return String(text).replace(/[&<>"']/g, c => map[c]);
+        // Routed to the shared SSOT escaper (js/core/escape-html.js).
+        // Entity output unchanged (already 5-entity); null-guard narrows to null/undefined
+        // (0/false now stringify rather than blank).
+        return window.escapeHtml(text);
     }
 
     // ═══════════════════════════════════════════════════════════

--- a/apps/admin-panel/js/ui/AdminThreadView.js
+++ b/apps/admin-panel/js/ui/AdminThreadView.js
@@ -535,13 +535,10 @@ return `לפני ${diffDays} ימים`;
          * @returns {string} - Escaped string
          */
         _escapeHTML(str) {
-            if (!str) {
-return '';
-}
-
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(str);
         }
     }
 

--- a/apps/admin-panel/js/ui/AnnouncementCard.js
+++ b/apps/admin-panel/js/ui/AnnouncementCard.js
@@ -153,9 +153,10 @@
          * Escape HTML to prevent XSS
          */
         static escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >) —
+            // safe in HTML text/attribute contexts.
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/ClientManagementModal.js
+++ b/apps/admin-panel/js/ui/ClientManagementModal.js
@@ -1796,9 +1796,10 @@ localService.packages = [];
          * בריחת תווי HTML
          */
         escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >) —
+            // safe in HTML text/attribute contexts (e.g. the fee-agreement title attr).
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/ClientReportModal.js
+++ b/apps/admin-panel/js/ui/ClientReportModal.js
@@ -1158,12 +1158,10 @@ return '';
          * מניעת XSS על ידי escape של HTML
          */
         escapeHtml(text) {
-            if (!text) {
-return '';
-}
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/ClientsTable.js
+++ b/apps/admin-panel/js/ui/ClientsTable.js
@@ -780,12 +780,12 @@ ${hasBillableHours ? `שעות נותרות: ${client.hoursRemaining || 0}` : ''
          * הימנעות מ-HTML injection
          */
         escapeHtml(text) {
-            if (!text) {
-return '';
-}
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            // NOTE: the separate data-tooltip-html escape in getTypeBadge() is intentionally
+            // NOT routed here (it packs pre-rendered HTML; a 5-entity escape would break it).
+            return window.escapeHtml(text);
         }
     }
 

--- a/apps/admin-panel/js/ui/DeleteDataSidePanel.js
+++ b/apps/admin-panel/js/ui/DeleteDataSidePanel.js
@@ -997,12 +997,10 @@ return;
          * עזר: escape HTML
          */
         escapeHtml(text) {
-            if (!text) {
-return '';
-}
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/MessagesFullscreenModal.js
+++ b/apps/admin-panel/js/ui/MessagesFullscreenModal.js
@@ -395,9 +395,10 @@ return timestamp;
      * @param {string} text - Text to escape
      */
     escapeHTML(text) {
-      const div = document.createElement('div');
-      div.textContent = text || '';
-      return div.innerHTML;
+      // Routed to the shared SSOT escaper (js/core/escape-html.js).
+      // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+      // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+      return window.escapeHtml(text);
     }
 
     /**

--- a/apps/admin-panel/js/ui/ReadStatusModal.js
+++ b/apps/admin-panel/js/ui/ReadStatusModal.js
@@ -174,9 +174,10 @@ return b.readAt - a.readAt;
          * Escape HTML
          */
         escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text || '';
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/TaskApprovalSidePanel.js
+++ b/apps/admin-panel/js/ui/TaskApprovalSidePanel.js
@@ -436,12 +436,10 @@
         }
 
         _escapeHtml(str) {
-            if (str === null || str === undefined) {
-                return '';
-            }
-            const div = document.createElement('div');
-            div.textContent = String(str);
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (was & < > only); the null/undefined
+            // guard + String() coercion are unchanged (already SSOT-equivalent).
+            return window.escapeHtml(str);
         }
     }
 

--- a/apps/admin-panel/js/ui/UserAlertsPanel.js
+++ b/apps/admin-panel/js/ui/UserAlertsPanel.js
@@ -430,12 +430,10 @@
          * Escape HTML
          */
         escapeHTML(str) {
-            if (!str) {
-return '';
-}
-            const div = document.createElement('div');
-            div.textContent = str;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // null-guard narrows to null/undefined only — safe in HTML text/attribute contexts.
+            return window.escapeHtml(str);
         }
 
         /**

--- a/apps/admin-panel/js/ui/UserDetailsModal.js
+++ b/apps/admin-panel/js/ui/UserDetailsModal.js
@@ -4408,9 +4408,10 @@ return '';
         }
 
         escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >) —
+            // safe in HTML text/attribute contexts (value= / title= / textarea sinks included).
+            return window.escapeHtml(text);
         }
 
         /**

--- a/apps/admin-panel/js/ui/UsersTable.js
+++ b/apps/admin-panel/js/ui/UsersTable.js
@@ -635,9 +635,10 @@ return '-';
          * בריחה מ-HTML למניעת XSS
          */
         escapeHtml(text) {
-            const div = document.createElement('div');
-            div.textContent = text;
-            return div.innerHTML;
+            // Routed to the shared SSOT escaper (js/core/escape-html.js).
+            // Behavior change: now also escapes " and ' (the temp-div escaped only & < >);
+            // undefined now renders '' instead of 'undefined' — safe in HTML text contexts.
+            return window.escapeHtml(text);
         }
     }
 

--- a/apps/admin-panel/system-announcements.html
+++ b/apps/admin-panel/system-announcements.html
@@ -86,6 +86,8 @@
     <script src="js/core/config-loader.js"></script>
     <script src="js/core/auth.js"></script>
     <script src="js/core/constants.js"></script>
+    <!-- Shared HTML-escape SSOT (escapeHtml dedup PR2) — must load before any consumer below -->
+    <script src="js/core/escape-html.js?v=20260621-escapehtml-pr2"></script>
 
     <!-- ===== Auth Guard (Unified Authentication) ===== -->
     <script src="js/core/auth-guard.js?v=20250103"></script>
@@ -96,9 +98,9 @@
     <!-- ===== System Announcements Components ===== -->
     <script src="js/models/SystemAnnouncement.js"></script>
     <script src="js/services/AnnouncementService.js"></script>
-    <script src="js/ui/AnnouncementCard.js"></script>
+    <script src="js/ui/AnnouncementCard.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/ui/AnnouncementEditor.js"></script>
-    <script src="js/ui/ReadStatusModal.js"></script>
+    <script src="js/ui/ReadStatusModal.js?v=20260621-escapehtml-pr2"></script>
     <script src="js/ui/SystemAnnouncementsPanel.js"></script>
 
     <!-- ===== Notifications ===== -->

--- a/tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts
+++ b/tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Routing guard — escapeHtml SSOT consolidation PR2
+ * ─────────────────────────────────────────────────────────────────────────────
+ * PR1 (#390) created the shared SSOT `window.escapeHtml` (js/core/escape-html.js,
+ * 5-entity `& < > " '`) and routed the 6 string-replace escapers to it. PR2 routes
+ * the remaining 16 LIVE duplicated escapers — 14 "temp-div" copies
+ * (`div.textContent = x; return div.innerHTML;` → 3 entities only) + 2 inline-map
+ * 5-entity copies (ReportGenerator, WhatsAppMessageDialog) — by replacing each
+ * escaper BODY with `return window.escapeHtml(<param>);` (call-sites unchanged).
+ *
+ * This is a SOURCE-LEVEL guard (the repo's AST-guard precedent — rules-drift-guard,
+ * PR-SEC-2 migration guards). The 16 escapers live on heavyweight UI managers that
+ * self-instantiate at load (Firebase/DOM deps), so a per-manager behavioral test is
+ * impractical for all 16 — the END-TO-END behavioral proof is covered by
+ * escape-html.test.ts (the SSOT, 8 tests) + report-generator-escaping.test.ts +
+ * whatsapp-message-dialog-escaping.test.ts (two routed managers, exercised live).
+ *
+ * ─── What this catches ───────────────────────────────────────────────────────
+ *   ✅ A routed escaper that was NOT actually delegated (still has its old body).
+ *   ✅ A leftover temp-div (`document.createElement`) or inline-map (`.replace`)
+ *      body between the signature and the delegation return.
+ *   ✅ A host page that loads a routed consumer WITHOUT loading escape-html.js, OR
+ *      loads it AFTER the consumer (the PR1 devils-advocate's load-order attack —
+ *      `window.escapeHtml` undefined at call-time → TypeError in production).
+ *
+ * Created: 2026-06-21 — refactor/escapehtml-ssot-pr2
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+// escapeHtml-dedup PR2 — load the SSOT so the behavioral contract can be re-pinned.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/escape-html.js';
+
+const ADMIN = path.resolve(__dirname, '../../../apps/admin-panel');
+const read = (rel: string): string => fs.readFileSync(path.resolve(ADMIN, rel), 'utf8');
+
+/**
+ * Extract the escaper body from its signature line through (and including) the
+ * `return window.escapeHtml(` delegation line. Scoping to exactly this span means
+ * the negative assertions (no temp-div, no inline-map) cannot false-positive on an
+ * unrelated `document.createElement` / `.replace` elsewhere in the file.
+ */
+function escaperBody(src: string, sig: string): string {
+  const all = src.split('\n');
+  const i = all.findIndex((l) => l.includes(sig));
+  expect(i, `escaper signature not found: ${sig}`).toBeGreaterThan(-1);
+  let j = -1;
+  for (let k = i; k < Math.min(i + 12, all.length); k++) {
+    if (all[k].includes('return window.escapeHtml(')) {
+      j = k;
+      break;
+    }
+  }
+  expect(j, `delegation "return window.escapeHtml(" not found within 12 lines of: ${sig}`).toBeGreaterThan(-1);
+  return all.slice(i, j + 1).join('\n');
+}
+
+// [file, escaper-signature (unique within the file), parameter name]
+const ROUTED: ReadonlyArray<readonly [string, string, string]> = [
+  ['js/ui/MessagesFullscreenModal.js', 'escapeHTML(text) {', 'text'],
+  ['js/fluent/FluentDataGrid.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/DeleteDataSidePanel.js', 'escapeHtml(text) {', 'text'],
+  ['js/features/ServiceOverdraftResolution.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/AnnouncementCard.js', 'static escapeHtml(text) {', 'text'],
+  ['js/ui/AdminThreadView.js', '_escapeHTML(str) {', 'str'],
+  ['js/ui/ClientReportModal.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/ClientManagementModal.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/ReadStatusModal.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/TaskApprovalSidePanel.js', '_escapeHtml(str) {', 'str'],
+  ['js/ui/UserAlertsPanel.js', 'escapeHTML(str) {', 'str'],
+  ['js/ui/UserDetailsModal.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/UsersTable.js', 'escapeHtml(text) {', 'text'],
+  ['js/ui/ClientsTable.js', 'escapeHtml(text) {', 'text'],
+  ['js/managers/WhatsAppMessageDialog.js', 'function escapeHtml(text) {', 'text'],
+  ['js/managers/ReportGenerator.js', 'escapeHtml(text) {', 'text'],
+];
+
+describe('escapeHtml PR2 — every routed escaper delegates to the SSOT', () => {
+  it('routes all 16 escapers (and the count is exactly 16)', () => {
+    expect(ROUTED).toHaveLength(16);
+  });
+
+  for (const [file, sig, param] of ROUTED) {
+    it(`${file} :: ${sig.replace(/\s*\{$/, '')} → window.escapeHtml(${param})`, () => {
+      const body = escaperBody(read(file), sig);
+      expect(body).toContain(`return window.escapeHtml(${param});`);
+      // the old temp-div body must be gone
+      expect(body, 'leftover temp-div body').not.toContain('document.createElement');
+      // the old inline-map body (ReportGenerator / WhatsAppMessageDialog) must be gone
+      expect(body, 'leftover inline-map body').not.toMatch(/\.replace\(/);
+    });
+  }
+});
+
+describe('escapeHtml PR2 — the ClientsTable data-tooltip-html escape stays EXCLUDED', () => {
+  // getTypeBadge packs ALREADY-RENDERED HTML into a data attribute and escapes
+  // only & + " on purpose; routing it to the 5-entity SSOT would turn <div> into
+  // &lt;div&gt; and break the tooltip. PR2 must NOT touch it.
+  it('getTypeBadge still uses its own &/" -only inline escape (not the SSOT)', () => {
+    const src = read('js/ui/ClientsTable.js');
+    expect(src).toContain(".replace(/&/g, '&amp;')");
+    expect(src).toContain(".replace(/\"/g, '&quot;')");
+  });
+});
+
+describe('escapeHtml PR2 — load-order invariant (escape-html.js before EVERY routed consumer)', () => {
+  // Match the actual `<script src="..."` tag, NOT the bare filename — a page may
+  // mention a consumer in an HTML comment BEFORE its script tag (e.g. clients.html
+  // references ClientReportModal.js in a comment above the load), which would make a
+  // bare-filename indexOf false-match. Asserting the <script> tag avoids that.
+  const ssotAt = (html: string): number => html.indexOf('<script src="js/core/escape-html.js');
+  const tagAt = (html: string, rel: string): number => html.indexOf('<script src="' + rel);
+
+  // page → EVERY routed consumer <script> it loads (devils-advocate #5-i: assert all,
+  // not one representative, so a future routed <script> inserted ABOVE escape-html.js
+  // on any page is caught — the exact PR1 load-order failure mode).
+  const PAGE_CONSUMERS: ReadonlyArray<readonly [string, readonly string[]]> = [
+    ['index.html', [
+      'js/ui/UsersTable.js', 'js/ui/UserDetailsModal.js', 'js/ui/DeleteDataSidePanel.js',
+      'js/managers/WhatsAppMessageDialog.js', 'js/ui/UserAlertsPanel.js',
+      'js/ui/MessagesFullscreenModal.js', 'js/ui/AdminThreadView.js',
+      'js/ui/TaskApprovalSidePanel.js', 'js/managers/ReportGenerator.js',
+    ]],
+    ['system-announcements.html', ['js/ui/AnnouncementCard.js', 'js/ui/ReadStatusModal.js']],
+    ['clients.html', [
+      'js/managers/ReportGenerator.js', 'js/ui/ClientReportModal.js',
+      'js/ui/ClientManagementModal.js', 'js/ui/ClientsTable.js',
+      'js/features/ServiceOverdraftResolution.js', 'js/ui/TaskApprovalSidePanel.js',
+    ]],
+    ['clients-fluent.html', [
+      'js/ui/ClientsTable.js', 'js/ui/ClientReportModal.js',
+      'js/managers/ReportGenerator.js', 'js/fluent/FluentDataGrid.js',
+    ]],
+  ];
+
+  for (const [page, consumers] of PAGE_CONSUMERS) {
+    it(`${page} loads escape-html.js before all ${consumers.length} routed consumers`, () => {
+      const html = read(page);
+      const ssot = ssotAt(html);
+      expect(ssot, `${page} does not load js/core/escape-html.js`).toBeGreaterThan(-1);
+      for (const consumer of consumers) {
+        const at = tagAt(html, consumer);
+        expect(at, `${page} does not load <script src="${consumer}`).toBeGreaterThan(-1);
+        expect(ssot, `${page}: escape-html.js must load BEFORE ${consumer}`).toBeLessThan(at);
+      }
+    });
+  }
+});
+
+describe('escapeHtml PR2 — SSOT behavioral contract the routing depends on', () => {
+  it('escapes all 5 entities (the routed temp-div copies now also escape " and \')', () => {
+    const escapeHtml = (globalThis as any).window?.escapeHtml ?? (globalThis as any).escapeHtml;
+    expect(typeof escapeHtml).toBe('function');
+    expect(escapeHtml(`O'Brien & <b>"x"</b>`)).toBe('O&#039;Brien &amp; &lt;b&gt;&quot;x&quot;&lt;/b&gt;');
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+});

--- a/tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts
+++ b/tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts
@@ -75,7 +75,7 @@ const ROUTED: ReadonlyArray<readonly [string, string, string]> = [
   ['js/ui/UsersTable.js', 'escapeHtml(text) {', 'text'],
   ['js/ui/ClientsTable.js', 'escapeHtml(text) {', 'text'],
   ['js/managers/WhatsAppMessageDialog.js', 'function escapeHtml(text) {', 'text'],
-  ['js/managers/ReportGenerator.js', 'escapeHtml(text) {', 'text'],
+  ['js/managers/ReportGenerator.js', 'escapeHtml(text) {', 'text']
 ];
 
 describe('escapeHtml PR2 — every routed escaper delegates to the SSOT', () => {
@@ -122,18 +122,18 @@ describe('escapeHtml PR2 — load-order invariant (escape-html.js before EVERY r
       'js/ui/UsersTable.js', 'js/ui/UserDetailsModal.js', 'js/ui/DeleteDataSidePanel.js',
       'js/managers/WhatsAppMessageDialog.js', 'js/ui/UserAlertsPanel.js',
       'js/ui/MessagesFullscreenModal.js', 'js/ui/AdminThreadView.js',
-      'js/ui/TaskApprovalSidePanel.js', 'js/managers/ReportGenerator.js',
+      'js/ui/TaskApprovalSidePanel.js', 'js/managers/ReportGenerator.js'
     ]],
     ['system-announcements.html', ['js/ui/AnnouncementCard.js', 'js/ui/ReadStatusModal.js']],
     ['clients.html', [
       'js/managers/ReportGenerator.js', 'js/ui/ClientReportModal.js',
       'js/ui/ClientManagementModal.js', 'js/ui/ClientsTable.js',
-      'js/features/ServiceOverdraftResolution.js', 'js/ui/TaskApprovalSidePanel.js',
+      'js/features/ServiceOverdraftResolution.js', 'js/ui/TaskApprovalSidePanel.js'
     ]],
     ['clients-fluent.html', [
       'js/ui/ClientsTable.js', 'js/ui/ClientReportModal.js',
-      'js/managers/ReportGenerator.js', 'js/fluent/FluentDataGrid.js',
-    ]],
+      'js/managers/ReportGenerator.js', 'js/fluent/FluentDataGrid.js'
+    ]]
   ];
 
   for (const [page, consumers] of PAGE_CONSUMERS) {
@@ -152,9 +152,10 @@ describe('escapeHtml PR2 — load-order invariant (escape-html.js before EVERY r
 
 describe('escapeHtml PR2 — SSOT behavioral contract the routing depends on', () => {
   it('escapes all 5 entities (the routed temp-div copies now also escape " and \')', () => {
-    const escapeHtml = (globalThis as any).window?.escapeHtml ?? (globalThis as any).escapeHtml;
+    // escape-html.js (imported above) sets window.escapeHtml; happy-dom provides window.
+    const escapeHtml = (window as any).escapeHtml;
     expect(typeof escapeHtml).toBe('function');
-    expect(escapeHtml(`O'Brien & <b>"x"</b>`)).toBe('O&#039;Brien &amp; &lt;b&gt;&quot;x&quot;&lt;/b&gt;');
+    expect(escapeHtml('O\'Brien & <b>"x"</b>')).toBe('O&#039;Brien &amp; &lt;b&gt;&quot;x&quot;&lt;/b&gt;');
     expect(escapeHtml(null)).toBe('');
     expect(escapeHtml(undefined)).toBe('');
   });

--- a/tests/unit/admin-panel/report-generator-escaping.test.ts
+++ b/tests/unit/admin-panel/report-generator-escaping.test.ts
@@ -18,6 +18,12 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
+// ReportGenerator.escapeHtml now DELEGATES to the shared SSOT window.escapeHtml
+// (escapeHtml-dedup PR2) — import the SSOT FIRST so the global is defined when the
+// report HTML is built below. Without this the routed escaper throws at call-time.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/escape-html.js';
+
 // ReportGenerator.js is an IIFE that assigns the singleton to window (happy-dom
 // provides window). Import for side-effect, then read the instance off window.
 // @ts-ignore — classic admin-panel script, no type declarations

--- a/tests/unit/admin-panel/whatsapp-message-dialog-escaping.test.ts
+++ b/tests/unit/admin-panel/whatsapp-message-dialog-escaping.test.ts
@@ -21,6 +21,12 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 
+// WhatsAppMessageDialog.escapeHtml now DELEGATES to the shared SSOT
+// window.escapeHtml (escapeHtml-dedup PR2) — import the SSOT FIRST so the global is
+// defined when the dialog HTML is built. Without this the routed escaper throws.
+// @ts-ignore — classic admin-panel script, no type declarations
+import '../../../apps/admin-panel/js/core/escape-html.js';
+
 // WhatsAppMessageDialog.js is an IIFE that assigns the module to window
 // (happy-dom provides window/document). Import for side-effect, then read it off
 // window — same harness pattern as report-generator-escaping.test.ts.


### PR DESCRIPTION
## escapeHtml SSOT consolidation — PR2

**Task type:** Refactor (SSOT-preserving) · **App:** Admin Panel · **Env:** DEV/main · frontend-only
**Rubric:** `.claude/rubrics/pr-escapehtml-ssot-pr2.md`

PR2 of the Haim-approved 3-PR escapeHtml-dedup (checkpoint 2026-06-17; PR2 scope re-confirmed 2026-06-21 → "PR אחד, 16 routes"). Routes the remaining **16 LIVE duplicated HTML-escapers** onto the shared SSOT `window.escapeHtml` (`apps/admin-panel/js/core/escape-html.js`, shipped in PR1 #390) — "route, never copy". 14 were "temp-div" copies (`div.textContent=x; return div.innerHTML` → 3-entity `& < >` only); 2 were inline-map 5-entity copies (ReportGenerator, WhatsAppMessageDialog). Each body becomes `return window.escapeHtml(<param>)`; call-sites unchanged.

### The 16 routed escapers
MessagesFullscreenModal · FluentDataGrid · DeleteDataSidePanel · ServiceOverdraftResolution · AnnouncementCard · AdminThreadView · ClientReportModal · ClientManagementModal · ReadStatusModal · TaskApprovalSidePanel · UserAlertsPanel · UserDetailsModal · UsersTable · ClientsTable (the `escapeHtml` **method** only) · WhatsAppMessageDialog · ReportGenerator

### Pages / cache-bust
- Added `<script src="js/core/escape-html.js?v=20260621-escapehtml-pr2">` to **index.html** + **system-announcements.html** — the only 2 host pages (of 13) that load a routed consumer without the SSOT; placed after `constants.js`, BEFORE every consumer. `clients.html` + `clients-fluent.html` already load it (PR1).
- Full per-occurrence `?v=20260621-escapehtml-pr2` bump on every routed consumer across the 4 host pages (incl. the divergent TaskApprovalSidePanel on index+clients and the previously-untagged AnnouncementCard/ReadStatusModal). Manual tag (the `csv-safe.js` precedent on index.html) — no `update-cache-busting.js` run, so no unrelated user-app churn.

### Excluded (correct, tracked)
- `notification-bell.safeText` — line 456 embeds output in `onclick="openReplyModal('${safeText(x).replace(/'/g,"\'")}')"`; SSOT `'`→`&#039;` would defeat the `\'` escaping → broken handler on apostrophes. Needs an addEventListener refactor (separate item).
- `case-form-validator.js` (admin copy) — loaded by **zero** admin pages (live copy is in `apps/user-app/`); dead code → PR3 deletion candidate.
- ClientsTable `data-tooltip-html` (packs pre-rendered HTML) + ClientManagementModal `data-name` inline `.replace(/"/g,…)` partials — permanent excludes.
- `WorkloadCard.sanitize` + `service-card-renderer` — PR3.

### Behavior change (G6 — declared)
The 14 temp-div escapers go **3-entity → 5-entity** (now also escape `"`→`&quot;` and `'`→`&#039;`): **inert** in HTML-text positions, a security **improvement** in the HTML-attribute sinks (closes latent attribute-breakout in e.g. ClientManagementModal `title=`, FluentDataGrid `data-type`/`title=`). The `if(!text)`/`text||''` falsy guards **narrow** to null/undefined-only (a literal `0`/`false` now stringifies instead of blanking — unobservable: every call-site passes strings or `||`-guards a string fallback). No non-HTML / `.value` / string-compare / JS-string sink consumes a routed escaper (ClientReportModal's `<input value>` sinks are `disabled`, static-HTML, parser-decoded, no read-back).

### Test plan
- NEW `tests/unit/admin-panel/escapehtml-ssot-pr2-routing.test.ts` (23 tests): 16 per-file delegation guards (body delegates + temp-div/inline-map body removed), the ClientsTable-tooltip exclusion guard, the 4-page **load-order invariant** asserting escape-html.js loads before **every** routed consumer (hardened per devils-advocate #5-i), and the SSOT 5-entity behavioral contract.
- FIXED the 2 existing behavioral tests (`report-generator-escaping.test.ts`, `whatsapp-message-dialog-escaping.test.ts`) — added `import '.../js/core/escape-html.js'` so `window.escapeHtml` resolves at call-time once their manager delegates (else TypeError → red CI). They now exercise the routed managers end-to-end (build HTML → assert XSS payload rendered inert).
- **admin-panel suite 174/174** (151 prior + 23). Full root run: only `user-app/israeli-id-drift-guard.test.ts` fails (`Failed to resolve "zod"` — worktree partial-`node_modules` artifact; this PR touches **zero** user-app/zod/schema files; passes in CI with full deps).
- Local ESLint not runnable in the worktree (flat config's `@typescript-eslint` plugin absent from the partial tracked `node_modules`) — **CI lint is the gate**; changes are mechanically lint-safe (body→single `return`, `div`/`map` locals removed, `window` pre-existing global).

### Reviews
- **outcomes-grader = PASS** — 6/6 MUST, 2/2 SHOULD, 7/7 gates, 9/9 bar; independently re-ran 174/174 + a **mutation test** proving the routing guard fails on a non-delegated body.
- **devils-advocate = GO-WITH-CHANGES** — 0 🔴, 1 🟡, 4 🟢; every attack (load-order, JS-string/`.value` regression, cross-file contract, null-guard) failed to land against the code. Its actionable change (harden the load-order test to all consumers per page) is **applied** in this PR.

## Rollback
`git revert <merge-commit>` + redeploy (frontend; Netlify). No data migration, no schema/rule change. Reverting restores the 16 local escapers + removes the 2 new `<script>` tags + the `?v=` bumps.

## PRODUCT-GRADE GATES
- **G1 PASS** — SSOT returns `''` for null/undefined; the temp-div `undefined`→`'undefined'` quirk is REMOVED — strictly fewer `undefined` leaks reach output.
- **G2 PASS** — `git revert` rollback (code-only, no data/schema/rule).
- **G3 N/A** — no data mutation (pure display-string escaping refactor).
- **G4 PASS** — routing-guard test (all 16 delegate + load-order) + the 2 fixed behavioral tests exercising the routed managers end-to-end + the PR1 SSOT contract test.
- **G5 PASS** — escaper maps only `& < > " '`; Hebrew + all other text passes through unchanged (behavioral tests assert a benign Hebrew name renders unchanged).
- **G6 PASS (declared)** — behavior change (3→5 entity + null-guard narrowing) declared above; inert/safer for benign input; no non-HTML sink regression.
- **G7 PASS** — XSS hardening (16 escapers onto the audited SSOT; 14 upgraded 3→5-entity, closing latent attribute-breakout gaps); the onclick JS-string hazard (notification-bell) correctly EXCLUDED rather than naively routed; URL/CSS-unsafe caveat documented in the SSOT header.

VERDICT: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)