### PR TITLE
chore(functions): repair-script dry-run report — orphan/hours/package totals (PR-DRIFT-2.1)

### DIFF
--- a/.claude/rubrics/pr-drift-2-1.md
+++ b/.claude/rubrics/pr-drift-2-1.md
@@ -1,0 +1,31 @@
+# Rubric — PR-DRIFT-2.1 (dry-run report self-sufficiency)
+
+**Title:** chore(functions): repair-script dry-run report — surface orphan/hours/package totals
+**Branch:** chore/drift-2-1-dryrun-report → main (DEV)
+**File:** `functions/scripts/repair-package-aggregates.js` (the PR-DRIFT-2 supervised repair script — NOT deployed; manual ops tool).
+**Scope:** REPORT-ONLY. The dry-run rollup previously left the orphan/unresolved counters at 0 (they were filled only inside `applyClient`, which runs solely on `--apply`), and never surfaced the per-client/aggregate HOURS being corrected — the key billing-review number. This PR makes the dry-run report self-sufficient by aggregating, for EVERY scanned client:
+- `orphansToStampTotal` / `orphansOnSkippedTotal` / `unresolvedTotal`
+- `netHoursDelta` + `absHoursDelta` (service-level — the billing-review number)
+- `packageCardReconcileAbs` (per-package-card movement — the dormant redistribution being reconciled)
+plus the per-client `netHoursDelta` / `absHoursDelta` / `packageCardReconcileAbs` in `summarizeForReport`.
+
+**NO change to the repair logic, the `--apply` mutation path, the forward-replay core, DRIFT-0, or the trigger.** Effort: obviously LIGHT (+26/-1, single ops script, non-deployed). Verified by running the dry-run against PROD 3× (read-only) — the new fields populate correctly.
+
+## MUST
+- **M1** — additive report fields only; `summarizeForReport` + the `main()` counts rollup; no edit to `applyClient`/`buildClientPlan`/the core. **Evidence:** the +26/-1 diff is confined to the two report sites.
+- **M2** — `node --check` clean; the dry-run runs against PROD read-only and emits the new fields with sane values (orphansToStampTotal 280 / orphansOnSkippedTotal 275 / unresolvedTotal 0 / netHoursDelta ≈ 0 / absHoursDelta 0.30 / packageCardReconcileAbs 3.94, run 2026-06-22). **Evidence:** 3 PROD dry-runs.
+- **M3** — no PII: the new fields are aggregate hours/counts only (no names/emails/ids beyond the existing non-PII report). **Evidence:** grep of the diff.
+
+## PRODUCT-GRADE GATES
+- **G1 (errors):** N/A — ops script + console report, no customer UI.
+- **G2 (rollback):** PASS — `git revert` (report-only, trivially reversible; no data touched).
+- **G3 (monitoring):** N/A — read-only report formatting; the `--apply` mutation/audit path is UNCHANGED.
+- **G4 (test proves scenario):** PASS — manual smoke (3 PROD dry-runs) confirms the new fields populate; the repair core/logic is unchanged and already covered by the PR-DRIFT-2 suite (88 tests).
+- **G5 (Hebrew UI):** N/A — no customer UI.
+- **G6 (breaking change):** N/A — additive report fields; no contract/schema/route change.
+- **G7 (security):** PASS — aggregate hours/counts only, no PII; no auth/permissions touched.
+
+## Verdict
+Lead-Agent self-certification under effort-scaling (obviously LIGHT: report-only, non-deployed ops script, +26/-1, verified by 3 read-only PROD dry-runs). The repair logic this report describes already passed grader + 2 devils-advocate rounds (PR-DRIFT-2).
+
+VERDICT: PASS

--- a/functions/scripts/repair-package-aggregates.js
+++ b/functions/scripts/repair-package-aggregates.js
@@ -299,10 +299,22 @@ function summarizeForReport(plan) {
   const changedServices = plan.serviceReports.filter((s) => !s.skip);
   const bigReversals = plan.phantomReversals.filter((p) => (p.beforeHoursUsed || 0) >= 20);
   const invariantFailures = changedServices.filter((s) => s.invariantOk === false);
+  // The hours actually being corrected on this client (THE billing-review number).
+  // net = signed sum (negative = removing over-count); abs = total magnitude moved.
+  const netHoursDelta = changedServices.reduce((sum, s) => sum + ((s.serviceAfter || 0) - (s.serviceBefore || 0)), 0);
+  const absHoursDelta = changedServices.reduce((sum, s) => sum + Math.abs((s.serviceAfter || 0) - (s.serviceBefore || 0)), 0);
+  // The per-PACKAGE-card movement on eligible services (the dormant redistribution
+  // being reconciled — large even when the service total barely moves).
+  const packageCardReconcileAbs = changedServices.reduce(
+    (sum, s) => sum + (s.packageDiffs || []).reduce((a, d) => a + Math.abs(d.delta || 0), 0), 0
+  );
   return {
     clientId: plan.clientId,
     eligibleServices: changedServices.length,
     skippedServices: plan.serviceReports.length - changedServices.length,
+    netHoursDelta: Math.round(netHoursDelta * 100) / 100,
+    absHoursDelta: Math.round(absHoursDelta * 100) / 100,
+    packageCardReconcileAbs: Math.round(packageCardReconcileAbs * 100) / 100,
     orphansToStamp: plan.stampPlan.length,
     orphansStampedOnSkipped: plan.orphansStampedOnSkipped, // A7
     basisCounts: plan.basisCounts,
@@ -573,7 +585,12 @@ async function main() {
   const counts = {
     clientsScanned: 0, clientsWithDrift: 0, clientsRepaired: 0,
     clientsRefusedBlockFlip: 0, clientsErrored: 0,
-    orphansPlanned: 0, orphansStamped: 0, orphansStampedOnSkipped: 0, // A6 planned-vs-stamped + A7
+    // PLANNED totals — aggregated from every scanned client (meaningful in BOTH
+    // dry-run AND apply; the *Stamped/Repaired counters below only fill on --apply).
+    orphansToStampTotal: 0, orphansOnSkippedTotal: 0, unresolvedTotal: 0,
+    netHoursDelta: 0, absHoursDelta: 0,             // the billing-review numbers (service-level)
+    packageCardReconcileAbs: 0,                     // per-package-card movement (the dormant +874h redistribution)
+    orphansPlanned: 0, orphansStamped: 0, orphansStampedOnSkipped: 0, // A6 planned-vs-stamped + A7 (apply-only)
     clientsWithPartialStamp: 0,                     // A6: clients where stamped < planned (re-run self-heals)
     unresolvedEntries: 0,                           // A6: entries with no eligible package (operator review)
     sameDayBoundaryFlags: 0,                        // A3
@@ -607,6 +624,14 @@ async function main() {
         if (summary.blockFlip) counts.blockFlips += 1;
         if (summary.invariantFailures.length > 0) counts.invariantFailures += 1;
         counts.sameDayBoundaryFlags += (summary.sameDayBoundaryFlags || []).length; // A3
+        // Planned totals — aggregated for EVERY scanned client (dry-run gets real
+        // numbers, not the apply-only Stamped counters which stay 0 until --apply).
+        counts.orphansToStampTotal += (summary.orphansToStamp || 0) - (summary.orphansStampedOnSkipped || 0);
+        counts.orphansOnSkippedTotal += summary.orphansStampedOnSkipped || 0;
+        counts.unresolvedTotal += summary.unresolvedCount || 0;
+        counts.netHoursDelta += summary.netHoursDelta || 0;
+        counts.absHoursDelta += summary.absHoursDelta || 0;
+        counts.packageCardReconcileAbs += summary.packageCardReconcileAbs || 0;
         if (hasWork || summary.blockFlip || summary.invariantFailures.length > 0
             || summary.duplicatePackageIds.length > 0 || summary.danglingEntries.length > 0
             || (summary.sameDayBoundaryFlags || []).length > 0) {


### PR DESCRIPTION
## PR-DRIFT-2.1 — dry-run report self-sufficiency (REPORT-ONLY)

Follow-up to PR-DRIFT-2 (#395). The repair script `functions/scripts/repair-package-aggregates.js` is a supervised, NOT-deployed ops tool. Its dry-run rollup left the orphan/unresolved counters at 0 (they were filled only inside `applyClient`, which runs solely on `--apply`), and never surfaced the HOURS being corrected — the key billing-review number.

This makes the dry-run report self-sufficient by aggregating, for EVERY scanned client:
- `orphansToStampTotal` / `orphansOnSkippedTotal` / `unresolvedTotal`
- `netHoursDelta` + `absHoursDelta` (service-level — the billing-review number)
- `packageCardReconcileAbs` (per-package-card movement — the dormant redistribution being reconciled)

plus the same per-client fields in `summarizeForReport`.

**No change** to the repair logic, the `--apply` mutation path, the forward-replay core, DRIFT-0, or the trigger. Diff is +26/-1, confined to the two report sites.

### Test plan
- `node --check` clean.
- Verified by running the dry-run against PROD 3x (read-only, no writes): the new fields populate with sane values — `orphansToStampTotal 280 / orphansOnSkippedTotal 275 / unresolvedTotal 0 / netHoursDelta ~0 / absHoursDelta 0.30 / packageCardReconcileAbs 3.94`.
- The repair core/logic this report describes is UNCHANGED and already covered by the PR-DRIFT-2 suite (88 tests) + 2 devils-advocate rounds.

### Rollback
- `git revert 12616f9` (report-only, trivially reversible; no data touched).

### PRODUCT-GRADE GATES
- **G1 (errors):** N/A — ops script + console report, no customer UI.
- **G2 (rollback):** PASS — `git revert` (report-only).
- **G3 (monitoring):** N/A — read-only report formatting; the `--apply` mutation/audit path is UNCHANGED.
- **G4 (test proves scenario):** PASS — manual smoke (3 read-only PROD dry-runs) confirms the new fields; the repair logic is unchanged and already test-covered.
- **G5 (Hebrew UI):** N/A — no customer UI.
- **G6 (breaking change):** N/A — additive report fields; no contract/schema/route change.
- **G7 (security):** PASS — aggregate hours/counts only, no PII; no auth/permissions touched.

Lead-Agent self-certification under effort-scaling (obviously LIGHT: report-only, non-deployed ops script, +26/-1).

VERDICT: PASS

Generated with Claude Code